### PR TITLE
PR 10/N (Stage 2): clear typecheck errors and gate typecheck in CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set production config
         run: npm run set-production-config
 
-      - name: Check (lint + format + test)
+      - name: Check (lint + format + typecheck + test)
         run: npm run check
 
       - name: Build (production)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,11 +63,11 @@ rm -rf development/data development/uploads development/extensions
 | `npm run lint:fix`          | Same, with autofix.                                                                 |
 | `npm run format`            | Prettier check (fails if anything isn't formatted).                                 |
 | `npm run format:fix`        | Prettier write.                                                                     |
-| `npm run typecheck`         | `vue-tsc --noEmit` — typechecks `.ts` and `.vue` files.                             |
+| `npm run typecheck`         | `vue-tsc --noEmit` — typechecks `.ts` and `.vue` files. Gated in CI.                |
 | `npm run test`              | Vitest run.                                                                         |
 | `npm run test:watch`        | Vitest in watch mode.                                                               |
 | `npm run test:coverage`     | Vitest with v8 coverage report (text + HTML at `coverage/` + lcov).                 |
-| `npm run check`             | Aggregate: `lint && format && test`.                                                |
+| `npm run check`             | Aggregate: `lint && format && typecheck && test`.                                   |
 | `npm run check:fix`         | Aggregate fix: `lint:fix && format:fix`.                                            |
 | `npm run knip`              | Detect unused files, deps, and exports. Local only (not gated in CI).               |
 | `npm run build`             | Minified production build of both extensions. This is what release publishes.       |

--- a/extensions/common/interfaces/directus-api.ts
+++ b/extensions/common/interfaces/directus-api.ts
@@ -12,9 +12,17 @@ export interface DirectusApi {
   upsertDirectusItem: <T extends Item>(ccollection: string, item: (Item & T) | null, payload: T, options?: ItemOptions) => Promise<void>;
 
   fetchDirectusItems<T extends Item>(collection: string, query?: Query): Promise<T[]>;
-  fetchDirectusSingletonItem<T extends Item>(collection: string, query?: Query): Promise<T>;
+  /**
+   * Singleton fetch is only used by the admin module's hydration flow,
+   * so the hook's implementation can omit it.
+   */
+  fetchDirectusSingletonItem?<T extends Item>(collection: string, query?: Query): Promise<T>;
 
-  createField(collection: string, field: DeepPartial<Field>): Promise<void>;
+  /**
+   * Field creation is only used by the admin module's hydration flow
+   * (the hook never mutates the schema), so the hook can omit it.
+   */
+  createField?(collection: string, field: DeepPartial<Field>): Promise<void>;
 
   getCollection(collection: string): Pick<Collection, 'collection'> | null;
   fetchSettings(): Promise<Item | null>;

--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -68,7 +68,6 @@
 import { useItems, useStores } from '@directus/extensions-sdk';
 import { PropType, Ref, computed, ref, watch, watchEffect } from 'vue';
 import { AppCollection, Field, Item } from '@directus/types';
-import { storeToRefs } from 'pinia';
 import { getLocalazyLanguages } from '@localazy/languages';
 import { SelectItem } from '../../models/directus/internals/select-item';
 import { Settings } from '../../../../common/models/collections-data/settings';
@@ -77,6 +76,7 @@ import { DirectusLocalazyAdapter } from '../../../../common/services/directus-lo
 import LoginButton from './LoginButton.vue';
 import LogoutButton from './LogoutButton.vue';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
+import { useDirectusCollectionsStoreRefs } from '../../composables/use-directus-stores';
 
 type Collection = AppCollection | null;
 
@@ -109,8 +109,8 @@ const localEdits = computed<Settings>({
   },
 });
 
-const { useCollectionsStore, useFieldsStore } = useStores();
-const { collections } = storeToRefs(useCollectionsStore());
+const { useFieldsStore } = useStores();
+const { collections } = useDirectusCollectionsStoreRefs();
 const { getFieldsForCollectionSorted } = useFieldsStore();
 const languageCollectionName = computed(() => localEdits.value.language_collection);
 

--- a/extensions/module/src/composables/use-collections-organizer.ts
+++ b/extensions/module/src/composables/use-collections-organizer.ts
@@ -2,12 +2,12 @@ import { sortBy, uniqWith } from 'lodash';
 import { computed } from 'vue';
 import { AppCollection } from '@directus/types';
 import { useStores } from '@directus/extensions-sdk';
-import { storeToRefs } from 'pinia';
 import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
+import { useDirectusCollectionsStoreRefs } from './use-directus-stores';
 
 export const useCollectionsOrganizer = () => {
-  const { useCollectionsStore, useFieldsStore } = useStores();
-  const { allCollections } = storeToRefs(useCollectionsStore());
+  const { useFieldsStore } = useStores();
+  const { allCollections } = useDirectusCollectionsStoreRefs();
   const { getFieldsForCollection } = useFieldsStore();
 
   const collections = computed<AppCollection[]>(() =>

--- a/extensions/module/src/composables/use-directus-api.ts
+++ b/extensions/module/src/composables/use-directus-api.ts
@@ -1,24 +1,29 @@
-import { useStores, useApi } from '@directus/extensions-sdk';
+import { useApi } from '@directus/extensions-sdk';
 import { Collection, DeepPartial, AppCollection, Field, Item, Query } from '@directus/types';
 import { Ref, ref } from 'vue';
-import { storeToRefs } from 'pinia';
 import { isEmpty, isEqual } from 'lodash';
 import { useErrorsStore } from '../stores/errors-store';
 import { DirectusApi, ItemOptions } from '../../../common/interfaces/directus-api';
+import { useDirectusCollectionsStore, useDirectusCollectionsStoreRefs } from './use-directus-stores';
 
-type UseDirectusApi = DirectusApi & {
-  upsertDirectusCollection: (collection: string, values: DeepPartial<Collection & { fields: Field[] }>) => Promise<AppCollection>;
-  loading: Ref<boolean>;
-};
+/**
+ * The module-side implementation of DirectusApi. fetchDirectusSingletonItem and
+ * createField are optional on the base DirectusApi (the hook doesn't need them)
+ * but always present here.
+ */
+type UseDirectusApi = DirectusApi &
+  Required<Pick<DirectusApi, 'fetchDirectusSingletonItem' | 'createField'>> & {
+    upsertDirectusCollection: (collection: string, values: DeepPartial<Collection & { fields: Field[] }>) => Promise<AppCollection>;
+    loading: Ref<boolean>;
+  };
 
 export function useDirectusApi(): UseDirectusApi {
-  const { useCollectionsStore } = useStores();
-  const { getCollection } = useCollectionsStore();
-  const { collections } = storeToRefs(useCollectionsStore());
+  const { getCollection } = useDirectusCollectionsStore();
+  const { collections } = useDirectusCollectionsStoreRefs();
   const api = useApi();
   const loading = ref(false);
   const { addDirectusError } = useErrorsStore();
-  const appCollections = collections?.value as AppCollection[];
+  const appCollections = collections.value;
 
   const updateDirectusItem = async <T extends Item>(collection: string, itemId: number | string, data: T, options: ItemOptions = {}) => {
     const resolvedPayload = options.ignoreEmpty

--- a/extensions/module/src/composables/use-directus-stores.ts
+++ b/extensions/module/src/composables/use-directus-stores.ts
@@ -1,0 +1,43 @@
+import { useStores } from '@directus/extensions-sdk';
+import { computed, type ComputedRef } from 'vue';
+import type { AppCollection, Collection } from '@directus/types';
+
+/**
+ * Shape of the Directus admin's collections Pinia store that this extension uses.
+ *
+ * Directus' extensions SDK 17 widened useStores()'s return type so the inner
+ * stores no longer expose their member typings to the consumer. The actual
+ * runtime shape is unchanged. This wrapper asserts the subset we depend on in
+ * one place rather than scattering casts at every call site.
+ */
+type CollectionsStore = {
+  collections: AppCollection[];
+  allCollections: AppCollection[];
+  getCollection: (collection: string) => Collection | null;
+  hydrate: () => Promise<void>;
+};
+
+type CollectionsStoreRefs = {
+  collections: ComputedRef<AppCollection[]>;
+  allCollections: ComputedRef<AppCollection[]>;
+};
+
+export const useDirectusCollectionsStore = (): CollectionsStore => {
+  const stores = useStores();
+  return stores.useCollectionsStore() as CollectionsStore;
+};
+
+/**
+ * Returns reactive accessors for the collections store. Equivalent to
+ * `storeToRefs(useDirectusCollectionsStore())` but typed correctly — `storeToRefs`
+ * can't infer through the SDK's widened store type. Pinia state properties are
+ * already reactive at runtime, so wrapping in `computed` here is a typing
+ * convenience and does not add a real reactivity layer.
+ */
+export const useDirectusCollectionsStoreRefs = (): CollectionsStoreRefs => {
+  const store = useDirectusCollectionsStore();
+  return {
+    collections: computed(() => store.collections),
+    allCollections: computed(() => store.allCollections),
+  };
+};

--- a/extensions/module/src/composables/use-hydrate.ts
+++ b/extensions/module/src/composables/use-hydrate.ts
@@ -1,5 +1,4 @@
 import { useStores } from '@directus/extensions-sdk';
-import { storeToRefs } from 'pinia';
 import { ref, computed } from 'vue';
 import { Item, AppCollection, Field } from '@directus/types';
 import { isEqual, merge } from 'lodash';
@@ -14,6 +13,7 @@ import { defaultConfiguration } from '../data/default-configuration';
 import { sleep } from '../../../common/utilities/sleep';
 import { getConfig } from '../../../common/config/get-config';
 import { useDirectusApi } from './use-directus-api';
+import { useDirectusCollectionsStore, useDirectusCollectionsStoreRefs } from './use-directus-stores';
 
 type HydrateOptions = {
   /** Force rehydration */
@@ -54,10 +54,10 @@ const hydratedDirectusData = ref(false);
 export const useHydrate = () => {
   const { addDirectusError } = useErrorsStore();
 
-  const { useCollectionsStore, useFieldsStore } = useStores();
+  const { useFieldsStore } = useStores();
   const { getFieldsForCollection, hydrate: hydrateFieldsStore } = useFieldsStore();
-  const { collections } = storeToRefs(useCollectionsStore());
-  const { hydrate: hydrateCollectionsStore } = useCollectionsStore();
+  const { collections } = useDirectusCollectionsStoreRefs();
+  const { hydrate: hydrateCollectionsStore } = useDirectusCollectionsStore();
   const { upsertDirectusItem, upsertDirectusCollection, fetchDirectusSingletonItem, createField, createDirectusItem } = useDirectusApi();
 
   const hasIncompleteConfiguration = computed(() => {
@@ -394,15 +394,15 @@ export const useHydrate = () => {
     if (hydratingDirectusData.value) return;
     settingsCollection.value =
       settingsCollection.value === null
-        ? collections?.value.find((c: AppCollection) => c.collection === defaultOptions.collections.settings)
+        ? (collections.value.find((c: AppCollection) => c.collection === defaultOptions.collections.settings) ?? null)
         : settingsCollection.value;
     localazyDataCollection.value =
       localazyDataCollection.value === null
-        ? collections?.value.find((c: AppCollection) => c.collection === defaultOptions.collections.localazyData)
+        ? (collections.value.find((c: AppCollection) => c.collection === defaultOptions.collections.localazyData) ?? null)
         : localazyDataCollection.value;
     contentTransferSetupCollection.value =
       contentTransferSetupCollection.value === null
-        ? collections?.value.find((c: AppCollection) => c.collection === defaultOptions.collections.contentTransferSetup)
+        ? (collections.value.find((c: AppCollection) => c.collection === defaultOptions.collections.contentTransferSetup) ?? null)
         : contentTransferSetupCollection.value;
 
     hydratingDirectusData.value = true;

--- a/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
@@ -94,7 +94,7 @@ class CollectionContentSynchronizationService extends BaseContentSynchronization
         return;
       }
 
-      if (settings.automated_deprecation !== 1) {
+      if (!settings.automated_deprecation) {
         return;
       }
 

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
@@ -30,7 +30,7 @@ function makeSchema() {
   };
 }
 
-const sampleSettings = { automated_deprecation: 1 };
+const sampleSettings = { automated_deprecation: true };
 const sampleTransferSetup = { translation_strings: true, enabled_fields: '[]' };
 const sampleLocalazyData = { access_token: 'tok' };
 const sampleProject = { id: 'p1' };
@@ -146,7 +146,7 @@ describe('translationStringsSynchronizationService.deprecateDeletedTranslationSt
   it('does nothing when automated_deprecation is disabled', async () => {
     const logger = makeLogger();
     vi.spyOn(proto, 'resolveLocalazySettings').mockResolvedValue({
-      settings: { automated_deprecation: 0 },
+      settings: { automated_deprecation: false },
       contentTransferSetup: sampleTransferSetup,
     });
     vi.spyOn(proto, 'resolveLocalazyData').mockResolvedValue({ localazyData: sampleLocalazyData });

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
@@ -92,7 +92,7 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
         return;
       }
 
-      if (settings.automated_deprecation !== 1) {
+      if (!settings.automated_deprecation) {
         return;
       }
       const localazyProject = await this.loadProject(localazyData.access_token);

--- a/extensions/sync-hook/src/services/directus-service.ts
+++ b/extensions/sync-hook/src/services/directus-service.ts
@@ -41,7 +41,7 @@ export class DirectusApiService implements DirectusApi {
     }
   }
 
-  async fetchDirectusItems(collection: string, query: Query = {}): Promise<Item[]> {
+  async fetchDirectusItems<T extends Item>(collection: string, query: Query = {}): Promise<T[]> {
     return this.readByQuery(collection, query);
   }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "knip": "knip",
-    "check": "npm run lint && npm run format && npm run test",
+    "check": "npm run lint && npm run format && npm run typecheck && npm run test",
     "check:fix": "npm run lint:fix && npm run format:fix",
     "build-scripts": "npm run set-production-config && node ./scripts/copy-license.mjs",
     "set-production-config": "npm run set-config -- --mode=production",


### PR DESCRIPTION
## Summary

Stage 2 tasks **#26, #27, #28, #29, #34** in one PR. After this, **`npm run typecheck` exits 0** and is wired into both `npm run check` and the CI workflow.

### Source bugs (#26)

`Settings.automated_deprecation` is typed `boolean`, but the deprecation gate in two sync services compared it to `1` (the SQLite int form that Directus' driver returns at runtime). With the boolean type the comparison `!== 1` was always true → deprecation would have been skipped for every customer where Directus normalised the value to a boolean.

Switched both sites to `!settings.automated_deprecation`, which handles both `false` and `0` correctly. Test fixture in `translation-strings-synchronization-service.test.ts` updated to match.

### Interface alignment (#27, #28)

- `fetchDirectusSingletonItem` and `createField` made **optional** on the `DirectusApi` base interface. The hook never reads singletons or mutates the schema — only the admin module's hydration flow does. The module's `UseDirectusApi` narrows them back to required via `Required<Pick<DirectusApi, ...>>`.
- `DirectusApiService.fetchDirectusItems` is now generic `<T extends Item>` to match the interface signature. The implementation returns the underlying `readByQuery` (typed `any` via `ItemsService`), so no cast is needed.

### Pinia store typing (#29)

SDK 17 widened `useStores()`'s return so accessing `.collections` / `.allCollections` on its inner Pinia stores no longer typechecks. The runtime shape didn't change.

New `extensions/module/src/composables/use-directus-stores.ts` exposes:
- `useDirectusCollectionsStore()` — returns the store with one `as CollectionsStore` cast.
- `useDirectusCollectionsStoreRefs()` — returns `ComputedRef<AppCollection[]>` accessors built via `computed(() => store.x)` (we can't use `storeToRefs()` here because it can't infer through the widened type).

The cast is contained at one site rather than scattered across call sites — aligns with the CLAUDE.md cast-avoidance rule.

Updated 4 call sites: `use-collections-organizer.ts`, `use-directus-api.ts`, `use-hydrate.ts`, `components/ProjectSetup/ProjectSetupForm.vue`. Dropped now-unused imports of `useStores`/`storeToRefs` where appropriate.

Fixed 3 cascading errors in `use-hydrate.ts` where the strictly-typed `collections.value.find()` returns `AppCollection | undefined` but the target ref accepts `AppCollection | null` — added `?? null`.

### Typecheck CI gate (#34)

- `npm run check` now runs `lint → format → typecheck → test`.
- `qa.yml` step renamed accordingly.
- CLAUDE.md commands table notes typecheck is now CI-gated.

## Verified

- `npm run check` — lint 0 errors, **typecheck 0 errors**, 49/49 tests, format clean.
- `npm run build` — production minified.
- `npm run knip` — zero findings.

## Stage 2 backlog

| # | Description | Status |
|---|---|---|
| 25 | Async queue move | ✅ |
| 26 | `boolean === number` fixes | ✅ this PR |
| 27 | DirectusApiService missing methods | ✅ this PR |
| 28 | `fetchDirectusItems` generic variance | ✅ this PR |
| 29 | Pinia store typing | ✅ this PR |
| 30 | Trivial cleanups | ✅ |
| 31 | `@localazy/generic-connector-client` bump | pending |
| 32 | `@localazy/languages` bump | pending |
| 33 | TypeScript 5.9 → 6 | pending |
| 34 | Typecheck CI gate | ✅ this PR |
| 35 | 99 `no-explicit-any` baseline | pending |
| 36 | Husky hook Node-version-aware | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)