### PR TITLE
PR 16/N (Stage 2): bump @localazy/languages 1 → 2 (drop-in for our usage)

### DIFF
--- a/extensions/common/package.json
+++ b/extensions/common/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@localazy/api-client": "^2.1.5",
     "@localazy/generic-connector-client": "^0.4.0",
-    "@localazy/languages": "^1.0.0",
+    "@localazy/languages": "^2.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/extensions/module/package.json
+++ b/extensions/module/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@localazy/api-client": "^2.1.5",
     "@localazy/generic-connector-client": "^0.4.0",
-    "@localazy/languages": "^1.0.0",
+    "@localazy/languages": "^2.0.0",
     "axios": "^1.13.0",
     "lodash": "^4.17.21",
     "pinia": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "dependencies": {
         "@localazy/api-client": "^2.1.5",
         "@localazy/generic-connector-client": "^0.4.0",
-        "@localazy/languages": "^1.0.0",
+        "@localazy/languages": "^2.0.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -56,7 +56,7 @@
       "dependencies": {
         "@localazy/api-client": "^2.1.5",
         "@localazy/generic-connector-client": "^0.4.0",
-        "@localazy/languages": "^1.0.0",
+        "@localazy/languages": "^2.0.0",
         "axios": "^1.13.0",
         "lodash": "^4.17.21",
         "pinia": "^2.3.1"
@@ -5013,9 +5013,14 @@
       "integrity": "sha512-jbs0YdlSWMu32QVRU1K9l2Xdvmn+KByHIqq/kOElZuzoWfLXFpdxzF8Jg8b5Fq0ZP/kqhlLKuelv+nb5eGYAHw=="
     },
     "node_modules/@localazy/languages": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@localazy/languages/-/languages-1.0.0.tgz",
-      "integrity": "sha512-uqk2pHgQjjn30yg2NyvjkAiPr8Bqr9KeRzUEthMr/DuMVwvAxbE3IRGsz6bhS4vSN+S9A4INODadqRJasHNiyQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@localazy/languages/-/languages-2.0.3.tgz",
+      "integrity": "sha512-12y/7creXhDPEtbK8pVma58nLADmYevsCC27ZPNuEm36GPiqQdL2o/ek98i0mjwTK+pz3MbPPQqjKHsQjkhG2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8.5"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",


### PR DESCRIPTION
## Summary

Stage 2 task **#32 — dep-bump half only.** The community language-mapping feature from PR #21 will land in a follow-up (split for review tractability — the feature touches ~10 files and adds a new Vue component, deserves its own focused PR).

### v2 surface vs. our usage

| API | v1.0 | v2.0.3 |
|---|---|---|
| `getLocalazyLanguages(): Language[]` | ✓ | unchanged |
| `findLocalazyLanguageByLocale(locale): Language \| undefined` | ✓ | unchanged |
| `Language` interface | `{ localazyId, name, locale, rtl }` | adds `important: boolean`, `bcp47: string` (additive) |
| `Locales` enum | ✓ | same string values, more entries |

We consume `getLocalazyLanguages`, `findLocalazyLanguageByLocale`, `Language`, and `Locales` across 5 files (`module/components/ProjectSetup/ProjectSetupForm.vue`, `module/components/Overview/{ConnectionOverview,ConnectionLanguages}.vue`, `common/services/{directus-localazy-adapter,synchronization-languages-service}.ts`). All compile clean against v2.

### Bundle impact

Module dist: **384.8 KB → 395.2 KB (+10.4 KB)**. v2 ships a larger `Locales` enum and more language records. The cost is bounded by Rollup's tree-shaking; consumers that only need a subset don't pay for the rest.

### Duplication note

`@localazy/api-client@2` and `@localazy/generic-connector-client@0.4` still depend on `@localazy/languages@^0.1.6` transitively. Those copies are isolated under each client's `node_modules` and don't leak into our source — we consume the v2 root version directly. Full deduplication would require those upstream client packages to bump their declared dep, which is outside this repo's scope.

## Verified

- `npm run check`: 61/61 tests, lint clean of errors, typecheck clean, format clean.
- `npm run build`: production minified.

## What's NOT in this PR (deferred to follow-up)

The community PR #21 language-mapping feature (DonkeyOatie). That's a substantial integration:
- new `LanguageMappingService`
- refactored `DirectusLocalazyAdapter`
- new `LanguageMappingsEditor.vue` admin component
- new `language_mappings` field on Settings schema
- dynamic FK field resolution
- UUID-based item ID comparison fix

Best handled as PR 17 against `next`, with its own review focus and test additions.

## Stage 2 backlog

| # | Status |
|---|---|
| 25-31, 34, 36-43 | ✅ done |
| **32 (dep half)** | ✅ this PR |
| 32 (feature half) | follows |
| ~~33~~ | dropped (Directus pins TS 5.9) |
| 35 (68 `any` residual) | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)