### PR TITLE
PR 12/N (Stage 2): typed Directus service constructors + fix latent resolveExportLanguages bug

### DIFF
--- a/extensions/sync-hook/src/services/api-directus-data-model-service.ts
+++ b/extensions/sync-hook/src/services/api-directus-data-model-service.ts
@@ -1,20 +1,21 @@
 import { Field, Relation, SchemaOverview } from '@directus/types';
 import { DirectusDataModel } from '../../../common/interfaces/directus-data-model';
 import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
+import type { FieldsServiceCtor } from '../types/directus-services';
 
 export class ApiDirectusDataModelService implements DirectusDataModel {
-  private FieldsService!: any;
+  private FieldsService: FieldsServiceCtor;
 
-  private schema!: SchemaOverview;
+  private schema: SchemaOverview;
 
-  constructor(schema: SchemaOverview, FieldsService: any) {
+  constructor(schema: SchemaOverview, FieldsService: FieldsServiceCtor) {
     this.FieldsService = FieldsService;
     this.schema = schema;
   }
 
-  async getFieldsForCollection(collection: string) {
-    const fields: Field[] = await new this.FieldsService({ schema: this.schema }).readAll(collection);
-    return fields;
+  async getFieldsForCollection(collection: string): Promise<Field[]> {
+    const service = new this.FieldsService({ schema: this.schema, accountability: null });
+    return (await service.readAll(collection)) as Field[];
   }
 
   /** Copied from Directus internals */

--- a/extensions/sync-hook/src/services/content-synchronization/base-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/base-content-synchronization-service.ts
@@ -14,6 +14,8 @@ import { DirectusLocalazyLanguage } from '../../../../common/models/directus-loc
 import { DirectusLocalazyAdapter } from '../../../../common/services/directus-localazy-adapter';
 import { LocalazyPaymentStatus } from '../../../../common/utilities/localazy-payment-status';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
+import type { ItemsServiceCtor } from '../../types/directus-services';
+import { DirectusApiService } from '../directus-service';
 
 type ExportToLocalazy = {
   schema: SchemaOverview;
@@ -26,7 +28,7 @@ type ExportToLocalazy = {
 type FetchLocalazyContent = {
   languages: DirectusLocalazyLanguage[];
   schema: SchemaOverview;
-  ItemsService: any;
+  ItemsService: ItemsServiceCtor;
   localazyProject?: Project;
   settings?: Settings | null;
   localazyData?: LocalazyData | null;
@@ -57,27 +59,20 @@ export abstract class BaseContentSynchronizationService {
     }
   }
 
-  protected async resolveLocalazySettings(ItemsService: any, schema: SchemaOverview) {
+  protected async resolveLocalazySettings(ItemsService: ItemsServiceCtor, schema: SchemaOverview) {
     try {
       // accountability: null runs with administrator permissions, which is what we want
       // here — Localazy's settings tables shouldn't be subject to the triggering user's
       // read permissions. emitEvents is not set because this code path only reads from
       // Directus; if future work adds writes here, those calls must pass { emitEvents: false }
       // to prevent the hook from recursively triggering itself.
-      const localazySettings = new ItemsService('localazy_settings', { schema, accountability: null });
-      const localazyContentTransferSetup = new ItemsService('localazy_content_transfer_setup', { schema, accountability: null });
-      const settings: Settings = (
-        await localazySettings.readByQuery({
-          fields: '*',
-          limit: 1,
-        })
-      )[0];
-      const contentTransferSetup: ContentTransferSetupDatabase = (
-        await localazyContentTransferSetup.readByQuery({
-          fields: '*',
-          limit: 1,
-        })
-      )[0];
+      const localazySettings = new ItemsService<Settings>('localazy_settings', { schema, accountability: null });
+      const localazyContentTransferSetup = new ItemsService<ContentTransferSetupDatabase>('localazy_content_transfer_setup', {
+        schema,
+        accountability: null,
+      });
+      const [settings = null] = await localazySettings.readByQuery({ fields: ['*'], limit: 1 });
+      const [contentTransferSetup = null] = await localazyContentTransferSetup.readByQuery({ fields: ['*'], limit: 1 });
 
       return {
         settings,
@@ -92,15 +87,10 @@ export abstract class BaseContentSynchronizationService {
     }
   }
 
-  protected async resolveLocalazyData(ItemsService: any, schema: SchemaOverview) {
+  protected async resolveLocalazyData(ItemsService: ItemsServiceCtor, schema: SchemaOverview) {
     try {
-      const localazyData = new ItemsService('localazy_config_data', { schema, accountability: null });
-      const data: LocalazyData = (
-        await localazyData.readByQuery({
-          fields: '*',
-          limit: 1,
-        })
-      )[0];
+      const localazyData = new ItemsService<LocalazyData>('localazy_config_data', { schema, accountability: null });
+      const [data = null] = await localazyData.readByQuery({ fields: ['*'], limit: 1 });
 
       return {
         localazyData: data,
@@ -226,13 +216,16 @@ export abstract class BaseContentSynchronizationService {
     await execute({ delayBetween: 100 });
   }
 
-  protected async resolveExportLanguages(ItemsService: any, settings: Settings) {
+  protected async resolveExportLanguages(ItemsService: ItemsServiceCtor, schema: SchemaOverview, settings: Settings) {
     try {
-      const synchronizationLanguagesService = new SynchronizationLanguagesService(ItemsService);
+      // SynchronizationLanguagesService expects a DirectusApi instance, not the raw
+      // ItemsService constructor. Wrap it via DirectusApiService.
+      const directusApi = new DirectusApiService(ItemsService, schema);
+      const synchronizationLanguagesService = new SynchronizationLanguagesService(directusApi);
       const exportLanguages = await synchronizationLanguagesService.resolveExportLanguages(settings);
       return exportLanguages;
-    } catch (e: any) {
-      trackDirectusError(e, 'resolveExportLanguages');
+    } catch (e: unknown) {
+      trackDirectusError(e instanceof Error ? e : new Error(String(e)), 'resolveExportLanguages');
       return [];
     }
   }

--- a/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
@@ -7,20 +7,21 @@ import { ContentTransferSetupDatabase } from '../../../../common/models/collecti
 import { ApiTranslatableCollectionsService } from '../translatable-collections-service';
 import { EnabledFieldsService } from '../../../../common/utilities/enabled-fields-service';
 import { trackDirectusError } from '../../functions/track-error';
+import type { DirectusLogger, FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
 
 type ExportCollectionContent = {
   schema: SchemaOverview;
-  ItemsService: any;
-  FieldsService: any;
-  logger: any;
+  ItemsService: ItemsServiceCtor;
+  FieldsService: FieldsServiceCtor;
+  logger: DirectusLogger;
   keys: string[];
   collection: string;
 };
 
 type FetchTranslatableCollectionsContent = {
   schema: SchemaOverview;
-  ItemsService: any;
-  FieldsService: any;
+  ItemsService: ItemsServiceCtor;
+  FieldsService: FieldsServiceCtor;
   keys: string[];
   collection: string;
   settings: Settings;
@@ -29,10 +30,10 @@ type FetchTranslatableCollectionsContent = {
 
 type DeprecateDeletedCollectionItems = {
   schema: SchemaOverview;
-  logger: any;
+  logger: DirectusLogger;
   collection: string;
   itemIds: string[];
-  ItemsService: any;
+  ItemsService: ItemsServiceCtor;
 };
 
 class CollectionContentSynchronizationService extends BaseContentSynchronizationService {
@@ -151,7 +152,7 @@ class CollectionContentSynchronizationService extends BaseContentSynchronization
 
     const translatableCollectionsService = new ApiTranslatableCollectionsService(ItemsService, schema, FieldsService);
 
-    const exportLanguages = await this.resolveExportLanguages(ItemsService, settings);
+    const exportLanguages = await this.resolveExportLanguages(ItemsService, schema, settings);
     const collectionsContent = translatableCollectionsService.fetchContentFromTranslatableCollections({
       translatableCollections: [
         {

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
@@ -12,12 +12,20 @@ type AnyFn = (...args: unknown[]) => unknown;
 
 const proto = BaseContentSynchronizationService.prototype as unknown as Record<string, AnyFn>;
 
+// Pino's Logger has overloaded log methods that vi.fn()'s Mock<Procedure> doesn't
+// structurally satisfy. The `as unknown as Logger` cast is the test-mock escape hatch
+// CLAUDE.md allows when a single `as Target` doesn't compile.
 function makeLogger() {
   return {
-    info: vi.fn(),
-    warn: vi.fn(),
+    level: 'info',
+    fatal: vi.fn(),
     error: vi.fn(),
-  };
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+  } as unknown as import('pino').Logger;
 }
 
 function makeSchema() {

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
@@ -7,16 +7,17 @@ import { Settings } from '../../../../common/models/collections-data/settings';
 import { ContentTransferSetupDatabase } from '../../../../common/models/collections-data/content-transfer-setup';
 import { DirectusApiService } from '../directus-service';
 import { trackDirectusError } from '../../functions/track-error';
+import type { DirectusLogger, ItemsServiceCtor } from '../../types/directus-services';
 
 type ExportTranslationString = {
   schema: SchemaOverview;
-  logger: any;
-  ItemsService: any;
+  logger: DirectusLogger;
+  ItemsService: ItemsServiceCtor;
 };
 
 type FetchTranslationStrings = {
   schema: SchemaOverview;
-  ItemsService: any;
+  ItemsService: ItemsServiceCtor;
   settings: Settings;
   contentTransferSetup: ContentTransferSetupDatabase;
 };
@@ -24,8 +25,8 @@ type FetchTranslationStrings = {
 type DeprecateDeletedTranslationStrings = {
   schema: SchemaOverview;
   itemIds: string[];
-  logger: any;
-  ItemsService: any;
+  logger: DirectusLogger;
+  ItemsService: ItemsServiceCtor;
 };
 
 class TranslationStringsSynchronizationService extends BaseContentSynchronizationService {
@@ -146,7 +147,7 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
 
     const translationStringsService = new TranslationStringsService(new DirectusApiService(ItemsService, schema));
 
-    const exportLanguages = await this.resolveExportLanguages(ItemsService, settings);
+    const exportLanguages = await this.resolveExportLanguages(ItemsService, schema, settings);
     try {
       const translationStrings = await translationStringsService.fetchTranslationStrings({
         languages: exportLanguages,

--- a/extensions/sync-hook/src/services/directus-service.ts
+++ b/extensions/sync-hook/src/services/directus-service.ts
@@ -1,13 +1,15 @@
-import { Query, Item, SchemaOverview } from '@directus/types';
+import type { CollectionOverview, Item, MutationOptions, Query, SchemaOverview } from '@directus/types';
 import { DirectusApi } from '../../../common/interfaces/directus-api';
+import { DirectusApiResultTranslationString } from '../../../common/models/translation-string';
 import { useGetCollectionFromSchema } from '../composables/use-get-collection-from-schema';
+import type { ItemsServiceCtor } from '../types/directus-services';
 
 export class DirectusApiService implements DirectusApi {
-  protected schema!: SchemaOverview;
+  protected schema: SchemaOverview;
 
-  protected ItemsService!: any;
+  protected ItemsService: ItemsServiceCtor;
 
-  constructor(ItemsService: any, schema: any) {
+  constructor(ItemsService: ItemsServiceCtor, schema: SchemaOverview) {
     this.ItemsService = ItemsService;
     this.schema = schema;
   }
@@ -16,20 +18,22 @@ export class DirectusApiService implements DirectusApi {
     const targetCollection = this.getCollection(collection);
 
     if (targetCollection?.singleton === true) {
-      this.upsertSingleton(collection, data);
+      await this.upsertSingleton(collection, data);
     } else {
-      this.updateOne(collection, itemId, data);
+      await this.updateOne(collection, itemId, data);
     }
   }
 
   async createDirectusItem<T extends Item>(collection: string, data: T) {
     const targetCollection = this.getCollection(collection);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id, ...payload } = data;
+    const { id: _id, ...rest } = data;
+    // rest is Omit<T, 'id'>, which is structurally a Partial<T> minus the id slot.
+    // createOne accepts Partial<T>; the cast bridges generic variance.
+    const payload = rest as Partial<T>;
     if (targetCollection?.singleton === true) {
-      this.upsertSingleton(collection, data);
+      await this.upsertSingleton(collection, data);
     } else {
-      this.createOne(collection, payload);
+      await this.createOne(collection, payload);
     }
   }
 
@@ -42,33 +46,33 @@ export class DirectusApiService implements DirectusApi {
   }
 
   async fetchDirectusItems<T extends Item>(collection: string, query: Query = {}): Promise<T[]> {
-    return this.readByQuery(collection, query);
+    return this.readByQuery<T>(collection, query);
   }
 
   async fetchSettings() {
-    const result = await this.readByQuery('directus_settings', {
+    const result = await this.readByQuery<Item>('directus_settings', {
       fields: ['translation_strings'],
       limit: -1,
     });
-    return result[0];
+    return result[0] ?? null;
   }
 
   async fetchTranslationStrings() {
-    return this.readByQuery('directus_translations', {
+    return this.readByQuery<DirectusApiResultTranslationString>('directus_translations', {
       limit: -1,
     });
   }
 
-  getCollection(collection: string) {
+  getCollection(collection: string): CollectionOverview | null {
     const { getCollection } = useGetCollectionFromSchema(this.schema);
-    return getCollection(collection) as SchemaOverview['collections'][0] | null;
+    return getCollection(collection);
   }
 
   async upsertTranslationString<T extends Item>(payload: T) {
     await this.upsertOne('directus_translations', payload);
   }
 
-  async updateSettings(payload: any) {
+  async updateSettings<T extends Item>(payload: T) {
     await this.upsertSingleton('directus_settings', payload);
   }
 
@@ -77,23 +81,28 @@ export class DirectusApiService implements DirectusApi {
   // triggering user's permissions. emitEvents is set to false on writes so a hook-driven
   // write doesn't recursively re-trigger the same hook.
 
-  private readByQuery(collection: string, query: any) {
-    return new this.ItemsService(collection, { schema: this.schema, accountability: null }).readByQuery(query);
+  private readByQuery<T extends Item>(collection: string, query: Query): Promise<T[]> {
+    const service = new this.ItemsService<T>(collection, { schema: this.schema, accountability: null });
+    return service.readByQuery(query);
   }
 
-  private createOne(collection: string, payload: any) {
-    return new this.ItemsService(collection, { schema: this.schema, accountability: null }).createOne(payload, { emitEvents: false });
+  private createOne<T extends Item>(collection: string, payload: Partial<T>) {
+    const service = new this.ItemsService<T>(collection, { schema: this.schema, accountability: null });
+    return service.createOne(payload, { emitEvents: false } as MutationOptions);
   }
 
-  private updateOne(collection: string, id: string | number, payload: any) {
-    return new this.ItemsService(collection, { schema: this.schema, accountability: null }).updateOne(id, payload, { emitEvents: false });
+  private updateOne<T extends Item>(collection: string, id: string | number, payload: Partial<T>) {
+    const service = new this.ItemsService<T>(collection, { schema: this.schema, accountability: null });
+    return service.updateOne(id, payload, { emitEvents: false } as MutationOptions);
   }
 
-  private upsertSingleton(collection: string, payload: any) {
-    return new this.ItemsService(collection, { schema: this.schema, accountability: null }).upsertSingleton(payload, { emitEvents: false });
+  private upsertSingleton<T extends Item>(collection: string, payload: Partial<T>) {
+    const service = new this.ItemsService<T>(collection, { schema: this.schema, accountability: null });
+    return service.upsertSingleton(payload, { emitEvents: false } as MutationOptions);
   }
 
-  private upsertOne(collection: string, payload: any) {
-    return new this.ItemsService(collection, { schema: this.schema, accountability: null }).upsertOne(payload, { emitEvents: false });
+  private upsertOne<T extends Item>(collection: string, payload: Partial<T>) {
+    const service = new this.ItemsService<T>(collection, { schema: this.schema, accountability: null });
+    return service.upsertOne(payload, { emitEvents: false } as MutationOptions);
   }
 }

--- a/extensions/sync-hook/src/services/translatable-collections-service.ts
+++ b/extensions/sync-hook/src/services/translatable-collections-service.ts
@@ -6,11 +6,12 @@ import {
   TranslatableCollectionsService,
   TranslatableCollectionsServiceOptions,
 } from '../../../common/services/translatable-collections-service';
+import type { FieldsServiceCtor, ItemsServiceCtor } from '../types/directus-services';
 
 export class ApiTranslatableCollectionsService {
-  private translatableCollectionsService!: TranslatableCollectionsService;
+  private translatableCollectionsService: TranslatableCollectionsService;
 
-  constructor(ItemsService: any, schema: SchemaOverview, FieldsService: any) {
+  constructor(ItemsService: ItemsServiceCtor, schema: SchemaOverview, FieldsService: FieldsServiceCtor) {
     this.translatableCollectionsService = new TranslatableCollectionsService({
       directusApi: new DirectusApiService(ItemsService, schema),
       translatableCollectionsContent: new ApiDirectusDataModelService(schema, FieldsService),
@@ -20,8 +21,8 @@ export class ApiTranslatableCollectionsService {
   async fetchContentFromTranslatableCollections(options: TranslatableCollectionsServiceOptions) {
     try {
       return this.translatableCollectionsService.fetchContentFromTranslatableCollections(options);
-    } catch (e: any) {
-      trackDirectusError(e, 'fetchContentFromTranslatableCollection');
+    } catch (e: unknown) {
+      trackDirectusError(e instanceof Error ? e : new Error(String(e)), 'fetchContentFromTranslatableCollection');
       return {
         sourceLanguage: {},
         otherLanguages: {},

--- a/extensions/sync-hook/src/types/directus-services.ts
+++ b/extensions/sync-hook/src/types/directus-services.ts
@@ -1,0 +1,19 @@
+import type { ApiExtensionContext, ExtensionsServices } from '@directus/types';
+
+/**
+ * Constructor type for Directus' ItemsService, as provided to extensions via
+ * the hook's `services` context. Generic in the row type to mirror the SDK.
+ */
+export type ItemsServiceCtor = ExtensionsServices['ItemsService'];
+
+/**
+ * Constructor type for Directus' FieldsService.
+ */
+export type FieldsServiceCtor = ExtensionsServices['FieldsService'];
+
+/**
+ * The Pino-flavoured logger Directus injects into hook context.
+ * Extracted from ApiExtensionContext so consumers don't need a direct
+ * dependency on `pino`.
+ */
+export type DirectusLogger = ApiExtensionContext['logger'];


### PR DESCRIPTION
## Summary

Stage 2 task **#39** (typed service constructors) plus a **real bug** that typechecking surfaced: `BaseContentSynchronizationService.resolveExportLanguages` was passing the `ItemsService` *constructor* where `SynchronizationLanguagesService` expects a `DirectusApi` *instance*. Any code path reaching it would have failed at runtime (`this.directusApi.fetchDirectusItems` on the constructor doesn't resolve).

### Typed service constructors

New `extensions/sync-hook/src/types/directus-services.ts` derives the types from `@directus/types`:

```ts
export type ItemsServiceCtor = ExtensionsServices['ItemsService'];
export type FieldsServiceCtor = ExtensionsServices['FieldsService'];
export type DirectusLogger    = ApiExtensionContext['logger'];
```

No new dependency on `pino` — we lift the logger type out of the SDK's context shape. Then `any` is replaced across six files: `directus-service.ts`, `api-directus-data-model-service.ts`, `translatable-collections-service.ts`, `base-content-synchronization-service.ts`, plus the two `*-synchronization-service.ts` subclasses.

`DirectusApiService` methods are made generic (`createOne<T>`, `updateOne<T>`, etc.) to match `AbstractService<T>`. `fetchDirectusItems` and `fetchTranslationStrings` now return their precise interface types.

### Latent bug fix

```ts
// Before:
const synchronizationLanguagesService = new SynchronizationLanguagesService(ItemsService);
// ↑ passes the constructor where a DirectusApi instance is expected

// After:
const directusApi = new DirectusApiService(ItemsService, schema);
const synchronizationLanguagesService = new SynchronizationLanguagesService(directusApi);
```

Threaded `schema` through `resolveExportLanguages`. Updated both callers (`translation-strings-synchronization-service.ts`, `collection-content-synchronization-service.ts`) to pass it.

### Other typecheck consequences

- `fields: '*'` in three `readByQuery` calls → `fields: ['*']` (Query.fields is `string[]`, not a wildcard).
- Array indexing `[0]` returns `Item | undefined`; replaced with `const [item = null] = await ...` so the call sites' existing null checks actually fire.
- `catch (e: any)` → `catch (e: unknown)` where the value is passed to `trackDirectusError`; wrap with `e instanceof Error ? e : new Error(String(e))` to satisfy its `Error | AxiosError` signature.
- Test logger mock now provides all required Pino `Logger` properties (`level`, `fatal`, `debug`, `trace`, `silent`). Single `as unknown as Logger` cast at the boundary; documented why the single `as Logger` form doesn't compile (vi.fn's `Mock<Procedure>` doesn't structurally satisfy Pino's overloaded `LogFn`).

## Stats

| Metric | Before | After | Delta |
|---|---|---|---|
| Lint warnings | 122 | **91** | **−31** |
| `no-explicit-any` baseline | 99 | **68** | **−31** (cuts ~⅓ of task #35) |
| Tests | 61/61 | 61/61 | — |
| Production build | clean | clean | — |

## Stage 2 backlog

| # | Status |
|---|---|
| 25, 26, 27, 28, 29, 30, 34, 37, 38, 41 | ✅ done |
| **39** | ✅ this PR |
| 31, 32, 33, 35 (residual 68), 36, 40, 42, 43 | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)