### PR TITLE
PR 20/N (Stage 3): use private-view title/icon props instead of hand-rolled slots

### DIFF
--- a/extensions/module/src/About.vue
+++ b/extensions/module/src/About.vue
@@ -1,15 +1,5 @@
 <template>
-  <private-view>
-    <template #title-outer:prepend>
-      <v-button class="header-icon" rounded disabled icon secondary>
-        <v-icon name="school" />
-      </v-button>
-    </template>
-
-    <template #title>
-      <h1 class="type-title">About this plugin</h1>
-    </template>
-
+  <private-view title="About this plugin" icon="school">
     <template #headline>
       <v-breadcrumb :items="[{ name: 'Localazy', to: '/localazy' }]" />
     </template>

--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -1,15 +1,5 @@
 <template>
-  <private-view>
-    <template #title-outer:prepend>
-      <v-button class="header-icon" rounded disabled icon secondary>
-        <v-icon name="settings" />
-      </v-button>
-    </template>
-
-    <template #title>
-      <h1 class="type-title">Additional Settings</h1>
-    </template>
-
+  <private-view title="Additional Settings" icon="settings">
     <template #headline>
       <v-breadcrumb :items="[{ name: 'Localazy', to: '/localazy' }]" />
     </template>

--- a/extensions/module/src/Overview.vue
+++ b/extensions/module/src/Overview.vue
@@ -1,17 +1,7 @@
 <template>
-  <private-view>
-    <template #title-outer:prepend>
-      <v-button class="header-icon" rounded disabled icon secondary>
-        <v-icon name="home" />
-      </v-button>
-    </template>
-
+  <private-view title="Overview" icon="home">
     <template #headline>
       <v-breadcrumb :items="[{ name: 'Localazy', to: '/localazy' }]" />
-    </template>
-
-    <template #title>
-      <h1 class="type-title">Overview</h1>
     </template>
 
     <template #navigation>

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -1,15 +1,5 @@
 <template>
-  <private-view>
-    <template #title-outer:prepend>
-      <v-button class="header-icon" rounded disabled icon secondary>
-        <v-icon name="lan" />
-      </v-button>
-    </template>
-
-    <template #title>
-      <h1 class="type-title">Project setup</h1>
-    </template>
-
+  <private-view title="Project setup" icon="lan">
     <template #headline>
       <v-breadcrumb :items="[{ name: 'Localazy', to: '/localazy' }]" />
     </template>

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -1,17 +1,7 @@
 <template>
-  <private-view>
-    <template #title-outer:prepend>
-      <v-button class="header-icon" rounded disabled icon secondary>
-        <v-icon name="translate" />
-      </v-button>
-    </template>
-
+  <private-view title="Import & Export" icon="translate">
     <template #headline>
       <v-breadcrumb :items="[{ name: 'Localazy', to: '/localazy' }]" />
-    </template>
-
-    <template #title>
-      <h1 class="type-title title">Import & Export</h1>
     </template>
 
     <template #navigation>
@@ -172,12 +162,5 @@ function deselectAll() {
   padding-top: 8px;
   margin-top: 8px;
   border-top: 1px solid var(--border-normal);
-}
-
-.title {
-  display: none;
-  @media screen and (min-width: 1400px) {
-    display: block;
-  }
 }
 </style>


### PR DESCRIPTION
## Summary

First PR of Stage 3 (module refactor). All five module views (Overview, Sync, ProjectSetup, AdvancedSettings, About) rebuilt private-view's title bar by hand — a `<template #title-outer:prepend>` slot containing a `<v-button rounded disabled icon secondary>`, plus a `<template #title>` slot containing `<h1 class="type-title">`. The component already accepts `title` and `icon` as props and renders them the same way Directus' own admin modules do.

Switching to props drops ~10 lines per view and brings module headers in line with the rest of the Directus admin.

## What changed

For each of `About.vue`, `AdvancedSettings.vue`, `Overview.vue`, `ProjectSetup.vue`, `Sync.vue`:

- Replaced `<template #title-outer:prepend><v-button ...><v-icon name="..."/></v-button></template>` + `<template #title><h1 class="type-title">...</h1></template>` with `<private-view title="..." icon="...">`.
- Removed the now-unreferenced `.header-icon` class (it was only on the deleted button).

`Sync.vue` also dropped its responsive `.title { display: none; @media (min-width: 1400px) { display: block } }` rule. The rule hid the title below 1400px width — custom responsive behavior that the prop-based rendering doesn't need at our typical viewport widths. If a narrow-viewport overlap surfaces with the action buttons, we'll address it differently (e.g. responsive action button arrangement).

## Verification

- `npm run check` clean (lint + format + typecheck + 87 tests)
- Production build green
- Visually verified all 5 routes in a local dev Directus (admin@example.com / d1r3ctu5) — headers now render with Directus' native icon-box-plus-title shape, matching the rest of the admin UI

## Diff size

5 files, +5/-62 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)