### PR TITLE
PR 28/N: split CONTRIBUTING.md out of README; fix module README typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thanks for your interest in contributing to the Localazy Directus extension.
+
+## Project layout
+
+This is an npm-workspaces monorepo with three packages under `extensions/`:
+
+| Path                    | Published as                                       | Purpose                                                                                                                                        |
+| ----------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extensions/module/`    | `@localazy/directus-extension-localazy`            | UI module (Vue 3 + Pinia). The Localazy admin pages — Overview, Import & Export, Project Setup, Additional Settings, About.                    |
+| `extensions/sync-hook/` | `@localazy/directus-extension-localazy-automation` | Server-side hook (plain TypeScript). Automates content upload on Directus item / translation / settings changes.                               |
+| `extensions/common/`    | (internal)                                         | Shared TypeScript code — services, models, types — consumed by both extensions. Not published; Rollup inlines it into each extension's bundle. |
+
+## Prerequisites
+
+- Node 22 (see `.nvmrc`). With nvm: `nvm use`.
+- No Docker required — the dev loop uses a local Directus instance against SQLite.
+
+## Install
+
+```bash
+npm install
+```
+
+Workspaces handle the sub-packages — one install at the root.
+
+## Local development
+
+```bash
+npm run dev
+```
+
+This will:
+
+- Build both extensions once.
+- Start a local Directus instance backed by a SQLite database under `development/data/`.
+- Watch-rebuild both extensions on change; Directus auto-reloads when the bundles update, so saved edits appear in the admin without a manual restart.
+
+Open the admin UI at **http://localhost:8055/admin** and sign in:
+
+| Field    | Value               |
+| -------- | ------------------- |
+| Email    | `admin@example.com` |
+| Password | `d1r3ctu5`          |
+
+These credentials are local-only — they're seeded by `scripts/dev.mjs` and live in the gitignored `development/data/data.db`.
+
+### Reset the local state
+
+To wipe the SQLite database, uploads, and the symlinked extensions layout, delete the data directory. The next `npm run dev` re-bootstraps from scratch:
+
+```bash
+rm -rf development/data development/uploads development/extensions
+```
+
+## Scripts
+
+### Verification
+
+| Command                 | What it does                                                                       |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| `npm run check`         | Aggregate: `lint && format && typecheck && test`. The one command that mirrors CI. |
+| `npm run check:fix`     | Aggregate fix: `lint:fix && format:fix`.                                           |
+| `npm run lint`          | ESLint across the monorepo.                                                        |
+| `npm run lint:fix`      | Same, with autofix.                                                                |
+| `npm run format`        | Prettier check. Fails if anything isn't formatted.                                 |
+| `npm run format:fix`    | Prettier write.                                                                    |
+| `npm run typecheck`     | `vue-tsc --noEmit` — typechecks `.ts` and `.vue` files.                            |
+| `npm run test`          | Vitest run (one-shot).                                                             |
+| `npm run test:watch`    | Vitest in watch mode.                                                              |
+| `npm run test:coverage` | Vitest with v8 coverage (text + HTML at `coverage/` + lcov).                       |
+| `npm run knip`          | Detect unused files, dependencies, and exports. Local only — not gated in CI.      |
+
+### Building
+
+| Command                     | What it does                                                            |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `npm run build`             | Production build of both extensions (minified). What release publishes. |
+| `npm run build:development` | Non-minified build (faster, used by `dev`).                             |
+
+## Continuous integration
+
+`.github/workflows/qa.yml` runs on every PR:
+
+1. `npm run check` — lint, format, typecheck, tests
+2. Production build of both extensions
+
+If `npm run check` passes locally, CI should pass too.
+
+## Useful references
+
+- [Directus Components Playground](https://components.directus.io/) — the UI library both extensions can use.
+- [Directus content translation guide](https://docs.directus.io/guides/headless-cms/content-translations.html) — required reading if you're working on the sync flow.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,21 @@
 # Localazy Directus Extension Monorepo
 
-This is a monorepo consisting of following Localazy extensions for [Directus](https://directus.io/)
+Localazy extensions for [Directus](https://directus.io/):
 
-1. Module - adds Localazy menu item and enables manual synchronization of content with Localazy
-2. Sync-hook - extends the core functionality by automating content upload from Directus to Localazy
+1. **Module** — adds a Localazy menu item and enables manual synchronization of content with Localazy.
+2. **Sync-hook** — extends the core functionality by automating content upload from Directus to Localazy.
 
-Please refer to [Localazy Directus Extension](extensions/module/README.md) and [Localazy Directus Extension Automation](extensions/sync-hook/README.md) for more information about each extension.
+Refer to [Localazy Directus Extension](extensions/module/README.md) and [Localazy Directus Extension Automation](extensions/sync-hook/README.md) for details on each one.
 
 ## Contributing
 
-### Prerequisites
-
-- Node 22 (see `.nvmrc`). With nvm: `nvm use`.
-- No Docker required — the dev loop uses a local Directus instance against SQLite.
-
-### Local development
-
-1. Install dependencies once at the repo root (workspaces handle the sub-packages):
-   ```bash
-   npm install
-   ```
-2. Start the dev loop:
-   ```bash
-   npm run dev
-   ```
-   This will:
-   - Build both extensions once.
-   - Start a local Directus instance backed by a SQLite database under `development/data/`.
-   - Watch-rebuild both extensions on change; Directus auto-reloads when the bundles update, so saved edits appear in the admin without a manual restart.
-3. Open the admin UI at **http://localhost:8055/admin** and sign in:
-
-   | Field    | Value               |
-   | -------- | ------------------- |
-   | Email    | `admin@example.com` |
-   | Password | `d1r3ctu5`          |
-
-   These credentials are local-only — they're seeded by `scripts/dev.mjs` and live in the gitignored `development/data/data.db`.
-
-### Reset the local Directus state
-
-Delete the data directory to wipe the SQLite database, uploads, and the symlinked extensions layout. Next `npm run dev` re-bootstraps from scratch:
-
-```bash
-rm -rf development/data development/uploads development/extensions
-```
-
-### Useful scripts
-
-- `npm run build` — production-style build of both extensions (mode = production, minified).
-- `npm run build:development` — non-minified build (what `dev` runs internally).
-- `npm run lint` — lint both extensions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development workflow, scripts, and CI.
 
 ## 📚 Documentation
 
 - [Localazy Directus Plugin](https://localazy.com/docs/directus/directus-plugin-introduction-installation)
 - [Getting Started With Localazy](https://localazy.com/docs/general/getting-started-with-localazy)
 - [Changelog](CHANGELOG.md)
-
-### Useful links
-
-- [Directus Components Overview](https://components.directus.io/)
-- [Directus Content Translation Guide](https://docs.directus.io/guides/headless-cms/content-translations.html)
 
 ## 🛟 Support
 

--- a/extensions/module/README.md
+++ b/extensions/module/README.md
@@ -10,7 +10,7 @@
   <br>
 </p>
 
-# 📦
+# 📦 Directus Extension Localazy
 
 > Turn translation of your Directus project into a seamless experience.
 


### PR DESCRIPTION
## Summary

Findings from the README review pass. Three moves.

## `CONTRIBUTING.md` (new)

GitHub auto-shows `CONTRIBUTING.md` on PR/issue creation pages — the idiomatic place for contributor onboarding. Moves setup, prerequisites, dev loop, reset, scripts, and CI expectations out of the root README into a dedicated file. Adds what the previous README was missing:

- **Project layout** — explains the three-workspace monorepo (`module` / `sync-hook` / `common`), what each one is, and why `common` isn't published.
- **Full scripts table** — the previous README listed only `lint`, leaving the whole testing workflow invisible. Now includes:
  - `check` / `check:fix` (the aggregate that mirrors CI)
  - `typecheck`
  - `format` / `format:fix`
  - `test` / `test:watch` / `test:coverage`
  - `knip` (dead-code detection)
- **CI expectations** — `qa.yml` runs `check` + production build on every PR.

## Root `README.md` (slim)

Cut from 84 to ~38 lines. Now scoped to "what is this monorepo" + ecosystem links, with a pointer to `CONTRIBUTING.md` for the contributor stuff. Doesn't repeat content that lives in either extension's own README.

## Module README typo

Line 13 was `# 📦` with no title — an empty H1. The sync-hook README got this right (`# 📦 Directus Extension Localazy Automation`). Fixed to `# 📦 Directus Extension Localazy`.

## Diff

+100 / -51 across 3 files (one new file: `CONTRIBUTING.md`).

## Verification

`npm run check` clean (92 tests).

## Deliberately out of scope

Per discussion during review: PR/branching conventions, pre-commit hook explanation, and a pointer to `CLAUDE.md` were considered but excluded — kept the contributor doc focused on getting set up and running, not the meta-workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)