### PR TITLE
PR 14/N (Stage 2): triage 22 floating-promise sites, fix one real bug, promote rule to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,18 +72,17 @@ export default tseslint.config(
     },
   },
 
-  // Type-aware Promise-safety rule. Scoped to TS/Vue because it requires
-  // type information (only enabled in those file types via projectService).
-  // Catches the bug class that produced the missing-await in
-  // sync-hook/src/index.ts. Set to 'warn' because the codebase has a baseline
-  // of intentional fire-and-forget patterns (Vue setup() top-level awaits,
-  // event-handler callbacks) — see Stage 2 task for incremental cleanup.
+  // Type-aware Promise-safety rule. Catches the bug class that produced the
+  // missing-await in sync-hook/src/index.ts. The baseline of intentional
+  // fire-and-forget patterns (Vue setup() top-level hydrations, analytics
+  // calls, etc.) has been triaged — each site is either awaited or prefixed
+  // with `void`. Set to 'error' so a new floating Promise blocks CI.
   // no-misused-promises is intentionally off: it produces false positives
   // against Directus' action() callback signature, which accepts async fns.
   {
     files: ['**/*.ts', '**/*.vue'],
     rules: {
-      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
 

--- a/extensions/common/services/localazy-api-throttle-service.ts
+++ b/extensions/common/services/localazy-api-throttle-service.ts
@@ -30,7 +30,9 @@ class LocalazyRequestProcessor {
         }
       });
 
-      this.processRequests();
+      // Intentionally fire-and-forget: addRequest returns a Promise that resolves when
+      // the queued request completes; the processor loop runs concurrently.
+      void this.processRequests();
     });
   }
 
@@ -81,9 +83,9 @@ class LocalazyRequestProcessor {
 
     this.processing = false;
 
-    // Process any queued requests
+    // Process any queued requests. Recursive fire-and-forget continues the loop.
     if (this.requests.length > 0) {
-      this.processRequests();
+      void this.processRequests();
     }
   }
 

