### PR TITLE
PR 19/N (Stage 2): fix UUID PK comparison + dynamic language FK resolution

### DIFF
--- a/extensions/module/src/composables/use-directus-localazy-adapter.test.ts
+++ b/extensions/module/src/composables/use-directus-localazy-adapter.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractLanguageCode } from './use-directus-localazy-adapter';
+
+describe('extractLanguageCode', () => {
+  it('returns the value when the FK column is a bare string', () => {
+    expect(extractLanguageCode('en-US', 'code')).toBe('en-US');
+  });
+
+  it('reads the configured field off an expanded relation object', () => {
+    expect(extractLanguageCode({ id: 1, code: 'en-US', name: 'English' }, 'code')).toBe('en-US');
+  });
+
+  it('respects a non-default code field (e.g. installations with `language` instead of `code`)', () => {
+    expect(extractLanguageCode({ id: 1, language: 'fr-FR' }, 'language')).toBe('fr-FR');
+  });
+
+  it('returns undefined when the configured field is missing from the object', () => {
+    expect(extractLanguageCode({ id: 1, name: 'English' }, 'code')).toBeUndefined();
+  });
+
+  it('returns undefined when the configured field is present but not a string', () => {
+    expect(extractLanguageCode({ id: 1, code: 42 }, 'code')).toBeUndefined();
+  });
+
+  it('returns undefined for null / undefined input', () => {
+    expect(extractLanguageCode(null, 'code')).toBeUndefined();
+    expect(extractLanguageCode(undefined, 'code')).toBeUndefined();
+  });
+
+  it('returns undefined for non-string primitives', () => {
+    expect(extractLanguageCode(42, 'code')).toBeUndefined();
+    expect(extractLanguageCode(true, 'code')).toBeUndefined();
+  });
+});

--- a/extensions/module/src/composables/use-directus-localazy-adapter.ts
+++ b/extensions/module/src/composables/use-directus-localazy-adapter.ts
@@ -6,6 +6,7 @@ import {
   LocalazyCollectionItem,
   LocalazyItemsInLanguage,
 } from '../../../common/models/localazy-content';
+import { Settings } from '../../../common/models/collections-data/settings';
 import { createAsyncQueue } from '../../../common/utilities/async-queue';
 import { TranslationPayload } from '../models/directus/translation-payload';
 import { mergeTranslationPayload } from '../utils/merge-translation-payload';
@@ -13,6 +14,7 @@ import { useErrorsStore } from '../stores/errors-store';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
 import { useDirectusApi } from './use-directus-api';
