### PR TITLE
PR 18/N (Stage 2): integrate community PR #21 language-mapping feature

### DIFF
--- a/extensions/common/models/collections-data/settings.ts
+++ b/extensions/common/models/collections-data/settings.ts
@@ -11,4 +11,6 @@ export type Settings = {
   automated_deprecation: boolean;
   skip_empty_strings: boolean;
   create_missing_languages_in_directus: CreateMissingLanguagesInDirectus;
+  /** JSON-encoded array of `LanguageMapping` rows. Empty string or `"[]"` means none. */
+  language_mappings: string;
 };

--- a/extensions/common/models/language-mapping.ts
+++ b/extensions/common/models/language-mapping.ts
@@ -1,0 +1,15 @@
+/**
+ * Custom mapping between a Directus language code and a Localazy language code.
+ * Used when the default transformation (replacing `-` with `_`) isn't enough.
+ * Example: Directus uses `zh-Hans` while Localazy uses `zh-CN#Hans`.
+ */
+export type LanguageMapping = {
+  /** The language code as used in Directus (e.g., `zh-Hans`). */
+  directusCode: string;
+  /** The language code as used in Localazy (e.g., `zh-CN#Hans`). */
+  localazyCode: string;
+  /** Optional human-readable note explaining the mapping. */
+  description?: string;
+};
+
+export type LanguageMappings = LanguageMapping[];