--- a/extensions/common/utilities/sleep.test.ts
+++ b/extensions/common/utilities/sleep.test.ts
@@ -10,7 +10,10 @@ describe('sleep', () => {
     vi.useFakeTimers();
     const promise = sleep(500);
     let resolved = false;
-    promise.then(() => {
+    // Fire-and-forget by design: the test awaits `promise` explicitly below
+    // (line 21) once the fake timer has advanced; this .then is only setting a
+    // flag the test reads to verify resolution timing.
+    void promise.then(() => {
       resolved = true;
     });
 

--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -70,9 +70,9 @@ watch(
   { immediate: true, deep: true },
 );
 
-hydrateDirectusData().then(() => {
-  hydrateLocalazyData({ localazyData });
-});
+// Fire-and-forget hydration at component setup time. Errors are captured inside
+// each hydrate function via the errors store.
+void hydrateDirectusData().then(() => hydrateLocalazyData({ localazyData }));
 
 const changesExist = computed(() => !isEqual(settingsEdits.value, configuration.value.settings));
 

--- a/extensions/module/src/Overview.vue
+++ b/extensions/module/src/Overview.vue
@@ -45,9 +45,9 @@ const { hydrateDirectusData, localazyData, hasIncompleteConfiguration, settings,
 const localazyStore = useLocalazyStore();
 const { hydrated } = storeToRefs(localazyStore);
 
-hydrateDirectusData().then(() => {
-  localazyStore.hydrateLocalazyData({ localazyData });
-});
+// Fire-and-forget hydration at component setup time. Errors are captured inside
+// each hydrate function via the errors store.
+void hydrateDirectusData().then(() => localazyStore.hydrateLocalazyData({ localazyData }));
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -75,9 +75,9 @@ watch(
   { immediate: true, deep: true },
 );
 
-hydrateDirectusData().then(() => {
-  hydrateLocalazyData({ localazyData });
-});
+// Fire-and-forget hydration at component setup time. Errors are captured inside
+// each hydrate function via the errors store.
+void hydrateDirectusData().then(() => hydrateLocalazyData({ localazyData }));
 
 const changesExist = computed(() => !isEqual(settingsEdits.value, configuration.value.settings));
 

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -116,9 +116,9 @@ const {
   contentTransferSetup,
 } = useHydrate();
 
-hydrateDirectusData().then(() => {
-  localazyStore.hydrateLocalazyData({ localazyData });
-});
+// Fire-and-forget hydration at component setup time. Errors are captured inside
+// each hydrate function via the errors store.
+void hydrateDirectusData().then(() => localazyStore.hydrateLocalazyData({ localazyData }));
 
 const iteratedCollections = computed(() =>
   showUntranslatableCollections.value ? rootCollections.value : translatableRootCollections.value,

--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -94,7 +94,8 @@ watch(
   () => props.settings,
   (s) => {
     if (s?.language_collection && s?.language_code_field) {
-      fetchDirectusLanguages(s?.language_collection, s?.language_code_field).then((languages) => {
+      // Fire-and-forget: rejection logs through fetchDirectusLanguages' own try/catch.
+      void fetchDirectusLanguages(s.language_collection, s.language_code_field).then((languages) => {
         directusLanguages.value = languages;
       });
     }

--- a/extensions/module/src/components/ProjectSetup/LoginButton.vue
+++ b/extensions/module/src/components/ProjectSetup/LoginButton.vue
@@ -84,7 +84,8 @@ const onLoginClick = async () => {
       await upsertDirectusItem(props.localazyDataCollection.collection, props.localazyData, newData);
       emit('update:localazyData', newData);
       await hydrateLocalazyData({ force: true, localazyData: props.localazyData });
-      AnalyticsService.trackLoggedIn({
+      // Analytics is fire-and-forget; we don't want to block the login flow on telemetry.
+      void AnalyticsService.trackLoggedIn({
         userId: pollResultData.user?.id || '',
         orgId: pollResultData.project?.orgId || '',
         name: pollResultData.user?.name || '',

--- a/extensions/module/src/components/ProjectSetup/LogoutButton.vue
+++ b/extensions/module/src/components/ProjectSetup/LogoutButton.vue
@@ -65,7 +65,8 @@ const onLogout = async () => {
       emit('update:localazyData', newData);
       await hydrateLocalazyData({ force: true, localazyData: newData });
       if (orgId && userId && name) {
-        AnalyticsService.trackLogOut({
+        // Analytics is fire-and-forget; logout shouldn't block on telemetry.
+        void AnalyticsService.trackLogOut({
           userId,
           orgId,
           name,

--- a/extensions/module/src/composables/use-export-to-localazy.ts
+++ b/extensions/module/src/composables/use-export-to-localazy.ts
@@ -77,7 +77,8 @@ export const useExportToLocalazy = (token: Ref<string>) => {
         id: ProgressTrackerId.EXPORT_FINISHED,
         message: nothingToExport ? 'Nothing to export from selected sources' : 'Export finished',
       });
-      AnalyticsService.trackUploadToLocalazy(
+      // Analytics is fire-and-forget; export completion shouldn't block on telemetry.
+      void AnalyticsService.trackUploadToLocalazy(
         ExportToLocalazyCommonService.getPayloadForUploadAnalytics({
           userId: localazyUser.value.id,
           orgId: localazyProject.value.orgId || '',

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -93,7 +93,8 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       message: 'Preparing Directus data for import',
     });
     const token = computed(() => configuration.value.localazy_data.access_token);
-    onSaveSettings(payload);
+    // Save settings is fire-and-forget; errors surface via the errors store inside onSaveSettings.
+    void onSaveSettings(payload);
     try {
       const exportLanguages = await resolveExportLanguages(configuration.value.settings);
       const [translationStrings, collectionsContent] = await Promise.all([
@@ -126,7 +127,8 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       id: ProgressTrackerId.RETRIEVING_LANGUAGES,
       message: 'Retrieving target languages',
     });
-    onSaveSettings(payload);
+    // Save settings is fire-and-forget; errors surface via the errors store inside onSaveSettings.
+    void onSaveSettings(payload);
     try {
       const importLanguages = await resolveImportLanguages(configuration.value.settings);
       const result = await useImportFromLocalazy().importContentFromLocalazy({
@@ -140,7 +142,8 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
           id: ProgressTrackerId.IMPORT_FINISHED,
           message: 'Import finished',
         });
-        AnalyticsService.trackDownloadFromLocalazy(
+        // Analytics is fire-and-forget; download flow shouldn't block on telemetry.
+        void AnalyticsService.trackDownloadFromLocalazy(
           ExportToLocalazyCommonService.getPayloadForUploadAnalytics({
             userId: localazyUser.value.id,
             orgId: localazyProject.value?.orgId || '',

--- a/extensions/module/src/composables/use-sync-container-init.ts
+++ b/extensions/module/src/composables/use-sync-container-init.ts
@@ -12,7 +12,9 @@ export const useInitSyncContainer = () => {
   const synchronizeTranslationStrings = ref(defaultConfiguration().content_transfer_setup.translation_strings);
   const { settings, localazyData, contentTransferSetup, hydrateDirectusData } = useHydrate();
 
-  hydrateDirectusData().then(() => {
+  // Fire-and-forget hydration during container init; errors are captured by the
+  // errors store inside hydrateDirectusData.
+  void hydrateDirectusData().then(() => {
     if (settings.value) {
       configuration.value.settings = cloneDeep(settings.value);
     }

--- a/extensions/module/src/stores/errors-store.ts
+++ b/extensions/module/src/stores/errors-store.ts
@@ -34,7 +34,8 @@ export const useErrorsStore = defineStore('errorsStore', () => {
 
   function addLocalazyError(error: LocalazyError, data: AddLocalazyError) {
     errors.value.localazy[data.type].push(error);
-    AnalyticsService.trackError({
+    // Analytics is fire-and-forget; error tracking shouldn't itself fail and block the flow.
+    void AnalyticsService.trackError({
       userId: data.userId,
       orgId: data.orgId,
       message: error.message,

--- a/extensions/module/src/stores/localazy-store.ts
+++ b/extensions/module/src/stores/localazy-store.ts
@@ -40,7 +40,8 @@ export const useLocalazyStore = defineStore('localazyStore', () => {
           const projects = await LocalazyApiThrottleService.listProjects(token, { organization: true, languages: true });
           localazyProject.value = projects[0] || null;
           resetLocalazyErrors();
-          AnalyticsService.trackConnectedProject({
+          // Analytics is fire-and-forget; hydration shouldn't block on telemetry.
+          void AnalyticsService.trackConnectedProject({
             orgId: localazyProject.value?.orgId || '',
             userId: localazyDataItem.value?.user_id || '',
             name: localazyProject.value?.name || '',

--- a/extensions/sync-hook/src/services/content-synchronization/base-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/base-content-synchronization-service.ts
@@ -205,7 +205,7 @@ export abstract class BaseContentSynchronizationService {
 
     keyIds.forEach((keyId) => {
       add(async () => {
-        LocalazyApiThrottleService.updateKey(localazyData.access_token, {
+        await LocalazyApiThrottleService.updateKey(localazyData.access_token, {
           project: projectId,
           key: keyId,
           deprecated: 0,


### PR DESCRIPTION
## Summary

Stage 2 task **#43**. Clears the 22-site baseline that PR 11 surfaced and promotes `@typescript-eslint/no-floating-promises` from `'warn'` to `'error'` — from here, a new floating Promise blocks CI.

### Real bug fixed

`extensions/sync-hook/src/services/content-synchronization/base-content-synchronization-service.ts:208` — `deprecateLocalazyKeys` was queuing async callbacks that called `LocalazyApiThrottleService.updateKey()` *without awaiting it*. The inner Promise was fire-and-forget inside an `async () => { ... }` callback the queue itself awaited, so the queue would resolve before the actual deprecation API call completed. Added the missing `await`.

### Intentional fire-and-forget marked with `void` (21 sites)

| Pattern | Sites |
|---|---|
| `this.processRequests()` kickoff in `addRequest` + recursive tail call | `localazy-api-throttle-service.ts` ×2 |
| `promise.then()` setting a flag the test reads back (fake-timer pattern) | `sleep.test.ts` |
| `hydrateDirectusData().then(() => hydrateLocalazyData(...))` at Vue setup time — errors captured inside each hydrate function | `AdvancedSettings.vue`, `Overview.vue`, `ProjectSetup.vue`, `Sync.vue`, `use-sync-container-init.ts` |
| `fetchDirectusLanguages().then(...)` inside watch callback | `ConnectionLanguages.vue` |
| `AnalyticsService.trackXxx()` — telemetry, must not block surrounding flow | `LoginButton.vue`, `LogoutButton.vue`, `use-export-to-localazy.ts`, `use-sync-container-actions.ts`, `errors-store.ts`, `localazy-store.ts` |
| `onSaveSettings(payload)` runs concurrently with sync action | `use-sync-container-actions.ts` ×2 |

Each `void` is accompanied by a comment explaining the fire-and-forget intent.

### Rule promotion

```js
'@typescript-eslint/no-floating-promises': 'error'  // was 'warn'
```

`no-misused-promises` stays **off** — SDK 17 still types `action()` callbacks as `() => void`, so every async hook handler is a false positive. Revisit when the SDK types catch up.

## Verified

- `npm run check`: 61/61 tests, lint **0 errors / 0 floating-promise warnings**, typecheck clean, format clean.
- `npm run build`: production minified.

## Stats

| Metric | Before | After |
|---|---|---|
| Lint warnings | 91 | **69** (−22) |
| `no-floating-promises` baseline | 22 | **0** |
| Tests | 61/61 | 61/61 |

## Stage 2 backlog after this PR

| # | Status |
|---|---|
| 25, 26, 27, 28, 29, 30, 34, 36, 37, 38, 39, 40, 41, 42 | ✅ done |
| **43** | ✅ this PR |
| 31 (`@localazy/generic-connector-client`), 32 (`@localazy/languages`), 33 (TypeScript 6), 35 (68 `any` residual) | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)