### PR TITLE
PR 25/N (Stage 3): reactivity pattern standardization

### DIFF
--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -23,7 +23,6 @@
 
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia';
-import { useStores } from '@directus/extensions-sdk';
 import AdvancedSettingsForm from './components/AdvancedSettings/AdvancedSettingsForm.vue';
 import Navigation from './components/Navigation.vue';
 import { useLocalazyStore } from './stores/localazy-store';
@@ -32,6 +31,7 @@ import { useLocalazyInstallerStore, LOCALAZY_COLLECTIONS } from './stores/locala
 import { useLocalazySettingsStore } from './stores/localazy-settings-store';
 import { useLocalazyConfigStore } from './stores/localazy-config-store';
 import { useSingletonForm } from './composables/use-singleton-form';
+import { useDirectusNotificationsStore } from './composables/use-directus-stores';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
@@ -43,8 +43,7 @@ const { data: localazyData } = storeToRefs(useLocalazyConfigStore());
 
 const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
 
-const { useNotificationsStore } = useStores();
-const notificationsStore = useNotificationsStore();
+const notificationsStore = useDirectusNotificationsStore();
 const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
 const { hydrating, hydrated } = storeToRefs(localazyStore);

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -22,7 +22,6 @@
 
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia';
-import { useStores } from '@directus/extensions-sdk';
 import ProjectSetupForm from './components/ProjectSetup/ProjectSetupForm.vue';
 import Navigation from './components/Navigation.vue';
 import { useLocalazyStore } from './stores/localazy-store';
@@ -31,6 +30,7 @@ import { useLocalazyInstallerStore, LOCALAZY_COLLECTIONS } from './stores/locala
 import { useLocalazySettingsStore } from './stores/localazy-settings-store';
 import { useLocalazyConfigStore } from './stores/localazy-config-store';
 import { useSingletonForm } from './composables/use-singleton-form';
+import { useDirectusNotificationsStore } from './composables/use-directus-stores';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
@@ -42,8 +42,7 @@ const { data: localazyData } = storeToRefs(useLocalazyConfigStore());
 
 const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
 
-const { useNotificationsStore } = useStores();
-const notificationsStore = useNotificationsStore();
+const notificationsStore = useDirectusNotificationsStore();
 const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
 const { hydrating, hydrated } = storeToRefs(localazyStore);

--- a/extensions/module/src/components/ProjectSetup/LoginButton.vue
+++ b/extensions/module/src/components/ProjectSetup/LoginButton.vue
@@ -12,10 +12,10 @@
 import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { GenericConnectorClient, Services, getOAuthAuthorizationUrl } from '@localazy/generic-connector-client';
-import { useStores } from '@directus/extensions-sdk';
 import { getConfig } from '../../../../common/config/get-config';
 import { useLocalazyStore } from '../../stores/localazy-store';
 import { useLocalazyConfigStore } from '../../stores/localazy-config-store';
+import { useDirectusNotificationsStore } from '../../composables/use-directus-stores';
 import { AnalyticsService } from '../../../../common/services/analytics-service';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
 
@@ -33,8 +33,7 @@ const configStore = useLocalazyConfigStore();
 const { data: localazyData } = storeToRefs(configStore);
 const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