+import { useDirectusRelationsStore } from './use-directus-stores';
 import { useTranslationStringsContent } from './use-translation-strings-content';
 
 type CreatePayloadForTranslationItem = {
@@ -20,6 +22,8 @@ type CreatePayloadForTranslationItem = {
   localazyItem: LocalazyCollectionItem;
   language: string;
   currentPayload: TranslationPayload;
+  languageFkField: string;
+  languageCodeField: string;
 };
 
 type UpsertItemFromLocalazyContent = {
@@ -27,24 +31,56 @@ type UpsertItemFromLocalazyContent = {
   itemsInCollection: Item[];
   itemId: string | number;
   translations: LocalazyItemsInLanguage[];
+  translationFieldFkMap: Map<string, string>;
+  languageCodeField: string;
 };
+
+/**
+ * Resolves the language code from a translation row's FK field. Directus expands
+ * relations into objects, but legacy callers may pass the bare string — accept both.
+ * Exported so the logic can be tested without standing up the Pinia stores.
+ */
+export function extractLanguageCode(fkValue: unknown, languageCodeField: string): string | undefined {
+  if (typeof fkValue === 'string') {
+    return fkValue;
+  }
+  if (fkValue && typeof fkValue === 'object') {
+    const codeValue = (fkValue as Record<string, unknown>)[languageCodeField];
+    return typeof codeValue === 'string' ? codeValue : undefined;
+  }
+  return undefined;
+}
 
 export const useDirectusLocalazyAdapter = () => {
   const { addDirectusError } = useErrorsStore();
   const { upsertProgressMessage } = useProgressTrackerStore();
   const { fetchDirectusItems, updateDirectusItem } = useDirectusApi();
   const { upsertTranslationStrings } = useTranslationStringsContent();
+  const relationsStore = useDirectusRelationsStore();
+
+  /**
+   * Resolve the FK column on a translation collection that points back at the languages
+   * collection. The Directus convention is `languages_code`, but real-world installs often
+   * use a different name (`lang_code`, `language`, etc.) — hardcoding breaks them.
+   * Falls back to `languages_code` when the relation can't be located.
+   */
+  function resolveLanguageFkField(parentCollection: string, translationField: string, languagesCollection: string): string {
+    const relations = relationsStore.getRelationsForField(parentCollection, translationField);
+    const languageRelation = relations.find((r) => r.related_collection === languagesCollection);
+    return languageRelation?.field || 'languages_code';
+  }
 
   function createPayloadForTranslationItem(payload: CreatePayloadForTranslationItem) {
-    const { collectionItem, localazyItem, language, currentPayload } = payload;
-    const translationItem = collectionItem[localazyItem.translationField]?.find(
-      (data: { languages_code?: string }) => data.languages_code === language,
-    );
+    const { collectionItem, localazyItem, language, currentPayload, languageFkField, languageCodeField } = payload;
+    const translationItem = collectionItem[localazyItem.translationField]?.find((data: Record<string, unknown>) => {
+      const code = extractLanguageCode(data[languageFkField], languageCodeField);
+      return code === language;
+    });
     const common = {
       localazyItem,
       translationItem,
       language,
-      languageCodeField: 'languages_code',
+      languageCodeField: languageFkField,
     };
     const isCreateOperation = translationItem === undefined;
 
@@ -61,7 +97,7 @@ export const useDirectusLocalazyAdapter = () => {
         ...common,
         type: 'create',
         value: {
-          languages_code: language,
+          [languageFkField]: language,
           [localazyItem.field]: localazyItem.value,
         },
       });
@@ -87,8 +123,11 @@ export const useDirectusLocalazyAdapter = () => {
   }
 
   async function upsertItemFromLocalazyContent(data: UpsertItemFromLocalazyContent) {
-    const { itemsInCollection, itemId, translations, collection } = data;
-    const collectionItem = itemsInCollection.find((i: Item) => +i.id === +itemId);
+    const { itemsInCollection, itemId, translations, collection, translationFieldFkMap, languageCodeField } = data;
+    // Stringify both sides — `+id` returns NaN for UUID primary keys, and NaN === NaN is
+    // false, so the strict numeric equality used previously silently failed for any
+    // installation with UUID-keyed collections.
+    const collectionItem = itemsInCollection.find((i: Item) => String(i.id) === String(itemId));
     let payload: TranslationPayload = {};
     const updateTranslationFields: Set<string> = new Set();
     let somethingToCreate = false;
@@ -98,11 +137,14 @@ export const useDirectusLocalazyAdapter = () => {
     }
     translations.forEach((translation) => {
       translation.items.forEach((item) => {
+        const languageFkField = translationFieldFkMap.get(item.translationField) || 'languages_code';
         const result = createPayloadForTranslationItem({
           collectionItem,
           localazyItem: item,
           language: translation.language,
           currentPayload: payload,
+          languageFkField,
+          languageCodeField,
         });
         payload = result.currentPayload;
         if (result.isCreateOperation) {
@@ -118,16 +160,33 @@ export const useDirectusLocalazyAdapter = () => {
     }
   }
 
-  async function upsertItemsFromSingleCollection(collection: string, content: LocalazyCollectionBlock) {
+  async function upsertItemsFromSingleCollection(collection: string, content: LocalazyCollectionBlock, settings: Settings) {
     try {
+      // Build a map of translation field -> FK column for the language relation, and ask
+      // Directus to expand each language reference (`${field}.${fk}.*`) so the FK column
+      // hands us an object we can pull `language_code_field` out of.
+      const translationFieldFkMap = new Map<string, string>();
+      const fields: string[] = ['id'];
+      content.translationFields.forEach((field) => {
+        const fkField = resolveLanguageFkField(collection, field, settings.language_collection);
+        translationFieldFkMap.set(field, fkField);
+        fields.push(`${field}.*`);
+        fields.push(`${field}.${fkField}.*`);
+      });
+
       const itemsInCollection = await fetchDirectusItems(collection, {
-        fields: ['id', ...content.translationFields.map((field) => `${field}.*`)],
+        fields,
         limit: -1,
       });
 
-      Object.entries(content.items).forEach(async ([itemId, translations], index) => {
+      // for...of awaits each iteration. The previous forEach(async ...) was fire-and-forget,
+      // so this function used to return before the upserts ran — errors went unhandled and
+      // the caller's progress tracker raced ahead.
+      const entries = Object.entries(content.items);
+      for (let index = 0; index < entries.length; index += 1) {
+        const [itemId, translations] = entries[index]!;
         upsertProgressMessage(ProgressTrackerId.UPDATING_DIRECTUS_COLLECTION, {
-          message: `Updating ${collection} collection (${index + 1}/${Object.keys(content.items).length})`,
+          message: `Updating ${collection} collection (${index + 1}/${entries.length})`,
         });
 
         try {
@@ -136,15 +195,17 @@ export const useDirectusLocalazyAdapter = () => {
             itemsInCollection,
             itemId,
             translations,
+            translationFieldFkMap,
+            languageCodeField: settings.language_code_field,
           });
         } catch (e: unknown) {
           addDirectusError(e);
           upsertProgressMessage(ProgressTrackerId.UPDATING_DIRECTUS_COLLECTION_ERROR, {
             type: 'error',
-            message: `Error updating ${collection} collection (${index + 1}/${Object.keys(content.items).length})`,
+            message: `Error updating ${collection} collection (${index + 1}/${entries.length})`,
           });
         }
-      });
+      }
     } catch (e: unknown) {
       addDirectusError(e);
       upsertProgressMessage(ProgressTrackerId.UPDATING_DIRECTUS_COLLECTION_ERROR, {
@@ -155,10 +216,10 @@ export const useDirectusLocalazyAdapter = () => {
     return {};
   }
 
-  async function upsertFromLocalazyContent(contentItems: LocalazyContent) {
+  async function upsertFromLocalazyContent(contentItems: LocalazyContent, settings: Settings) {
     const { add, execute } = createAsyncQueue();
     contentItems.collections.forEach((content, collection) => {
-      add(async () => upsertItemsFromSingleCollection(collection, content));
+      add(async () => upsertItemsFromSingleCollection(collection, content, settings));
     });
     add(async () => upsertTranslationStrings(Array.from(contentItems.translationStrings.values())));
 

--- a/extensions/module/src/composables/use-directus-stores.ts
+++ b/extensions/module/src/composables/use-directus-stores.ts
@@ -1,6 +1,6 @@
 import { useStores } from '@directus/extensions-sdk';
 import { computed, type ComputedRef } from 'vue';
-import type { AppCollection, Collection } from '@directus/types';
+import type { AppCollection, Collection, Relation } from '@directus/types';
 
 /**
  * Shape of the Directus admin's collections Pinia store that this extension uses.
@@ -40,4 +40,14 @@ export const useDirectusCollectionsStoreRefs = (): CollectionsStoreRefs => {
     collections: computed(() => store.collections),
     allCollections: computed(() => store.allCollections),
   };
+};
+
+/** Subset of Directus' relations Pinia store that this extension depends on. */
+type RelationsStore = {
+  getRelationsForField: (collection: string, field: string) => Relation[];
+};
+
+export const useDirectusRelationsStore = (): RelationsStore => {
+  const stores = useStores();
+  return stores.useRelationsStore() as RelationsStore;
 };

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -137,7 +137,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
         enabledFields: enabledFields.value,
       });
       if (result.success) {
-        await upsertFromLocalazyContent(result.content);
+        await upsertFromLocalazyContent(result.content, configuration.value.settings);
         addProgressMessage({
           id: ProgressTrackerId.IMPORT_FINISHED,
           message: 'Import finished',


### PR DESCRIPTION
## Summary

Three bug fixes in `extensions/module/src/composables/use-directus-localazy-adapter.ts`, all originally part of community PR #21 (DonkeyOatie) but split out from the language-mapping feature in PR 18 so each can land independently.

## Bugs fixed

### 1. UUID PKs silently skipped — real bug

`+i.id === +itemId` coerces both sides via `Number()`. For UUID primary keys both become `NaN`, and `NaN === NaN` is always `false`. The previous code therefore never matched an item in collections with UUID PKs, so translation upserts on those installations always no-op'd.

Fix: `String(i.id) === String(itemId)`.

### 2. Hardcoded `languages_code` FK — real bug for many installs

The composable assumed every translation collection links to languages via a column named `languages_code`. Real-world installations often name it differently (`lang`, `language`, `lang_code`).

Fix: look the FK up via `useRelationsStore.getRelationsForField(...)`, matching the relation whose `related_collection === settings.language_collection`. Fall back to `languages_code` when not found, so existing installs keep working.

The Directus query now expands the language relation dynamically (`${field}.${fkField}.*`), and a small `extractLanguageCode` helper accepts both the expanded object (`{ id, code, name }`) and the bare string form so we don't break callers that don't expand.

### 3. `forEach(async ...)` in `upsertItemsFromSingleCollection`

Same fire-and-forget pattern PRs 11/14 fixed elsewhere. The outer `forEach` returns before any inner upsert resolves — the progress tracker advanced past unfinished work and errors went unhandled.

Fix: `for...of` loop.

## Test coverage

- New `use-directus-localazy-adapter.test.ts` covering `extractLanguageCode` for string FK, expanded object FK, non-default code-field name, and the missing / malformed cases.
- Typed wrapper `useDirectusRelationsStore` added to `use-directus-stores.ts` matching the existing `useDirectusCollectionsStore` pattern.

## Test plan

- [x] `npm run check` clean (lint + format + typecheck + 68 tests) ✅
- [x] Production build succeeds ✅
- [ ] Manual: import translations into a Directus collection with UUID PKs — confirm rows actually get written (regression of bug 1)
- [ ] Manual: import translations into a collection whose translation FK is named anything other than `languages_code` — confirm rows are matched correctly (regression of bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)