### PR TITLE
PR 29/N: dev environment cleanup (sass, log levels, schema defaults, seed)

### DIFF
--- a/extensions/module/src/About.vue
+++ b/extensions/module/src/About.vue
@@ -90,7 +90,7 @@ import Navigation from './components/Navigation.vue';
 </script>
 
 <style lang="scss" scoped>
-@import './styles/mixins/page';
+@use './styles/mixins/page' as *;
 
 .page {
   @include page;

--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -52,7 +52,7 @@ async function onSaveChanges() {
 </script>
 
 <style lang="scss" scoped>
-@import './styles/mixins/page';
+@use './styles/mixins/page' as *;
 
 .page {
   @include page;

--- a/extensions/module/src/Overview.vue
+++ b/extensions/module/src/Overview.vue
@@ -44,7 +44,7 @@ onBeforeMount(() => {
 </script>
 
 <style lang="scss" scoped>
-@import './styles/mixins/page';
+@use './styles/mixins/page' as *;
 
 .page {
   @include page;

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -51,7 +51,7 @@ async function onSaveChanges() {
 </script>
 
 <style lang="scss" scoped>
-@import './styles/mixins/page';
+@use './styles/mixins/page' as *;
 
 .page {
   @include page;

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -151,7 +151,7 @@ function deselectAll() {
 </script>
 
 <style lang="scss" scoped>
-@import './styles/mixins/page';
+@use './styles/mixins/page' as *;
 .page {
   @include page;
 }

--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -163,7 +163,7 @@ const automatedDeprecationOptions = ref<Item[]>([
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/mixins/form-grid';
+@use '../../styles/mixins/form-grid' as *;
 .form {
   @include form-grid;
   max-width: 1300px;

--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -155,7 +155,7 @@ const languageRows = computed((): Row[] => {
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/mixins/common';
+@use '../../styles/mixins/common' as *;
 
 .languages-table {
   @include common;

--- a/extensions/module/src/components/Overview/ConnectionOverview.vue
+++ b/extensions/module/src/components/Overview/ConnectionOverview.vue
@@ -112,7 +112,7 @@ async function onReconnect() {
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/mixins/common';
+@use '../../styles/mixins/common' as *;
 
 .connection-overview {
   @include common;

--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -194,7 +194,7 @@ watch(
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/mixins/form-grid';
+@use '../../styles/mixins/form-grid' as *;
 .form {
   @include form-grid;
   max-width: 1300px;

--- a/extensions/module/src/data/default-configuration.test.ts
+++ b/extensions/module/src/data/default-configuration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import type { Field, DeepPartial } from '@directus/types';
+import { defaultConfiguration } from './default-configuration';
+import { createSettingsFields } from './fields/settings/create';
+import { createContentTransferSetupsFields } from './fields/content-transfer-setup/create';
+import { createLocalazyDataFields } from './fields/localazy-data/create';
+
+/**
+ * Guard test for the installer's heal path.
+ *
+ * On a fresh install the installer creates the collection and PATCHes `defaultConfiguration()`
+ * into the singleton row. On an upgrade — when a new field is added to one of the `create*Fields()`
+ * arrays — the installer takes the heal path and only POSTs `/fields/{collection}` with the field
+ * declaration; it does NOT re-PATCH `defaultConfiguration()` onto the existing row. The existing
+ * row's new column is populated from `schema.default_value` (or NULL if absent).
+ *
+ * To make the create and heal paths converge, every non-primary-key field in `create*Fields()`
+ * must declare a `schema.default_value`, and that value must match the corresponding key in
+ * `defaultConfiguration()`. This test enforces both invariants for all three collections, so
+ * adding a new field without its config-side counterpart (or with a divergent default) fails CI.
+ */
+
+type Section = keyof ReturnType<typeof defaultConfiguration>;
+
+const SECTIONS: Array<{ section: Section; fields: () => Array<DeepPartial<Field>> }> = [
+  { section: 'settings', fields: createSettingsFields },
+  { section: 'content_transfer_setup', fields: createContentTransferSetupsFields },
+  { section: 'localazy_data', fields: createLocalazyDataFields },
+];
+
+describe('defaultConfiguration <-> field declarations', () => {
+  for (const { section, fields } of SECTIONS) {
+    describe(section, () => {
+      const fieldDeclarations = fields();
+      const config = defaultConfiguration()[section] as Record<string, unknown>;
+      const nonPkFields = fieldDeclarations.filter((f) => !f.schema?.is_primary_key);
+
+      it('every non-primary-key field declares schema.default_value', () => {
+        const missing = nonPkFields.filter((f) => !f.schema || !('default_value' in f.schema)).map((f) => f.field);
+        expect(missing, `fields missing schema.default_value: ${missing.join(', ')}`).toEqual([]);
+      });
+
+      it('every field has a matching key in defaultConfiguration with the same value', () => {
+        for (const f of nonPkFields) {
+          expect(config, `defaultConfiguration().${section} is missing key "${f.field}"`).toHaveProperty(f.field as string);
+          expect(
+            f.schema?.default_value,
+            `schema.default_value for "${f.field}" does not match defaultConfiguration().${section}.${f.field}`,
+          ).toEqual(config[f.field as string]);
+        }
+      });
+
+      it('defaultConfiguration has no keys without a corresponding field declaration', () => {
+        const declaredNames = new Set(nonPkFields.map((f) => f.field as string));
+        const orphans = Object.keys(config).filter((key) => !declaredNames.has(key));
+        expect(orphans, `defaultConfiguration().${section} keys with no field declaration: ${orphans.join(', ')}`).toEqual([]);
+      });
+    });
+  }
+});

--- a/extensions/module/src/data/fields/localazy-data/create.ts
+++ b/extensions/module/src/data/fields/localazy-data/create.ts
@@ -23,6 +23,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'user_id',
@@ -31,6 +34,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       interface: 'input',
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
     },
   },
   {
@@ -41,6 +47,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'project_id',
@@ -49,6 +58,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       interface: 'input',
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
     },
   },
   {
@@ -59,6 +71,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'project_name',
@@ -68,6 +83,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'org_id',
@@ -76,6 +94,9 @@ export const createLocalazyDataFields = (): Array<DeepPartial<Field>> => [
       interface: 'input',
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
     },
   },
 ];

--- a/extensions/module/src/data/fields/settings/create.ts
+++ b/extensions/module/src/data/fields/settings/create.ts
@@ -24,6 +24,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'language_code_field',
@@ -32,6 +35,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       interface: 'input',
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
     },
   },
   {
@@ -42,6 +48,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: '',
+    },
   },
   {
     field: 'localazy_oauth_response',
@@ -50,6 +59,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       interface: 'input-multiline',
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
     },
   },
   {
@@ -61,6 +73,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
     },
+    schema: {
+      default_value: true,
+    },
   },
   {
     field: 'automated_deprecation',
@@ -70,6 +85,9 @@ export const createSettingsFields = (): Array<DeepPartial<Field>> => [
       special: ['cast-boolean'],
       readonly: getConfig().APP_MODE === 'production',
       hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: true,
     },
   },
   {

--- a/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/collection-content-synchronization-service.ts
@@ -40,7 +40,7 @@ class CollectionContentSynchronizationService extends BaseContentSynchronization
   async exportCollectionContent(data: ExportCollectionContent) {
     const { schema, ItemsService, logger, collection } = data;
     if (this.missingLocalazyCollections(schema)) {
-      logger.error('Localazy: Incomplete configuration');
+      logger.debug('Localazy: not configured yet — skipping collection export');
       return;
     }
     try {

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
@@ -49,7 +49,7 @@ describe('translationStringsSynchronizationService.exportTranslationString', () 
     vi.restoreAllMocks();
   });
 
-  it('logs and returns early when the Localazy collections are missing from the schema', async () => {
+  it('logs at debug and returns early when the Localazy collections are missing from the schema', async () => {
     const logger = makeLogger();
     const exportSpy = vi.spyOn(proto, 'exportToLocalazy').mockResolvedValue(undefined);
 
@@ -59,7 +59,8 @@ describe('translationStringsSynchronizationService.exportTranslationString', () 
       ItemsService: vi.fn(),
     });
 
-    expect(logger.error).toHaveBeenCalledWith('Localazy: Incomplete configuration');
+    expect(logger.debug).toHaveBeenCalledWith('Localazy: not configured yet — skipping translation strings export');
+    expect(logger.error).not.toHaveBeenCalled();
     expect(exportSpy).not.toHaveBeenCalled();
   });
 

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
@@ -33,7 +33,7 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
   async exportTranslationString(data: ExportTranslationString) {
     const { schema, ItemsService, logger } = data;
     if (this.missingLocalazyCollections(schema)) {
-      logger.error('Localazy: Incomplete configuration');
+      logger.debug('Localazy: not configured yet — skipping translation strings export');
       return;
     }
 
@@ -81,7 +81,7 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
   async deprecateDeletedTranslationStrings(options: DeprecateDeletedTranslationStrings) {
     const { itemIds, schema, ItemsService, logger } = options;
     if (this.missingLocalazyCollections(schema)) {
-      logger.error('Localazy: Incomplete configuration');
+      logger.debug('Localazy: not configured yet — skipping deletion deprecation');
       return;
     }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -51,7 +51,8 @@ const directusEnv = {
   PUBLIC_URL: 'http://localhost:8055',
 };
 
-if (!existsSync(dbFile)) {
+const freshBoot = !existsSync(dbFile);
+if (freshBoot) {
   console.log('[dev] bootstrapping Directus database');
   const bootstrap = spawnSync('npx', ['directus', 'bootstrap'], { stdio: 'inherit', cwd: root, env: directusEnv });
   if (bootstrap.status !== 0) process.exit(bootstrap.status ?? 1);
@@ -96,3 +97,38 @@ spawnLong(
 
 console.log('[dev] starting Directus at http://localhost:8055');
 spawnLong('directus', 'npx', ['directus', 'start']);
+
+if (freshBoot) {
+  waitForHealth(directusEnv.PUBLIC_URL).then((ready) => {
+    if (!ready) {
+      console.warn('[dev] Directus did not become healthy in time — skipping seed');
+      return;
+    }
+    console.log('[dev] seeding demo data');
+    const seed = spawnSync('node', ['scripts/seed-dev-data.mjs'], {
+      stdio: 'inherit',
+      cwd: root,
+      env: {
+        ...process.env,
+        DIRECTUS_URL: directusEnv.PUBLIC_URL,
+        ADMIN_EMAIL: directusEnv.ADMIN_EMAIL,
+        ADMIN_PASSWORD: directusEnv.ADMIN_PASSWORD,
+      },
+    });
+    if (seed.status !== 0) console.warn('[dev] seed script exited with code', seed.status);
+  });
+}
+
+async function waitForHealth(url, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`${url}/server/health`);
+      if (r.ok) return true;
+    } catch {
+      // server not up yet
+    }
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  return false;
+}

--- a/scripts/seed-dev-data.mjs
+++ b/scripts/seed-dev-data.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Seeds the local Directus dev database with a minimal translatable
+// `articles` collection following the Directus "Generate Translations"
+// convention (parent + `_translations` junction + `languages` collection).
+// Runs once after `directus bootstrap` against the running server.
+
+const baseUrl = process.env.DIRECTUS_URL ?? 'http://localhost:8055';
+const email = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const password = process.env.ADMIN_PASSWORD ?? 'd1r3ctu5';
+
+async function login() {
+  const r = await fetch(`${baseUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!r.ok) throw new Error(`login failed: ${r.status} ${await r.text()}`);
+  const { data } = await r.json();
+  return data.access_token;
+}
+
+async function api(token, path, method, body) {
+  const r = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!r.ok) throw new Error(`${method} ${path} → ${r.status} ${await r.text()}`);
+  return r.status === 204 ? null : r.json();
+}
+
+async function main() {
+  const token = await login();
+
+  console.log('[seed] creating languages collection');
+  await api(token, '/collections', 'POST', {
+    collection: 'languages',
+    meta: { icon: 'translate' },
+    schema: {},
+    fields: [
+      {
+        field: 'code',
+        type: 'string',
+        meta: { interface: 'input', width: 'full' },
+        schema: { is_primary_key: true, is_nullable: false, length: 16 },
+      },
+      {
+        field: 'name',
+        type: 'string',
+        meta: { interface: 'input', width: 'full' },
+        schema: {},
+      },
+      {
+        field: 'direction',
+        type: 'string',
+        meta: {
+          interface: 'select-dropdown',
+          options: {
+            choices: [
+              { text: 'Left to Right', value: 'ltr' },
+              { text: 'Right to Left', value: 'rtl' },
+            ],
+          },
+          width: 'full',
+        },
+        schema: { default_value: 'ltr' },
+      },
+    ],
+  });
+
+  await api(token, '/items/languages', 'POST', [
+    { code: 'en', name: 'English', direction: 'ltr' },
+    { code: 'de', name: 'German', direction: 'ltr' },
+    { code: 'fr', name: 'French', direction: 'ltr' },
+  ]);
+
+  console.log('[seed] creating articles collection');
+  await api(token, '/collections', 'POST', {
+    collection: 'articles',
+    meta: { icon: 'article' },
+    schema: {},
+    fields: [
+      {
+        field: 'id',
+        type: 'integer',
+        meta: { hidden: true, interface: 'input', readonly: true },
+        schema: { is_primary_key: true, has_auto_increment: true },
+      },
+      {
+        field: 'status',
+        type: 'string',
+        meta: {
+          interface: 'select-dropdown',
+          options: {
+            choices: [
+              { text: 'Published', value: 'published' },
+              { text: 'Draft', value: 'draft' },
+              { text: 'Archived', value: 'archived' },
+            ],
+          },
+          width: 'full',
+        },
+        schema: { default_value: 'draft' },
+      },
+      {
+        field: 'title',
+        type: 'string',
+        meta: { interface: 'input', width: 'full' },
+        schema: {},
+      },
+    ],
+  });
+
+  console.log('[seed] creating articles_translations collection');
+  await api(token, '/collections', 'POST', {
+    collection: 'articles_translations',
+    meta: { hidden: true, icon: 'translate' },
+    schema: {},
+    fields: [
+      {
+        field: 'id',
+        type: 'integer',
+        meta: { hidden: true, interface: 'input', readonly: true },
+        schema: { is_primary_key: true, has_auto_increment: true },
+      },
+    ],
+  });
+
+  await api(token, '/fields/articles_translations', 'POST', {
+    field: 'articles_id',
+    type: 'integer',
+    meta: { hidden: true, interface: 'input' },
+    schema: {},
+  });
+  await api(token, '/fields/articles_translations', 'POST', {
+    field: 'languages_code',
+    type: 'string',
+    meta: { interface: 'input' },
+    schema: { length: 16 },
+  });
+  await api(token, '/fields/articles_translations', 'POST', {
+    field: 'title',
+    type: 'string',
+    meta: { interface: 'input', width: 'full' },
+    schema: {},
+  });
+  await api(token, '/fields/articles_translations', 'POST', {
+    field: 'body',
+    type: 'text',
+    meta: { interface: 'input-multiline', width: 'full' },
+    schema: {},
+  });
+
+  // Alias field on the parent — this is what makes the `translations` interface appear.
+  await api(token, '/fields/articles', 'POST', {
+    field: 'translations',
+    type: 'alias',
+    meta: {
+      interface: 'translations',
+      special: ['translations'],
+      width: 'full',
+    },
+  });
+
+  console.log('[seed] creating relations');
+  // junction → parent. `one_field: 'translations'` + `junction_field: 'languages_code'`
+  // is what flips this from a plain O2M into Directus' translations shape.
+  await api(token, '/relations', 'POST', {
+    collection: 'articles_translations',
+    field: 'articles_id',
+    related_collection: 'articles',
+    meta: {
+      many_collection: 'articles_translations',
+      many_field: 'articles_id',
+      one_collection: 'articles',
+      one_field: 'translations',
+      junction_field: 'languages_code',
+      one_deselect_action: 'nullify',
+      sort_field: null,
+    },
+    schema: { on_delete: 'SET NULL' },
+  });
+  await api(token, '/relations', 'POST', {
+    collection: 'articles_translations',
+    field: 'languages_code',
+    related_collection: 'languages',
+    meta: {
+      many_collection: 'articles_translations',
+      many_field: 'languages_code',
+      one_collection: 'languages',
+      one_field: null,
+      junction_field: 'articles_id',
+    },
+    schema: { on_delete: 'SET NULL' },
+  });
+
+  console.log('[seed] inserting demo articles');
+  const article1 = await api(token, '/items/articles', 'POST', {
+    status: 'published',
+    title: 'Welcome to Localazy',
+  });
+  const article2 = await api(token, '/items/articles', 'POST', {
+    status: 'draft',
+    title: 'Getting started with translations',
+  });
+
+  await api(token, '/items/articles_translations', 'POST', [
+    {
+      articles_id: article1.data.id,
+      languages_code: 'en',
+      title: 'Welcome to Localazy',
+      body: 'Hello from the Localazy Directus extension.',
+    },
+    {
+      articles_id: article1.data.id,
+      languages_code: 'de',
+      title: 'Willkommen bei Localazy',
+      body: 'Hallo von der Localazy Directus Extension.',
+    },
+    {
+      articles_id: article2.data.id,
+      languages_code: 'en',
+      title: 'Getting started with translations',
+      body: 'A second article you can use to test sync flows.',
+    },
+  ]);
+
+  console.log('[seed] done');
+}
+
+main().catch((e) => {
+  console.error('[seed] failed:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Post-Stage-3 batch of dev-quality polish; touches files that PR 28 (CONTRIBUTING.md) doesn't, so the two PRs are independent.

- **Sass deprecation:** `@import` → `@use ... as *` in 9 SFC `<style>` blocks. Drops the Dart Sass 1.x deprecation warning that fires on every dev build.
- **Hook log noise:** downgrade `logger.error('Localazy: Incomplete configuration')` to `logger.debug('not configured yet — skipping ...')` in `collection-content-synchronization-service` and `translation-strings-synchronization-service`. The error was firing on every `items.create` / `settings.create` before Localazy is connected, polluting logs in a fresh install. Test asserts the new debug log.
- **Schema defensiveness:** add explicit `default_value` to every `localazy_data` and `localazy_settings` field. Belt-and-suspenders on top of the installer healing path so fields created on older installs land with predictable values.
- **Dev seed script:** new `scripts/seed-dev-data.mjs` creates a minimal `articles` collection with translations + `languages` collection on first bootstrap. `scripts/dev.mjs` health-polls Directus after `directus bootstrap` and invokes the seed.
- **New test:** `extensions/module/src/data/default-configuration.test.ts` (+9 tests; 92 → 101 total).

## Test plan

- [x] `npm run check` clean (lint + format + typecheck + 101 tests pass)
- [ ] Verify dev seed runs on a fresh bootstrap (`rm -rf development/data && npm run dev`)
- [ ] Verify the deprecation warning no longer appears in dev build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)