--- a/extensions/common/services/directus-localazy-adapter.test.ts
+++ b/extensions/common/services/directus-localazy-adapter.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { DirectusLocalazyAdapter } from './directus-localazy-adapter';
+
+describe('DirectusLocalazyAdapter — language mapping integration', () => {
+  afterEach(() => {
+    // Static state — leaks across tests if not reset.
+    DirectusLocalazyAdapter.clearMappings();
+  });
+
+  it('falls back to default `-` ↔ `_` swap when no mappings are initialised', () => {
+    expect(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage('pt-BR')).toBe('pt_BR');
+    expect(DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage('pt_BR')).toBe('pt-BR');
+  });
+
+  it('uses custom mappings once initialised', () => {
+    DirectusLocalazyAdapter.initializeMappings([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+    expect(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage('zh-Hans')).toBe('zh-CN#Hans');
+    expect(DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage('zh-CN#Hans')).toBe('zh-Hans');
+  });
+
+  it('still falls back to default for unmapped codes after initialisation', () => {
+    DirectusLocalazyAdapter.initializeMappings([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+    expect(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage('pt-BR')).toBe('pt_BR');
+  });
+
+  it('clearMappings restores fallback behaviour', () => {
+    DirectusLocalazyAdapter.initializeMappings([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+    DirectusLocalazyAdapter.clearMappings();
+    expect(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage('zh-Hans')).toBe('zh_Hans');
+  });
+
+  it('accepts JSON string input from settings', () => {
+    DirectusLocalazyAdapter.initializeMappings('[{"directusCode":"zh-Hans","localazyCode":"zh-CN#Hans"}]');
+    expect(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage('zh-Hans')).toBe('zh-CN#Hans');
+  });
+});

--- a/extensions/common/services/directus-localazy-adapter.ts
+++ b/extensions/common/services/directus-localazy-adapter.ts
@@ -1,6 +1,27 @@
 import { getLocalazyLanguages } from '@localazy/languages';
+import { LanguageMappingService } from './language-mapping-service';
+import { LanguageMappings } from '../models/language-mapping';
 
 export class DirectusLocalazyAdapter {
+  /**
+   * Process-wide mapping service. Each extension (hook in Node, module in the browser)
+   * has its own static slot. Callers should invoke `initializeMappings` once settings are
+   * available; until then, the transform methods fall back to the default `-` ↔ `_` swap.
+   */
+  private static mappingService: LanguageMappingService | null = null;
+
+  static initializeMappings(mappingsInput: string | LanguageMappings): void {
+    this.mappingService = new LanguageMappingService(mappingsInput);
+  }
+
+  static getMappingService(): LanguageMappingService | null {
+    return this.mappingService;
+  }
+
+  static clearMappings(): void {
+    this.mappingService = null;
+  }
+
   static mapDirectusToLocalazySourceLanguage(localazySourceLanguageId: number, directusSourceLanguage: string) {
     const directusSourceLanguageAsLocalazyLanguage =
       getLocalazyLanguages().find((lang) => lang.localazyId === localazySourceLanguageId)?.locale || directusSourceLanguage;
@@ -16,14 +37,26 @@ export class DirectusLocalazyAdapter {
     return processedLanguage;
   }
 
-  /** Directus prefers to use '-' whereas Localazy '_' as region separator */
+  /**
+   * Directus prefers `-` as a region separator, Localazy uses `_`. When a custom mapping
+   * is configured for the code, it wins over the default character swap.
+   */
   static transformDirectusToLocalazyLanguage(directusLanguage: string) {
+    if (this.mappingService) {
+      return this.mappingService.transformDirectusToLocalazy(directusLanguage);
+    }
     return directusLanguage.replace('-', '_');
   }
 
-  /** Directus prefers to use '-' whereas Localazy '_' as region separator */
-  static transformLocalazyToDirectusPreferedFormLanguage(directusLanguage: string) {
-    return directusLanguage.replace('_', '-');
+  /**
+   * Inverse of `transformDirectusToLocalazyLanguage`. Custom mapping wins over default
+   * `_` → `-` swap when configured.
+   */
+  static transformLocalazyToDirectusPreferedFormLanguage(localazyLanguage: string) {
+    if (this.mappingService) {
+      return this.mappingService.transformLocalazyToDirectus(localazyLanguage);
+    }
+    return localazyLanguage.replace('_', '-');
   }
 
   static resolveLocalazyLanguageId(langId: number) {

--- a/extensions/common/services/language-mapping-service.test.ts
+++ b/extensions/common/services/language-mapping-service.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { LanguageMappingService } from './language-mapping-service';
+
+describe('LanguageMappingService', () => {
+  describe('construction + transform', () => {
+    it('transforms via custom mapping when one is defined', () => {
+      const service = new LanguageMappingService([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+      expect(service.transformDirectusToLocalazy('zh-Hans')).toBe('zh-CN#Hans');
+      expect(service.transformLocalazyToDirectus('zh-CN#Hans')).toBe('zh-Hans');
+    });
+
+    it('falls back to default `-` ↔ `_` swap when no mapping exists', () => {
+      const service = new LanguageMappingService([]);
+      expect(service.transformDirectusToLocalazy('pt-BR')).toBe('pt_BR');
+      expect(service.transformLocalazyToDirectus('pt_BR')).toBe('pt-BR');
+    });
+
+    it('accepts a JSON string as input', () => {
+      const service = new LanguageMappingService('[{"directusCode":"zh-Hans","localazyCode":"zh-CN#Hans"}]');
+      expect(service.transformDirectusToLocalazy('zh-Hans')).toBe('zh-CN#Hans');
+    });
+
+    it('tolerates malformed JSON without throwing', () => {
+      const service = new LanguageMappingService('not-json');
+      expect(service.transformDirectusToLocalazy('pt-BR')).toBe('pt_BR');
+    });
+
+    it('treats empty string as empty mappings array', () => {
+      const service = new LanguageMappingService('');
+      expect(service.transformDirectusToLocalazy('en-US')).toBe('en_US');
+    });
+
+    it('skips entries missing either code', () => {
+      const service = new LanguageMappingService([
+        { directusCode: 'zh-Hans', localazyCode: '' },
+        { directusCode: '', localazyCode: 'zh-CN#Hans' },
+        { directusCode: 'pt-BR', localazyCode: 'pt_BR_custom' },
+      ]);
+      expect(service.transformDirectusToLocalazy('zh-Hans')).toBe('zh_Hans');
+      expect(service.transformDirectusToLocalazy('pt-BR')).toBe('pt_BR_custom');
+    });
+  });
+
+  describe('hasCustomMapping', () => {
+    it('returns true for codes mapped in either direction', () => {
+      const service = new LanguageMappingService([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+      expect(service.hasCustomMapping('zh-Hans')).toBe(true);
+      expect(service.hasCustomMapping('zh-CN#Hans')).toBe(true);
+      expect(service.hasCustomMapping('en-US')).toBe(false);
+    });
+  });
+
+  describe('getAllMappings', () => {
+    it('returns all configured mappings', () => {
+      const service = new LanguageMappingService([
+        { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+        { directusCode: 'pt-BR', localazyCode: 'pt_BR_custom' },
+      ]);
+      const mappings = service.getAllMappings();
+      expect(mappings).toHaveLength(2);
+      expect(mappings).toContainEqual({ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' });
+      expect(mappings).toContainEqual({ directusCode: 'pt-BR', localazyCode: 'pt_BR_custom' });
+    });
+  });
+
+  describe('validateMappings (static)', () => {
+    it('flags a JSON object that is not an array', () => {
+      const { valid, errors } = LanguageMappingService.validateMappings('{}');
+      expect(valid).toBe(false);
+      expect(errors).toContain('Mappings must be an array');
+    });
+
+    it('flags missing or empty codes', () => {
+      const { valid, errors } = LanguageMappingService.validateMappings(
+        JSON.stringify([{ directusCode: '', localazyCode: 'x' }, { directusCode: 'y' }]),
+      );
+      expect(valid).toBe(false);
+      expect(errors).toContain('Mapping 1: Directus code cannot be empty');
+      expect(errors).toContain('Mapping 2: Missing or invalid Localazy code');
+    });
+
+    it('flags duplicates on either side', () => {
+      const { valid, errors } = LanguageMappingService.validateMappings(
+        JSON.stringify([
+          { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+          { directusCode: 'zh-Hans', localazyCode: 'other' },
+          { directusCode: 'pt-BR', localazyCode: 'zh-CN#Hans' },
+        ]),
+      );
+      expect(valid).toBe(false);
+      expect(errors.some((e) => e.includes('Duplicate Directus code "zh-Hans"'))).toBe(true);
+      expect(errors.some((e) => e.includes('Duplicate Localazy code "zh-CN#Hans"'))).toBe(true);
+    });
+
+    it('flags malformed JSON', () => {
+      const { valid, errors } = LanguageMappingService.validateMappings('{not json');
+      expect(valid).toBe(false);
+      expect(errors).toContain('Invalid JSON format');
+    });
+
+    it('accepts a valid mappings array', () => {
+      const { valid, errors } = LanguageMappingService.validateMappings(
+        JSON.stringify([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]),
+      );
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts an empty input', () => {
+      expect(LanguageMappingService.validateMappings('')).toEqual({ valid: true, errors: [] });
+      expect(LanguageMappingService.validateMappings('[]')).toEqual({ valid: true, errors: [] });
+    });
+  });
+});

--- a/extensions/common/services/language-mapping-service.ts
+++ b/extensions/common/services/language-mapping-service.ts
@@ -1,0 +1,128 @@
+import { LanguageMappings } from '../models/language-mapping';
+
+/**
+ * Service for handling custom language code mappings between Directus and Localazy.
+ *
+ * Directus and Localazy use different conventions for language codes:
+ * - Directus typically uses BCP 47 format (e.g., `zh-Hans`, `pt-BR`)
+ * - Localazy uses locale format with special characters (e.g., `zh-CN#Hans`, `pt_BR`)
+ *
+ * For most codes the default transformation (`-` ↔ `_`) works. This service lets
+ * users define explicit mappings for codes that can't be converted that way, with
+ * fallback to the default transformation when no mapping exists.
+ */
+export class LanguageMappingService {
+  private directusToLocalazy: Map<string, string> = new Map();
+
+  private localazyToDirectus: Map<string, string> = new Map();
+
+  /**
+   * @param mappingsInput JSON string (from the Directus settings field) or an
+   *                      already-parsed `LanguageMappings` array.
+   */
+  constructor(mappingsInput: string | LanguageMappings) {
+    this.loadMappings(mappingsInput);
+  }
+
+  private loadMappings(input: string | LanguageMappings): void {
+    try {
+      const mappings: LanguageMappings = Array.isArray(input) ? input : (JSON.parse(input || '[]') as LanguageMappings);
+      mappings.forEach((mapping) => {
+        if (mapping.directusCode && mapping.localazyCode) {
+          this.directusToLocalazy.set(mapping.directusCode, mapping.localazyCode);
+          this.localazyToDirectus.set(mapping.localazyCode, mapping.directusCode);
+        }
+      });
+    } catch (e) {
+      console.error('Failed to parse language mappings:', e);
+    }
+  }
+
+  /**
+   * Transform a Directus language code to a Localazy language code. Uses the
+   * custom mapping if defined; otherwise falls back to replacing `-` with `_`.
+   */
+  transformDirectusToLocalazy(directusCode: string): string {
+    const mapped = this.directusToLocalazy.get(directusCode);
+    if (mapped !== undefined) {
+      return mapped;
+    }
+    return directusCode.replace('-', '_');
+  }
+
+  /**
+   * Transform a Localazy language code to a Directus language code. Uses the
+   * custom mapping if defined; otherwise falls back to replacing `_` with `-`.
+   */
+  transformLocalazyToDirectus(localazyCode: string): string {
+    const mapped = this.localazyToDirectus.get(localazyCode);
+    if (mapped !== undefined) {
+      return mapped;
+    }
+    return localazyCode.replace('_', '-');
+  }
+
+  /** Whether a code has a custom mapping in either direction. */
+  hasCustomMapping(code: string): boolean {
+    return this.directusToLocalazy.has(code) || this.localazyToDirectus.has(code);
+  }
+
+  /** All configured mappings as an array. */
+  getAllMappings(): LanguageMappings {
+    const mappings: LanguageMappings = [];
+    this.directusToLocalazy.forEach((localazyCode, directusCode) => {
+      mappings.push({ directusCode, localazyCode });
+    });
+    return mappings;
+  }
+
+  /**
+   * Validate a JSON string of language mappings. Checks structural integrity
+   * (array of objects with non-empty directusCode + localazyCode strings) plus
+   * absence of duplicate codes in either column.
+   */
+  static validateMappings(json: string): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    try {
+      const parsed: unknown = JSON.parse(json || '[]');
+
+      if (!Array.isArray(parsed)) {
+        errors.push('Mappings must be an array');
+        return { valid: false, errors };
+      }
+
+      const directusCodes = new Set<string>();
+      const localazyCodes = new Set<string>();
+
+      parsed.forEach((entry, index) => {
+        const mapping = entry as Partial<LanguageMappings[number]>;
+        const mappingNum = index + 1;
+
+        if (typeof mapping.directusCode !== 'string') {
+          errors.push(`Mapping ${mappingNum}: Missing or invalid Directus code`);
+        } else if (mapping.directusCode.trim() === '') {
+          errors.push(`Mapping ${mappingNum}: Directus code cannot be empty`);
+        } else if (directusCodes.has(mapping.directusCode)) {
+          errors.push(`Mapping ${mappingNum}: Duplicate Directus code "${mapping.directusCode}"`);
+        } else {
+          directusCodes.add(mapping.directusCode);
+        }
+
+        if (typeof mapping.localazyCode !== 'string') {
+          errors.push(`Mapping ${mappingNum}: Missing or invalid Localazy code`);
+        } else if (mapping.localazyCode.trim() === '') {
+          errors.push(`Mapping ${mappingNum}: Localazy code cannot be empty`);
+        } else if (localazyCodes.has(mapping.localazyCode)) {
+          errors.push(`Mapping ${mappingNum}: Duplicate Localazy code "${mapping.localazyCode}"`);
+        } else {
+          localazyCodes.add(mapping.localazyCode);
+        }
+      });
+    } catch {
+      errors.push('Invalid JSON format');
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+}

--- a/extensions/common/services/synchronization-languages-service.ts
+++ b/extensions/common/services/synchronization-languages-service.ts
@@ -28,15 +28,20 @@ export class SynchronizationLanguagesService {
 
   async createLanguages(settings: Settings, localazyLanguages: Language[]) {
     const { language_code_field, language_collection } = settings;
-    localazyLanguages.forEach(async (language) => {
+    // for...of awaits each creation properly (forEach(async ...) fires-and-forgets) and
+    // routes the Localazy code through the adapter so any custom mapping wins over the
+    // default `_` → `-` swap.
+    for (const language of localazyLanguages) {
+      const directusCode = DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(language.code);
       await this.directusApi.createDirectusItem(language_collection, {
-        [language_code_field]: language.code,
+        [language_code_field]: directusCode,
         name: language.name,
       });
-    });
+    }
   }
 
   async resolveImportLanguages(settings: Settings, localazyProject: Project): Promise<DirectusLocalazyLanguage[]> {
+    DirectusLocalazyAdapter.initializeMappings(settings.language_mappings || '[]');
     const { language_code_field, language_collection, import_source_language } = settings;
     const directusLanguages = await this.fetchDirectusLanguages(language_collection, language_code_field);
     const localazyLanguages = localazyProject.languages || [];
@@ -102,6 +107,7 @@ export class SynchronizationLanguagesService {
   }
 
   async resolveExportLanguages(settings: Settings) {
+    DirectusLocalazyAdapter.initializeMappings(settings.language_mappings || '[]');
     const { language_code_field, language_collection, source_language, upload_existing_translations } = settings;
     const exportLanguages = upload_existing_translations
       ? await this.fetchDirectusLanguages(language_collection, language_code_field)

--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -69,6 +69,8 @@
           Automatically create missing languages in Directus when importing translations from Localazy.
         </p>
       </div>
+
+      <LanguageMappingsEditor v-model="localEdits.language_mappings" />
     </div>
   </div>
 </template>
@@ -78,6 +80,7 @@ import { PropType, computed, ref } from 'vue';
 import { Item } from '@directus/types';
 import { Settings } from '../../../../common/models/collections-data/settings';
 import { CreateMissingLanguagesInDirectus } from '../../../../common/enums/create-missing-languages-in-directus';
+import LanguageMappingsEditor from './LanguageMappingsEditor.vue';
 
 const props = defineProps({
   edits: {

--- a/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
+++ b/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="language-mappings">
+    <v-divider :inline-title="false" large>Custom language mappings</v-divider>
+
+    <p class="note description">
+      Define custom mappings between Directus and Localazy language codes. Use this when the default transformation isn't enough — e.g.,
+      Directus's <code>zh-Hans</code> needs to map to Localazy's <code>zh-CN#Hans</code>.
+    </p>
+
+    <div v-if="parsedMappings.length > 0" class="mappings-list">
+      <div class="mapping-row header">
+        <span class="type-label">Directus code</span>
+        <span class="type-label">Localazy code</span>
+        <span class="type-label">Actions</span>
+      </div>
+      <div v-for="(mapping, index) in parsedMappings" :key="index" class="mapping-row">
+        <v-input v-model="mapping.directusCode" placeholder="e.g., zh-Hans" @update:model-value="emitChange" />
+        <v-input v-model="mapping.localazyCode" placeholder="e.g., zh-CN#Hans" @update:model-value="emitChange" />
+        <v-button icon rounded secondary @click="removeMapping(index)">
+          <v-icon name="delete" />
+        </v-button>
+      </div>
+    </div>
+
+    <div v-else class="empty-state">
+      <p class="note">No custom mappings configured. Default behaviour swaps <code>-</code> and <code>_</code> in both directions.</p>
+    </div>
+
+    <v-button class="add-button" secondary @click="addMapping">
+      <v-icon name="add" left />
+      Add mapping
+    </v-button>
+
+    <div v-if="validationErrors.length > 0" class="validation-errors">
+      <v-notice type="danger">
+        <ul>
+          <li v-for="error in validationErrors" :key="error">{{ error }}</li>
+        </ul>
+      </v-notice>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from 'vue';
+import { LanguageMappings } from '../../../../common/models/language-mapping';
+import { LanguageMappingService } from '../../../../common/services/language-mapping-service';
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '[]',
+  },
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const parsedMappings = ref<LanguageMappings>([]);
+const validationErrors = ref<string[]>([]);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    try {
+      parsedMappings.value = JSON.parse(value || '[]') as LanguageMappings;
+    } catch {
+      parsedMappings.value = [];
+    }
+  },
+  { immediate: true },
+);
+
+function emitChange() {
+  const json = JSON.stringify(parsedMappings.value);
+  const validation = LanguageMappingService.validateMappings(json);
+  validationErrors.value = validation.errors;
+  emit('update:modelValue', json);
+}
+
+function addMapping() {
+  parsedMappings.value.push({ directusCode: '', localazyCode: '' });
+  emitChange();
+}
+
+function removeMapping(index: number) {
+  parsedMappings.value.splice(index, 1);
+  emitChange();
+}
+</script>
+
+<style lang="scss" scoped>
+.language-mappings {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  margin-top: 40px;
+}
+
+.description {
+  margin-bottom: 20px;
+}
+
+.mappings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.mapping-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 12px;
+  align-items: center;
+
+  &.header {
+    margin-bottom: 8px;
+  }
+}
+
+.empty-state {
+  margin-bottom: 20px;
+  padding: 20px;
+  background: var(--background-subdued);
+  border-radius: var(--border-radius);
+}
+
+.add-button {
+  margin-bottom: 20px;
+}
+
+.validation-errors {
+  margin-top: 12px;
+
+  ul {
+    margin: 0;
+    padding-left: 20px;
+  }
+}
+
+.note {
+  font-style: italic;
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--foreground-normal);
+}
+
+code {
+  background: var(--background-subdued);
+  padding: 2px 6px;
+  border-radius: var(--border-radius);
+  font-family: var(--family-monospace);
+}
+</style>

--- a/extensions/module/src/composables/use-hydrate.ts
+++ b/extensions/module/src/composables/use-hydrate.ts
@@ -12,6 +12,7 @@ import { useErrorsStore } from '../stores/errors-store';
 import { defaultConfiguration } from '../data/default-configuration';
 import { sleep } from '../../../common/utilities/sleep';
 import { getConfig } from '../../../common/config/get-config';
+import { DirectusLocalazyAdapter } from '../../../common/services/directus-localazy-adapter';
 import { useDirectusApi } from './use-directus-api';
 import { useDirectusCollectionsStore, useDirectusCollectionsStoreRefs } from './use-directus-stores';
 
@@ -158,6 +159,13 @@ export const useHydrate = () => {
       await normalizeSettingsData(settingsCollectionName);
     } catch (e: unknown) {
       addDirectusError(e);
+    }
+
+    // Seed the adapter with custom language mappings so any subsequent transform call in
+    // the module uses them. The hook initialises its own mapping service in the sync flow;
+    // the two static slots are isolated by process.
+    if (settingsItem.value) {
+      DirectusLocalazyAdapter.initializeMappings(settingsItem.value.language_mappings || '[]');
     }
   }
 

--- a/extensions/module/src/data/default-configuration.ts
+++ b/extensions/module/src/data/default-configuration.ts
@@ -13,6 +13,7 @@ export const defaultConfiguration = (): Configuration => ({
     import_source_language: false,
     skip_empty_strings: true,
     create_missing_languages_in_directus: CreateMissingLanguagesInDirectus.ONLY_NON_HIDDEN,
+    language_mappings: '[]',
   },
   content_transfer_setup: {
     enabled_fields: '[]',

--- a/extensions/module/src/data/fields/settings/create.ts
+++ b/extensions/module/src/data/fields/settings/create.ts
@@ -123,4 +123,16 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       default_value: CreateMissingLanguagesInDirectus.ONLY_NON_HIDDEN,
     },
   },
+  {
+    field: 'language_mappings',
+    type: 'text',
+    meta: {
+      interface: 'input-multiline',
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '[]',
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Integrates the language-mapping work from community PR #21 (DonkeyOatie), adapted to the repo's conventions. Lets users define custom Directus ↔ Localazy code mappings for cases where the default `-` ↔ `_` swap isn't enough (e.g., Directus `zh-Hans` → Localazy `zh-CN#Hans`).

## What's in

- **`LanguageMapping` model + `LanguageMappingService`** with `validateMappings` for the editor.
- **`DirectusLocalazyAdapter`** gains `initializeMappings` / `getMappingService` / `clearMappings`. Transform methods delegate to the service when initialised, otherwise fall back to the prior behaviour.
- **Hook** initialises mappings in `SynchronizationLanguagesService.resolveImportLanguages` / `resolveExportLanguages`. `createLanguages` also routes the Localazy code through the transform, and is fixed from `forEach(async ...)` (fire-and-forget) to `for...of`.
- **Module** initialises mappings in `useHydrate.loadSettings` once the settings singleton is loaded.
- **UI**: `LanguageMappingsEditor.vue` in the Advanced Settings form. Validation surfaces in a `v-notice`.
- **Settings model + Directus field + default `'[]'`** for the new `language_mappings` column.
- **Tests** for the service (parse, transform, validate) and adapter (init / clear / fallback).

## What's deliberately out

PR #21 also bundled changes that don't belong in this feature:
- Dynamic FK field resolution from relations
- UUID-aware item ID comparison
- `validateLanguageCode` / `isRecognizedByLocalazy` helpers

Those should be reviewed independently as their own PRs.

## Test plan

- [ ] `npm run check` clean ✅ (lint + format + typecheck + 80 tests)
- [ ] Production build succeeds ✅
- [ ] Boot dev server, open Advanced Settings, add a mapping (e.g. `zh-Hans` → `zh-CN#Hans`), reload, confirm value persists
- [ ] Trigger a translation sync with the mapping active; verify Localazy receives the mapped code

🤖 Generated with [Claude Code](https://claude.com/claude-code)