### PR TITLE
PR 22/N (Stage 3): useSingletonForm composable; refactor AdvancedSettings + ProjectSetup

### DIFF
--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template #actions>
-      <v-button class="panel-button" :disabled="!changesExist" :loading="hydrating || loading" @click="onSaveChanges"
+      <v-button class="panel-button" :disabled="!changesExist" :loading="hydrating || saving" @click="onSaveChanges"
         >Save changes
       </v-button>
     </template>
@@ -22,11 +22,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
-import { cloneDeep, isEqual } from 'lodash';
 import { storeToRefs } from 'pinia';
 import { useStores } from '@directus/extensions-sdk';
-import { Settings } from '../../common/models/collections-data/settings';
 import AdvancedSettingsForm from './components/AdvancedSettings/AdvancedSettingsForm.vue';
 import Navigation from './components/Navigation.vue';
 import { useLocalazyStore } from './stores/localazy-store';
@@ -34,6 +31,7 @@ import ErrorsNotice from './components/ErrorsNotice.vue';
 import { useLocalazyInstallerStore, LOCALAZY_COLLECTIONS } from './stores/localazy-installer-store';
 import { useLocalazySettingsStore } from './stores/localazy-settings-store';
 import { useLocalazyConfigStore } from './stores/localazy-config-store';
+import { useSingletonForm } from './composables/use-singleton-form';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
@@ -41,11 +39,9 @@ const installer = useLocalazyInstallerStore();
 const { installed } = storeToRefs(installer);
 
 const settingsStore = useLocalazySettingsStore();
-const { data: settings } = storeToRefs(settingsStore);
 const { data: localazyData } = storeToRefs(useLocalazyConfigStore());
 
-const settingsEdits = ref<Settings>(cloneDeep(settings.value));
-const loading = ref(false);
+const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
 
 const { useNotificationsStore } = useStores();
 const notificationsStore = useNotificationsStore();
@@ -53,30 +49,12 @@ const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
 const { hydrating, hydrated } = storeToRefs(localazyStore);
 
-// Reseat editing state when the source-of-truth settings change (e.g. after install
-// completes, or after another tab saves). The form composable in PR 22 will own this
-// pattern — for now we keep the historical shape so the diff stays focused.
-watch(
-  settings,
-  (s) => {
-    settingsEdits.value = cloneDeep(s);
-  },
-  { immediate: true, deep: true },
-);
-
 // Fire-and-forget at component setup; errors land in the errors store inside `run()`.
 void installer.run().then(() => hydrateLocalazyData({ localazyData }));
 
-const changesExist = computed(() => !isEqual(settingsEdits.value, settings.value));
-
 async function onSaveChanges() {
-  loading.value = true;
-  try {
-    await settingsStore.save(settingsEdits.value);
-    notificationsStore.add({ title: 'Settings saved' });
-  } finally {
-    loading.value = false;
-  }
+  await saveSettings();
+  notificationsStore.add({ title: 'Settings saved' });
 }
 </script>
 

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template #actions>
-      <v-button class="panel-button" :disabled="!changesExist" :loading="hydrating || loading" @click="onSaveChanges"
+      <v-button class="panel-button" :disabled="!changesExist" :loading="hydrating || saving" @click="onSaveChanges"
         >Save changes
       </v-button>
     </template>
@@ -21,11 +21,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
-import { cloneDeep, isEqual } from 'lodash';
 import { storeToRefs } from 'pinia';
 import { useStores } from '@directus/extensions-sdk';
-import { Settings } from '../../common/models/collections-data/settings';
 import ProjectSetupForm from './components/ProjectSetup/ProjectSetupForm.vue';
 import Navigation from './components/Navigation.vue';
 import { useLocalazyStore } from './stores/localazy-store';
@@ -33,6 +30,7 @@ import ErrorsNotice from './components/ErrorsNotice.vue';
 import { useLocalazyInstallerStore, LOCALAZY_COLLECTIONS } from './stores/localazy-installer-store';
 import { useLocalazySettingsStore } from './stores/localazy-settings-store';
 import { useLocalazyConfigStore } from './stores/localazy-config-store';
+import { useSingletonForm } from './composables/use-singleton-form';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
@@ -40,11 +38,9 @@ const installer = useLocalazyInstallerStore();
 const { installed } = storeToRefs(installer);
 
 const settingsStore = useLocalazySettingsStore();
