### PR TITLE
PR 15/N (Stage 2): bump @localazy/generic-connector-client 0.2 → 0.4 (drop-in)

### DIFF
--- a/extensions/common/package.json
+++ b/extensions/common/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@localazy/api-client": "^2.1.5",
-    "@localazy/generic-connector-client": "^0.2.3",
+    "@localazy/generic-connector-client": "^0.4.0",
     "@localazy/languages": "^1.0.0",
     "lodash": "^4.17.21"
   },

--- a/extensions/module/package.json
+++ b/extensions/module/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@localazy/api-client": "^2.1.5",
-    "@localazy/generic-connector-client": "^0.2.3",
+    "@localazy/generic-connector-client": "^0.4.0",
     "@localazy/languages": "^1.0.0",
     "axios": "^1.13.0",
     "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "version": "1.0.10",
       "dependencies": {
         "@localazy/api-client": "^2.1.5",
-        "@localazy/generic-connector-client": "^0.2.3",
+        "@localazy/generic-connector-client": "^0.4.0",
         "@localazy/languages": "^1.0.0",
         "lodash": "^4.17.21"
       },
@@ -55,7 +55,7 @@
       "version": "1.0.10",
       "dependencies": {
         "@localazy/api-client": "^2.1.5",
-        "@localazy/generic-connector-client": "^0.2.3",
+        "@localazy/generic-connector-client": "^0.4.0",
         "@localazy/languages": "^1.0.0",
         "axios": "^1.13.0",
         "lodash": "^4.17.21",
@@ -4998,9 +4998,9 @@
       "link": true
     },
     "node_modules/@localazy/generic-connector-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@localazy/generic-connector-client/-/generic-connector-client-0.2.3.tgz",
-      "integrity": "sha512-o0CL0ils+rwQurWRlrV5BRnesERC4XO3HwFDtJFES6ZzZHtUZplpAvi+yhUfaxSfbnJHC49tc3TMSTGSNfoZBw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@localazy/generic-connector-client/-/generic-connector-client-0.4.0.tgz",
+      "integrity": "sha512-7RQ/YzXB9+1BwKVamEZfZxZWKYb42i71Fzpcu76AaoMiwm6tyRxkLUnm5+bFe4dhuTFgS+s0QrbJMRLQnasfxg==",
       "license": "MIT",
       "dependencies": {
         "@localazy/languages": "^0.1.6",


### PR DESCRIPTION
## Summary

Stage 2 task **#31**. 0.x major bump but the API surface this repo touches is **unchanged in 0.4** — drop-in compatible.

### What we use vs. what changed

| API | 0.2.3 | 0.4.0 |
|---|---|---|
| `new GenericConnectorClient({ pluginId, genericConnectorUrl })` | ✓ | unchanged |
| `Services.DIRECTUS` enum value | ✓ | unchanged |
| `getOAuthAuthorizationUrl(query, baseUrl?)` | ✓ | unchanged |

Two consumer sites continue to work as-is:
- `extensions/common/api/generic-connector-api.ts` (factory)
- `extensions/module/src/components/ProjectSetup/LoginButton.vue` (OAuth URL helper)

Internal changes that the 0.x → 0.4 bump probably brings (HTTP client, response handling, etc.) don't affect us — we only consume the public types listed above.

### Note on transitive `@localazy/languages`

0.4 still pulls `@localazy/languages@^0.1.6` transitively, coexisting with our declared `@localazy/languages@^1.0`. **Pre-existing duplication, not caused by this PR.** Resolved by Stage 2 task #32, which bumps our direct `@localazy/languages` to v2 alongside the community language-mapping feature integration.

## Verified

- `npm run check`: 61/61 tests, lint clean of errors, typecheck clean, format clean.
- `npm run build`: production minified.
- Module bundle: **384.7 KB → 384.8 KB** (+115 bytes from minor internal differences in 0.4).

## Stage 2 backlog after this PR

| # | Status |
|---|---|
| 25, 26, 27, 28, 29, 30, 34, 36, 37, 38, 39, 40, 41, 42, 43 | ✅ done |
| **31** | ✅ this PR |
| 32 (`@localazy/languages` 1→2 + PR #21 integration), 33 (TypeScript 6), 35 (68 `any` residual) | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)