### PR TITLE
PR 27/N (Stage 3++): final review cleanup

### DIFF
--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -55,7 +55,7 @@
       </div>
 
       <progress-tracker-modal
-        :show-progress="showProgress"
+        v-model:show-progress="showProgress"
         :loading="loading"
         :progress-tracker="progressTracker"
         @finish="onFinishAction"

--- a/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
+++ b/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
@@ -46,22 +46,13 @@ import { ref, watch } from 'vue';
 import { LanguageMappings } from '../../../../common/models/language-mapping';
 import { LanguageMappingService } from '../../../../common/services/language-mapping-service';
 
-const props = defineProps({
-  modelValue: {
-    type: String,
-    default: '[]',
-  },
-});
-
-const emit = defineEmits<{
-  (e: 'update:modelValue', value: string): void;
-}>();
+const modelValue = defineModel<string>({ default: '[]' });
 
 const parsedMappings = ref<LanguageMappings>([]);
 const validationErrors = ref<string[]>([]);
 
 watch(
-  () => props.modelValue,
+  modelValue,
   (value) => {
     try {
       parsedMappings.value = JSON.parse(value || '[]') as LanguageMappings;
@@ -76,7 +67,7 @@ function emitChange() {
   const json = JSON.stringify(parsedMappings.value);
   const validation = LanguageMappingService.validateMappings(json);
   validationErrors.value = validation.errors;
-  emit('update:modelValue', json);
+  modelValue.value = json;
 }
 
 function addMapping() {

--- a/extensions/module/src/components/Modals/ProgressTrackerModal.vue
+++ b/extensions/module/src/components/Modals/ProgressTrackerModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog :model-value="showProgress">
+  <v-dialog v-model="showProgress">
     <v-card>
       <v-card-title>Progress Status</v-card-title>
       <v-card-text>
@@ -24,11 +24,9 @@
 import { PropType } from 'vue';
 import { ProgressTracker } from '../../models/progress-tracker';
 
+const showProgress = defineModel<boolean>('showProgress', { required: true });
+
 defineProps({
-  showProgress: {
-    type: Boolean,
-    required: true,
-  },
   progressTracker: {
     type: Array as PropType<ProgressTracker>,
     required: true,
@@ -39,7 +37,7 @@ defineProps({
   },
 });
 
-defineEmits(['update:showProgress', 'finish']);
+defineEmits(['finish']);
 </script>
 
 <style scoped lang="scss"></style>

--- a/extensions/module/src/components/Navigation.vue
+++ b/extensions/module/src/components/Navigation.vue
@@ -40,11 +40,9 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
 import packageJson from '../../package.json';
 
-const version = ref<string>(packageJson.version);
-const versionLabel = ref<string>(`Version ${version.value}`);
+const versionLabel = `Version ${packageJson.version}`;
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -11,7 +11,7 @@
       </div>
       <div class="ml-2">
         <v-icon
-          v-if="!data.directus.recoznigedInLocalazy"
+          v-if="!data.directus.recognizedInLocalazy"
           name="error"
           color="var(--danger)"
           title="Localazy does not recognize this language"
@@ -25,7 +25,7 @@
         />
         <v-icon v-else name="clear" color="var(--danger)" title="This language has not been added in your Localazy project" />
 
-        <span v-if="!data.directus.recoznigedInLocalazy"> Unknown Localazy language </span>
+        <span v-if="!data.directus.recognizedInLocalazy"> Unknown Localazy language </span>
         <span v-else-if="data.localazy.hidden"> Disabled </span>
         <span v-else-if="data.localazy.presentMapped && !data.localazy.present">
           Mapped to {{ data.localazy.mappedTo }}
@@ -74,7 +74,7 @@ type Row = {
     present: boolean;
     presentMapped: boolean;
     mappedTo: string;
-    recoznigedInLocalazy: boolean;
+    recognizedInLocalazy: boolean;
   };
 };
 
@@ -106,7 +106,6 @@ watch(
 const languageRows = computed((): Row[] => {
   const localazyLanguages = localazyProject.value?.languages || [];
   const localazyLocales = localazyLanguages.map((l) => l.code);
-  // const allLanguages = uniq([...directusLanguages.value, ...localazyLocales]);
 
   const allLanguages = [...directusLanguages.value, ...localazyLocales].map((locale) => {
     const directusFormLocale = DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(locale);
@@ -128,7 +127,7 @@ const languageRows = computed((): Row[] => {
         present: directusLanguages.value.includes(locale),
         presentMapped: directusLanguages.value.includes(directusFormLocale),
         mappedTo: directusFormLocale,
-        recoznigedInLocalazy: !!localazyLanguage,
+        recognizedInLocalazy: !!localazyLanguage,
       },
     } as Row;
   });

--- a/extensions/module/src/components/Overview/ConnectionOverview.vue
+++ b/extensions/module/src/components/Overview/ConnectionOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="connection-overiew">
+  <div class="connection-overview">
     <div class="flex items-center justify-between w-full">
       <div class="flex flex-col">
         <span class="font-medium">Localazy connection</span>
@@ -114,7 +114,7 @@ async function onReconnect() {
 <style lang="scss" scoped>
 @import '../../styles/mixins/common';
 
-.connection-overiew {
+.connection-overview {
   @include common;
 }
 

--- a/extensions/module/src/components/Sync/TranslationStringsContent.vue
+++ b/extensions/module/src/components/Sync/TranslationStringsContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-checkbox class="collection-item collection-item-clickable" :model-value="!!shouldSynchronize" @update:model-value="onToggle">
+    <v-checkbox v-model="shouldSynchronize" class="collection-item collection-item-clickable">
       <span>
         <v-icon color="var(--primary)" class="collection-icon" name="translate" />
         <span class="collection-name"
@@ -21,18 +21,9 @@
 </template>
 
 <script lang="ts" setup>
-const props = defineProps({
-  shouldSynchronize: {
-    type: Boolean,
-    required: true,
-  },
-});
-
-const emits = defineEmits(['update:shouldSynchronize']);
-
-function onToggle() {
-  emits('update:shouldSynchronize', props.shouldSynchronize);
-}
+// Previously this component had a hand-rolled v-model that re-emitted the OLD prop
+// value, so the toggle silently no-op'd. defineModel binds correctly to v-checkbox.
+const shouldSynchronize = defineModel<boolean>('shouldSynchronize', { required: true });
 </script>
 
 <style lang="scss" scoped>
@@ -44,35 +35,6 @@ function onToggle() {
   font-weight: 500;
   margin-top: 8px !important;
   margin-bottom: 8px !important;
-}
-
-.collection-item-unclickable {
-  font-weight: 400;
-  margin-bottom: 0px !important;
-}
-
-.field-item {
-  margin-left: 28px;
-  margin-bottom: 8px !important;
-}
-
-.collection-group {
-  display: block;
-}
-
-.collection-group-chevron {
-  margin-right: 0 !important;
-  color: var(--foreground-subdued);
-  transform: rotate(0deg);
-  transition: transform var(--medium) var(--transition);
-
-  &:hover {
-    color: var(--foreground-normal);
-  }
-
-  &.active {
-    transform: rotate(90deg);
-  }
 }
 
 .open-in-new {

--- a/extensions/module/src/composables/use-import-from-localazy.ts
+++ b/extensions/module/src/composables/use-import-from-localazy.ts
@@ -1,4 +1,3 @@
-import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
@@ -28,8 +27,6 @@ type ImportContentFromLocalazyErrorReturn = {
 type ImportContentFromLocalazyReturn = ImportContentFromLocalazySuccessReturn | ImportContentFromLocalazyErrorReturn;
 
 export const useImportFromLocalazy = () => {
-  const loading = ref(false);
-
   const { addProgressMessage } = useProgressTrackerStore();
   const { addLocalazyError } = useErrorsStore();
   const { localazyProject } = storeToRefs(useLocalazyStore());
@@ -68,7 +65,6 @@ export const useImportFromLocalazy = () => {
   };
 
   return {
-    loading,
     importContentFromLocalazy,
   };
 };

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -47,6 +47,9 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   const transferSetupStore = useLocalazyTransferSetupStore();
   const { data: transferSetup } = storeToRefs(transferSetupStore);
 
+  const accessToken = computed(() => localazyData.value.access_token);
+  const exportService = useExportToLocalazy(accessToken);
+
   const loading = ref(false);
   const showProgress = ref(false);
 
@@ -76,7 +79,6 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       id: ProgressTrackerId.PREPARING_EXPORT,
       message: 'Preparing Directus data for export',
     });
-    const token = computed(() => localazyData.value.access_token);
     // Save settings is fire-and-forget; errors surface via the errors store inside onSaveSettings.
     void onSaveSettings();
     try {
@@ -95,7 +97,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
         }),
       ]);
 
-      await useExportToLocalazy(token).exportContentToLocalazy({
+      await exportService.exportContentToLocalazy({
         content: merge(collectionsContent, translationStrings),
         settings: settings.value,
       });

--- a/extensions/module/src/services/import-from-localazy-service.ts
+++ b/extensions/module/src/services/import-from-localazy-service.ts
@@ -1,7 +1,6 @@
 import { uniqWith } from 'lodash';
 import { Locales, Project } from '@localazy/api-client';
 import { LocalazyApiThrottleService } from '../../../common/services/localazy-api-throttle-service';
-// import { trackLocalazyError } from '../functions/track-error';
 import { DirectusLocalazyLanguage } from '../../../common/models/directus-localazy-language';
 import { ContentFromLocalazyService } from './content-from-localazy-service';
 import { EnabledField } from '../../../common/models/collections-data/content-transfer-setup';
@@ -78,18 +77,12 @@ class ImportFromLocalazyService {
     if (!token) {
       return null;
     }
-
-    if (token) {
-      try {
-        const files = await LocalazyApiThrottleService.listFiles(token, {
-          project: projectId,
-        });
-        return files.find((file) => file.name === 'directus.json') || null;
-      } catch (_e: unknown) {
-        // trackLocalazyError(_e, 'loadFile');
-        return null;
-      }
-    } else {
+    try {
+      const files = await LocalazyApiThrottleService.listFiles(token, {
+        project: projectId,
+      });
+      return files.find((file) => file.name === 'directus.json') || null;
+    } catch {
       return null;
     }
   }

--- a/extensions/module/src/stores/progress-tracker-store.ts
+++ b/extensions/module/src/stores/progress-tracker-store.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { ProgressTracker, ProgressTrackerMessage } from '../models/progress-tracker';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 
-export const useProgressTrackerStore = defineStore('progress-tracker-store', () => {
+export const useProgressTrackerStore = defineStore('progressTrackerStore', () => {
   const progressTracker = ref<ProgressTracker>([]);
 
   function addProgressMessage(message: ProgressTrackerMessage) {


### PR DESCRIPTION
## Summary

Findings from one more pass through every page, component, and composable. Real bug + 6 cleanup items.

## Real bug

**`TranslationStringsContent.vue` toggle was broken.** The hand-rolled v-model was:
```ts
function onToggle() {
  emits('update:shouldSynchronize', props.shouldSynchronize);
}
```
The handler ignored the new value v-checkbox passed and re-emitted the *current* prop, so the parent's `synchronizeTranslationStrings` ref never flipped. Verified the bug existed in dev mode (initial state `checked: true`, no toggle on click) and the fix works (toggles cleanly true/false). Replaced with `defineModel`.

## Typos

- `ConnectionOverview.vue`: CSS class `connection-overiew` → `connection-overview` (2 usages, self-consistent typo)
- `ConnectionLanguages.vue`: field `recoznigedInLocalazy` → `recognizedInLocalazy` (type + template + computed, 4 occurrences)

## `defineModel` stragglers (PR 26 caught some, missed these)

- `LanguageMappingsEditor.vue` — was still using manual `modelValue` + emit
- `ProgressTrackerModal.vue` — `defineModel` for `showProgress`, drop never-emitted `update:showProgress` from `defineEmits`. Sync.vue updated from `:show-progress` to `v-model:show-progress`

## Dead code removed

- `ConnectionLanguages.vue` — commented-out `// const allLanguages = uniq(...)`
- `import-from-localazy-service.ts` — commented-out `// import { trackLocalazyError }` + dead else-branch in `loadFile`
- `TranslationStringsContent.vue` — ~30 lines of SCSS for classes that don't exist in template (copy-paste from CollectionItem.vue)
- `use-import-from-localazy.ts` — `loading` ref declared, returned, never used

## Other

- `Navigation.vue` — `version` and `versionLabel` were `ref()` but `packageJson.version` is a build-time constant. Plain consts.
- Pinia store ID consistency — `progress-tracker-store` was kebab-case while every other Pinia store used camelCase. Renamed to `'progressTrackerStore'`. Devtools-label only.
- `useExportToLocalazy(token)` hoisted out of `onExport` — was constructed inside the event handler each call.

## Verification

- `npm run check` clean (lint + format + typecheck + 92 tests)
- Production build green
- Toggle bug fix verified programmatically in dev mode: clicks alternate `checked` true ↔ false

## Diff

+30 / -91 across 11 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)