-const { data: settings } = storeToRefs(settingsStore);
 const { data: localazyData } = storeToRefs(useLocalazyConfigStore());
 
-const settingsEdits = ref<Settings>(cloneDeep(settings.value));
-const loading = ref(false);
+const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
 
 const { useNotificationsStore } = useStores();
 const notificationsStore = useNotificationsStore();
@@ -52,30 +48,12 @@ const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
 const { hydrating, hydrated } = storeToRefs(localazyStore);
 
-// The login/logout buttons write to the Localazy config store directly, so we don't
-// need an `edits` ref for localazyData here — only for the settings form. Reseat the
-// settings edits when the underlying source changes (install finishes, save reloads).
-watch(
-  settings,
-  (s) => {
-    settingsEdits.value = cloneDeep(s);
-  },
-  { immediate: true, deep: true },
-);
-
 // Fire-and-forget at component setup; errors land in the errors store inside `run()`.
 void installer.run().then(() => hydrateLocalazyData({ localazyData }));
 
-const changesExist = computed(() => !isEqual(settingsEdits.value, settings.value));
-
 async function onSaveChanges() {
-  loading.value = true;
-  try {
-    await settingsStore.save(settingsEdits.value);
-    notificationsStore.add({ title: 'Settings saved' });
-  } finally {
-    loading.value = false;
-  }
+  await saveSettings();
+  notificationsStore.add({ title: 'Settings saved' });
 }
 </script>
 

--- a/extensions/module/src/composables/use-singleton-form.test.ts
+++ b/extensions/module/src/composables/use-singleton-form.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reactive, nextTick } from 'vue';
+import { useSingletonForm } from './use-singleton-form';
+
+type FakeData = { a: string; b: number };
+
+function makeStore(initial: FakeData) {
+  const save = vi.fn(async (payload: Partial<FakeData>) => {
+    // Mimic the real factory: save merges into the persisted data and the data updates
+    // reactively. This is what triggers the form composable to reseat its edits.
+    Object.assign(store.data, payload);
+  });
+  const store = reactive({
+    data: initial,
+    loading: false,
+    save,
+  });
+  return store;
+}
+
+describe('useSingletonForm', () => {
+  it('seeds edits from the persisted data without sharing the reference', () => {
+    const store = makeStore({ a: 'hello', b: 1 });
+    const { edits } = useSingletonForm(store);
+
+    expect(edits.value).toEqual({ a: 'hello', b: 1 });
+    // Mutating edits must not bleed into the store
+    edits.value.a = 'edited';
+    expect(store.data.a).toBe('hello');
+  });
+
+  it('changesExist tracks divergence between edits and the persisted data', async () => {
+    const store = makeStore({ a: 'hello', b: 1 });
+    const { edits, changesExist } = useSingletonForm(store);
+
+    expect(changesExist.value).toBe(false);
+
+    edits.value.a = 'changed';
+    await nextTick();
+    expect(changesExist.value).toBe(true);
+
+    edits.value.a = 'hello';
+    await nextTick();
+    expect(changesExist.value).toBe(false);
+  });
+
+  it('save pushes the edits through the store', async () => {
+    const store = makeStore({ a: 'hello', b: 1 });
+    const { edits, save } = useSingletonForm(store);
+
+    edits.value.a = 'changed';
+    edits.value.b = 42;
+    await save();
+
+    expect(store.save).toHaveBeenCalledOnce();
+    expect(store.save).toHaveBeenCalledWith({ a: 'changed', b: 42 });
+  });
+
+  it('reseats edits when the persisted data changes (e.g. after a reload)', async () => {
+    const store = makeStore({ a: 'hello', b: 1 });
+    const { edits, changesExist } = useSingletonForm(store);
+
+    edits.value.a = 'changed';
+    await nextTick();
+    expect(changesExist.value).toBe(true);
+
+    // External update — installer finishes, save reloads, cross-tab edit, etc.
+    store.data = { a: 'external', b: 99 };
+    await nextTick();
+
+    expect(edits.value).toEqual({ a: 'external', b: 99 });
+    expect(changesExist.value).toBe(false);
+  });
+
+  it('proxies the store loading flag', async () => {
+    const store = makeStore({ a: 'hello', b: 1 });
+    const { loading } = useSingletonForm(store);
+
+    expect(loading.value).toBe(false);
+    store.loading = true;
+    await nextTick();
+    expect(loading.value).toBe(true);
+  });
+});