-const { useNotificationsStore } = useStores();
-const notificationsStore = useNotificationsStore();
+const notificationsStore = useDirectusNotificationsStore();
 
 const onLoginClick = async () => {
   try {

--- a/extensions/module/src/components/ProjectSetup/LogoutButton.vue
+++ b/extensions/module/src/components/ProjectSetup/LogoutButton.vue
@@ -13,9 +13,9 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useStores } from '@directus/extensions-sdk';
 import { useLocalazyStore } from '../../stores/localazy-store';
 import { useLocalazyConfigStore } from '../../stores/localazy-config-store';
+import { useDirectusNotificationsStore } from '../../composables/use-directus-stores';
 import { AnalyticsService } from '../../../../common/services/analytics-service';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
 
@@ -28,8 +28,7 @@ const configStore = useLocalazyConfigStore();
 const { data: localazyData } = storeToRefs(configStore);
 const localazyStore = useLocalazyStore();
 const { hydrateLocalazyData } = localazyStore;
-const { useNotificationsStore } = useStores();
-const notificationsStore = useNotificationsStore();
+const notificationsStore = useDirectusNotificationsStore();
 
 const onLogout = async () => {
   try {

--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script lang="ts" setup>
-import { useItems, useStores } from '@directus/extensions-sdk';
+import { useItems } from '@directus/extensions-sdk';
 import { PropType, Ref, computed, ref, watch, watchEffect } from 'vue';
 import { AppCollection, Field, Item } from '@directus/types';
 import { storeToRefs } from 'pinia';
@@ -66,7 +66,7 @@ import { getConfig } from '../../../../common/config/get-config';
 import { DirectusLocalazyAdapter } from '../../../../common/services/directus-localazy-adapter';
 import LoginButton from './LoginButton.vue';
 import LogoutButton from './LogoutButton.vue';
-import { useDirectusCollectionsStoreRefs } from '../../composables/use-directus-stores';
+import { useDirectusCollectionsStoreRefs, useDirectusFieldsStore } from '../../composables/use-directus-stores';
 import { useLocalazyConfigStore } from '../../stores/localazy-config-store';
 
 const props = defineProps({
@@ -92,9 +92,8 @@ const localEdits = computed<Settings>({
   },
 });
 
-const { useFieldsStore } = useStores();
 const { collections } = useDirectusCollectionsStoreRefs();
-const { getFieldsForCollectionSorted } = useFieldsStore();
+const { getFieldsForCollectionSorted } = useDirectusFieldsStore();
 const languageCollectionName = computed(() => localEdits.value.language_collection);
 
 const languagesMap = computed(() => {

--- a/extensions/module/src/composables/use-collections-organizer.ts
+++ b/extensions/module/src/composables/use-collections-organizer.ts
@@ -1,14 +1,12 @@
 import { sortBy, uniqWith } from 'lodash';
 import { computed } from 'vue';
 import { AppCollection } from '@directus/types';
-import { useStores } from '@directus/extensions-sdk';
 import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
-import { useDirectusCollectionsStoreRefs } from './use-directus-stores';
+import { useDirectusCollectionsStoreRefs, useDirectusFieldsStore } from './use-directus-stores';
 
 export const useCollectionsOrganizer = () => {
-  const { useFieldsStore } = useStores();
   const { allCollections } = useDirectusCollectionsStoreRefs();
-  const { getFieldsForCollection } = useFieldsStore();
+  const { getFieldsForCollection } = useDirectusFieldsStore();
 
   const collections = computed<AppCollection[]>(() =>
     sortBy(

--- a/extensions/module/src/composables/use-directus-stores.ts
+++ b/extensions/module/src/composables/use-directus-stores.ts
@@ -1,6 +1,21 @@
 import { useStores } from '@directus/extensions-sdk';
 import { computed, type ComputedRef } from 'vue';
-import type { AppCollection, Collection, Relation } from '@directus/types';
+import type { AppCollection, Collection, Field, Relation } from '@directus/types';
+
+/**
+ * One file for every Directus Pinia store this extension consumes. SDK 17 widened
+ * `useStores()`'s return type so the inner stores no longer expose their member
+ * typings — without these wrappers, every call site needs an `as Type` cast.
+ *
+ * Rule of thumb for this codebase:
+ *   - Directus stores (anything reached via `useStores()`)  →  always use the
+ *     wrappers in this file, never the raw `useStores().useXStore()`.
+ *   - Our own Pinia stores (errors, localazy, progress-tracker, etc.)  →  consume
+ *     directly with `storeToRefs` for state refs; no wrappers needed (types are
+ *     already correct).
+ *   - Never direct-destructure state from a Pinia store — silently breaks
+ *     reactivity. State always goes through `storeToRefs`.
+ */
 
 /**
  * Shape of the Directus admin's collections Pinia store that this extension uses.
@@ -50,4 +65,26 @@ type RelationsStore = {
 export const useDirectusRelationsStore = (): RelationsStore => {
   const stores = useStores();
   return stores.useRelationsStore() as RelationsStore;
+};
+
+/** Subset of Directus' fields Pinia store that this extension depends on. */
+type FieldsStore = {
+  getFieldsForCollection: (collection: string) => Field[];
+  getFieldsForCollectionSorted: (collection: string) => Field[];
+  hydrate: () => Promise<void>;
+};
+
+export const useDirectusFieldsStore = (): FieldsStore => {
+  const stores = useStores();
+  return stores.useFieldsStore() as FieldsStore;
+};
+
+/** Subset of Directus' notifications Pinia store that this extension depends on. */
+type NotificationsStore = {
+  add: (notification: { title: string; type?: 'info' | 'success' | 'warning' | 'error' }) => void;
+};
+
+export const useDirectusNotificationsStore = (): NotificationsStore => {
+  const stores = useStores();
+  return stores.useNotificationsStore() as NotificationsStore;
 };

--- a/extensions/module/src/composables/use-get-fields-for-translation-relation.ts
+++ b/extensions/module/src/composables/use-get-fields-for-translation-relation.ts
@@ -1,12 +1,11 @@
 import { Field, Relation } from '@directus/types';
-import { useStores } from '@directus/extensions-sdk';
 import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
+import { useDirectusCollectionsStore, useDirectusFieldsStore, useDirectusRelationsStore } from './use-directus-stores';
 
 export const useGetFieldsForTranslationRelation = () => {
-  const { useFieldsStore, useRelationsStore, useCollectionsStore } = useStores();
-  const { getFieldsForCollection } = useFieldsStore();
-  const { getRelationsForField } = useRelationsStore();
-  const { getCollection } = useCollectionsStore();
+  const { getFieldsForCollection } = useDirectusFieldsStore();
+  const { getRelationsForField } = useDirectusRelationsStore();
+  const { getCollection } = useDirectusCollectionsStore();
 
   const getTranslatableFields = (collection: string) => {
     const fields: Field[] = getFieldsForCollection(collection);

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -1,7 +1,6 @@
 import { isEqual, merge } from 'lodash';
 import { Ref, computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useStores } from '@directus/extensions-sdk';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 import { EnabledFieldsService } from '../../../common/utilities/enabled-fields-service';
 import { useExportToLocalazy } from './use-export-to-localazy';
@@ -19,6 +18,7 @@ import { useTranslationStringsContent } from './use-translation-strings-content'
 import { EnabledField } from '../../../common/models/collections-data/content-transfer-setup';
 import { AnalyticsService } from '../../../common/services/analytics-service';
 import { ExportToLocalazyCommonService } from '../../../common/services/export-to-localazy-common-service';
+import { useDirectusNotificationsStore } from './use-directus-stores';
 
 type UseSyncContainerActions = {
   enabledFields: Ref<EnabledField[]>;
@@ -34,8 +34,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   const { translatableCollections } = useCollectionsOrganizer();
   const { upsertFromLocalazyContent } = useDirectusLocalazyAdapter();
 
-  const { useNotificationsStore } = useStores();
-  const notificationsStore = useNotificationsStore();
+  const notificationsStore = useDirectusNotificationsStore();
 
   const { addProgressMessage, resetProgressTracker } = useProgressTrackerStore();
   const localazyStore = useLocalazyStore();

--- a/extensions/module/src/composables/use-translatable-collections.ts
+++ b/extensions/module/src/composables/use-translatable-collections.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { useApi, useStores } from '@directus/extensions-sdk';
+import { useApi } from '@directus/extensions-sdk';
 import {
   TranslatableCollectionsService,
   TranslatableCollectionsServiceOptions,
@@ -9,23 +9,24 @@ import { TranslatableContent } from '../../../common/models/translatable-content
 import { DirectusDataModel } from '../../../common/interfaces/directus-data-model';
 import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
 import { DirectusModuleApi } from '../services/directus-module-api';
-import { useDirectusCollectionsStore } from './use-directus-stores';
+import { useDirectusCollectionsStore, useDirectusFieldsStore, useDirectusRelationsStore } from './use-directus-stores';
 
 export const useTranslatableCollections = () => {
   const loading = ref(false);
-  const { useFieldsStore, useRelationsStore } = useStores();
-  const fieldsStore = useFieldsStore();
-  const relationsStore = useRelationsStore();
+  const fieldsStore = useDirectusFieldsStore();
+  const relationsStore = useDirectusRelationsStore();
   const directusApi = new DirectusModuleApi(useApi(), useDirectusCollectionsStore());
 
   // The TranslatableCollectionsService expects a small adapter (DirectusDataModel) so the
   // common-side code doesn't depend on the SDK's store types directly. Inline it here —
   // there's exactly one construction site, so the previous separate composable was
-  // indirection without payoff.
+  // indirection without payoff. The interface returns Promises because the hook
+  // implementation is genuinely async (DB calls); we resolve synchronously here.
   const translatableCollectionsContent: DirectusDataModel = {
-    getFieldsForCollection: (collection) => fieldsStore.getFieldsForCollection(collection),
+    getFieldsForCollection: async (collection) => fieldsStore.getFieldsForCollection(collection),
     getRelationsForField: (collection, field) => relationsStore.getRelationsForField(collection, field),
-    getTranslationTypeFields: (collection) => fieldsStore.getFieldsForCollection(collection).filter(FieldsUtilsService.isTranslationField),
+    getTranslationTypeFields: async (collection) =>
+      fieldsStore.getFieldsForCollection(collection).filter(FieldsUtilsService.isTranslationField),
   };
 
   const translatableCollectionsService = new TranslatableCollectionsService({

--- a/extensions/module/src/stores/localazy-installer-store.ts
+++ b/extensions/module/src/stores/localazy-installer-store.ts
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import { useApi, useStores } from '@directus/extensions-sdk';
+import { useApi } from '@directus/extensions-sdk';
 import type { DeepPartial, Field } from '@directus/types';
 import { sleep } from '../../../common/utilities/sleep';
 import { getConfig } from '../../../common/config/get-config';
 import { useErrorsStore } from './errors-store';
-import { useDirectusCollectionsStore } from '../composables/use-directus-stores';
+import { useDirectusCollectionsStore, useDirectusFieldsStore } from '../composables/use-directus-stores';
 import { defaultConfiguration } from '../data/default-configuration';
 import { createSettingsFields } from '../data/fields/settings/create';
 import { createContentTransferSetupsFields } from '../data/fields/content-transfer-setup/create';
@@ -51,8 +51,7 @@ export const useLocalazyInstallerStore = defineStore('localazyInstaller', () => 
   const api = useApi();
   const { addDirectusError } = useErrorsStore();
   const collectionsStore = useDirectusCollectionsStore();
-  const { useFieldsStore } = useStores();
-  const fieldsStore = useFieldsStore();
+  const fieldsStore = useDirectusFieldsStore();
 
   const installing = ref(false);
   const installed = ref(false);


### PR DESCRIPTION
## Summary

Final Stage 3 PR. Applies the rule from Q8 of the grill:

- **Directus stores** (anything reached via `useStores()`) → always through typed wrappers in `use-directus-stores.ts`
- **Our own Pinia stores** → `storeToRefs` for state refs, direct destructure for actions
- **Never direct-destructure state** from a Pinia store (silently breaks reactivity)

## Two new typed wrappers

- `useDirectusFieldsStore` — 5 call sites used the raw form
- `useDirectusNotificationsStore` — 5 call sites used the raw form

## Sites migrated

- **Notifications (5)**: AdvancedSettings.vue, ProjectSetup.vue, use-sync-container-actions.ts, LoginButton.vue, LogoutButton.vue
- **Fields (5)**: use-collections-organizer.ts, use-translatable-collections.ts, use-get-fields-for-translation-relation.ts, ProjectSetupForm.vue, localazy-installer-store.ts
- Stray `useCollectionsStore` raw access in `use-get-fields-for-translation-relation.ts` → `useDirectusCollectionsStore`
- Stray `useRelationsStore` raw access in `use-translatable-collections.ts` → `useDirectusRelationsStore`

After this PR, `useStores` is imported from the SDK in **exactly one file** — `use-directus-stores.ts` — and never anywhere else in the module. Every Directus store access is type-safe at the call site.

## One typecheck fix bundled in

Now that `useDirectusFieldsStore` types `getFieldsForCollection` as sync `Field[]` (matching runtime), the `DirectusDataModel` adapter inlined in PR 24 needed `async` qualifiers to satisfy the interface's `Promise<Field[]>`. The hook-side implementation is genuinely async (real DB calls), so the interface stays — the module-side just wraps synchronously.

## Verification

- `npm run check` clean (lint + format + typecheck + 92 tests)
- Production build green

## Diff

+69 / -41 across 11 files.

## Stage 3 complete

This closes out Stage 3. The seven PRs (20–25 plus this) restructured the module from a 442-line `useHydrate` plus prop-drilling and raw store access into:
- A Pinia-based installer + factory + 3 singleton stores
- A reusable form composable
- A symmetric `DirectusModuleApi` service class
- A typed store-access surface

Net Stage 3: roughly +850 / −1100 lines (depending on how you count) across all 6 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)