--- a/extensions/module/src/composables/use-singleton-form.ts
+++ b/extensions/module/src/composables/use-singleton-form.ts
@@ -1,0 +1,67 @@
+import { ref, watch, computed, type ComputedRef, type Ref } from 'vue';
+import { cloneDeep, isEqual } from 'lodash';
+
+/**
+ * Minimal contract a `useLocalazySingleton`-style store must satisfy to be edited via
+ * this composable. We accept the Pinia store directly; reactive access (`store.data`,
+ * `store.loading`) is automatic inside watch / computed.
+ */
+type EditableSingleton<T> = {
+  data: T;
+  loading: boolean;
+  save: (payload: Partial<T>) => Promise<void>;
+};
+
+type SingletonForm<T> = {
+  /** Mutable working copy bound to the form template. */
+  edits: Ref<T>;
+  /** True whenever the working copy differs from the persisted data. */
+  changesExist: ComputedRef<boolean>;
+  /** Persist the working copy. Returns when the store reload finishes. */
+  save: () => Promise<void>;
+  /** True while the underlying store is talking to Directus. */
+  loading: ComputedRef<boolean>;
+};
+
+/**
+ * Forms for `useLocalazySingleton`-style records — `AdvancedSettings.vue`,
+ * `ProjectSetup.vue`, and any future singleton edits — all share the same shape:
+ *   1. clone the persisted record into a working copy
+ *   2. compare to detect dirty
+ *   3. on save, push the working copy through `store.save`
+ *   4. when the store reload returns the new persisted value, reseat the working copy
+ *      so `changesExist` flips back to false
+ *
+ * This composable owns that contract so the views don't each reimplement it. Notification
+ * on success stays at the call site — the text varies per page and isn't a form concern.
+ *
+ * Usage:
+ * ```ts
+ * const settingsStore = useLocalazySettingsStore();
+ * const { edits, changesExist, save, loading } = useSingletonForm(settingsStore);
+ * ```
+ */
+export function useSingletonForm<T extends Record<string, unknown>>(store: EditableSingleton<T>): SingletonForm<T> {
+  const edits = ref<T>(cloneDeep(store.data)) as Ref<T>;
+
+  // Reseat the working copy whenever the persisted data changes — initial load,
+  // post-save reload, or a rare cross-tab edit. The `deep: true` is important because
+  // store.data is a plain object; without it Vue compares by reference and misses any
+  // change inside the object.
+  watch(
+    () => store.data,
+    (next) => {
+      edits.value = cloneDeep(next);
+    },
+    { immediate: true, deep: true },
+  );
+
+  const changesExist = computed(() => !isEqual(edits.value, store.data));
+  const loading = computed(() => store.loading);
+
+  async function save(): Promise<void> {
+    await store.save(edits.value);
+  }
+
+  return { edits, changesExist, save, loading };
+}


### PR DESCRIPTION
## Summary

Extracts the watch-clone-diff-save pattern duplicated between `AdvancedSettings.vue` and `ProjectSetup.vue` into a shared `useSingletonForm<T>(store)` composable, per the Q5 design from the Stage-3 grill.

## What the composable does

Given any `useLocalazySingleton`-style store, returns `{ edits, changesExist, save, loading }`:

1. Clones the persisted data into a working `edits` ref
2. Watches the store's data (deep) and reseats the working copy on every change — initial load, post-save reload, cross-tab edits
3. Computes `changesExist` via `isEqual`
4. `save()` pushes the working copy through `store.save`
5. Proxies `store.loading` so the button can disable mid-save

Notification on success stays at the call site — text varies per page and isn't a form concern.

## Caller cleanup

Both `AdvancedSettings.vue` and `ProjectSetup.vue` lose ~22 lines each: no more local `settingsEdits` ref + immediate-deep `watch` + `changesExist` computed + try/finally save. The post-refactor views are ~60 lines and structurally identical except for which form component renders — natural setup for a shared shell extraction in PR 24's audit pass.

## Tests

New `use-singleton-form.test.ts` covers:
- Seeding edits from initial data without aliasing
- `changesExist` tracking divergence both ways
- `save` dispatching the current edits through the store
- External-update reseating (the post-reload / cross-tab path)
- `loading` proxy

92 tests total, all passing.

## Verification

- `npm run check` clean (lint + format + typecheck + 92 tests)
- Production build green
- Visually verified both refactored views in dev mode — Save changes correctly disabled until edits diverge from the persisted record

## Diff

+161 / -54 lines across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)