### PR TITLE
PR 30/N (Stage 4): incremental download sync

### DIFF
--- a/extensions/common/models/collections-data/sync-state.ts
+++ b/extensions/common/models/collections-data/sync-state.ts
@@ -1,0 +1,33 @@
+/**
+ * Sync cursor data, indexed by (language, Localazy key id). The recorded number is the
+ * `event` value of the most recently applied modification for that (language, key) pair.
+ *
+ * On the next download sync we skip any (language, key) whose stored event is `>=` the
+ * one returned by the API — i.e. we only fetch translations modified since we last wrote
+ * them. Cells with `undefined` storedEvent or `undefined` API event are always treated as
+ * "needs sync" (safe mode), preserving correctness if the server ever omits the field.
+ */
+export type SyncCursor = {
+  /** `{ [lang]: { [localazyKeyId]: lastProcessedEventNumber } }` */
+  processed_keys: Record<string, Record<string, number>>;
+};
+
+/**
+ * Shape of the `localazy_sync_state` singleton row. Persisted as a single record per
+ * Directus install; the cursor is serialized as JSON in `processed_keys`.
+ */
+export type SyncState = {
+  /** JSON-encoded `SyncCursor['processed_keys']`. Default `'{}'`. */
+  processed_keys: string;
+  /**
+   * Localazy project id the cursor was last written against. If it changes (user
+   * reconnected to a different project), the next sync auto-invalidates the cursor.
+   */
+  cursor_project_id: string;
+  /** Schema version of the cursor data. Bump when the storage shape changes. */
+  cursor_version: number;
+  /** ISO timestamp of the last successful download sync. */
+  last_sync_at: string | null;
+};
+
+export const CURSOR_VERSION = 1;

--- a/extensions/common/models/localazy-content.ts
+++ b/extensions/common/models/localazy-content.ts
@@ -26,7 +26,10 @@ export interface LocalazyCollectionBlock {
 export type LocalazyTranslationStringBlock = {
   key: string;
   directusId: string;
-  localazyKey: Key;
+  // Per-language Localazy Key — each language has its own (id, event) pair.
+  // Required for the incremental sync cursor; collapsing into a single Key would mean
+  // the cursor records the wrong-language id and never matches on the next sync.
+  localazyKeys: Record<string, Key>;
   translations: {
     [language: string]: string;
   };

--- a/extensions/common/services/content-from-localazy-service.ts
+++ b/extensions/common/services/content-from-localazy-service.ts
@@ -64,13 +64,18 @@ export class ContentFromLocalazyService {
     const directusId = data.key.key[2] || '';
     const translationStringKey = translationStrings.get(directusKey) || {
       key: directusKey,
+      directusId,
+      localazyKeys: {},
       translations: {},
     };
 
     translationStrings.set(directusKey, {
       ...translationStringKey,
-      localazyKey: data.key,
       directusId,
+      localazyKeys: {
+        ...translationStringKey.localazyKeys,
+        [data.language]: data.key,
+      },
       translations: {
         ...translationStringKey.translations,
         [data.language]: data.key.value.toString(),

--- a/extensions/common/services/translation-strings-service.ts
+++ b/extensions/common/services/translation-strings-service.ts
@@ -92,7 +92,7 @@ export class TranslationStringsService {
       const payloadMap = new Map();
 
       translationStrings.forEach((item) => {
-        const existingKey: Omit<LocalazyTranslationStringBlock, 'localazyKey'> = payloadMap.get(item.key) || {
+        const existingKey: Omit<LocalazyTranslationStringBlock, 'localazyKeys' | 'directusId'> = payloadMap.get(item.key) || {
           key: item.key,
           translations: {},
         };

--- a/extensions/common/utilities/sync-cursor.test.ts
+++ b/extensions/common/utilities/sync-cursor.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import type { Key } from '@localazy/api-client';
+import {
+  createEmptyCursor,
+  parseCursor,
+  serializeCursor,
+  cursorMatchesProject,
+  filterKeysByEventCursor,
+  recordCursorEntry,
+  mergeCursor,
+  countCursorEntries,
+} from './sync-cursor';
+
+const makeKey = (id: string, event?: number): Key =>
+  ({
+    id,
+    key: ['some', 'key'],
+    value: 'val',
+    ...(event !== undefined ? { event } : {}),
+  }) as Key;
+
+describe('createEmptyCursor', () => {
+  it('returns a cursor with an empty processed_keys map', () => {
+    expect(createEmptyCursor()).toEqual({ processed_keys: {} });
+  });
+});
+
+describe('parseCursor', () => {
+  it('returns empty cursor for null / undefined / empty string', () => {
+    expect(parseCursor(null)).toEqual({ processed_keys: {} });
+    expect(parseCursor(undefined)).toEqual({ processed_keys: {} });
+    expect(parseCursor('')).toEqual({ processed_keys: {} });
+  });
+
+  it('parses a well-formed JSON map', () => {
+    const raw = JSON.stringify({ en: { k1: 10, k2: 20 }, fr: { k1: 5 } });
+    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10, k2: 20 }, fr: { k1: 5 } } });
+  });
+
+  it('returns empty cursor for malformed JSON', () => {
+    expect(parseCursor('{not-json')).toEqual({ processed_keys: {} });
+  });
+
+  it('returns empty cursor for non-object JSON (array / string / number)', () => {
+    expect(parseCursor('[1,2,3]')).toEqual({ processed_keys: {} });
+    expect(parseCursor('"hello"')).toEqual({ processed_keys: {} });
+    expect(parseCursor('42')).toEqual({ processed_keys: {} });
+  });
+
+  it('drops non-numeric event values silently', () => {
+    const raw = JSON.stringify({ en: { k1: 10, k2: 'oops', k3: null, k4: 7 } });
+    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10, k4: 7 } } });
+  });
+
+  it('drops non-object per-language buckets', () => {
+    const raw = JSON.stringify({ en: { k1: 10 }, fr: 'broken', de: null });
+    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10 } } });
+  });
+
+  it('drops Infinity / NaN as non-finite numbers', () => {
+    // JSON.stringify would normally turn these to null, so build the object manually.
+    const raw = '{"en":{"k1":10,"k2":null}}';
+    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10 } } });
+  });
+});
+
+describe('serializeCursor', () => {
+  it('serializes the processed_keys map to JSON', () => {
+    expect(serializeCursor({ processed_keys: { en: { k1: 10 } } })).toBe('{"en":{"k1":10}}');
+  });
+
+  it('serializes empty cursor to empty object string', () => {
+    expect(serializeCursor(createEmptyCursor())).toBe('{}');
+  });
+
+  it('round-trips through parseCursor', () => {
+    const original = { processed_keys: { en: { k1: 10, k2: 20 }, fr: { k3: 5 } } };
+    expect(parseCursor(serializeCursor(original))).toEqual(original);
+  });
+});
+
+describe('cursorMatchesProject', () => {
+  it('returns true when stored project id is empty (first sync)', () => {
+    expect(cursorMatchesProject('', 'abc')).toBe(true);
+  });
+
+  it('returns true when stored matches current', () => {
+    expect(cursorMatchesProject('abc', 'abc')).toBe(true);
+  });
+
+  it('returns false when stored differs from current', () => {
+    expect(cursorMatchesProject('abc', 'def')).toBe(false);
+  });
+});
+
+describe('filterKeysByEventCursor', () => {
+  it('returns all keys when the cursor is undefined (no prior sync for this language)', () => {
+    const keys = [makeKey('k1', 10), makeKey('k2', 20)];
+    expect(filterKeysByEventCursor(keys, undefined)).toEqual(keys);
+  });
+
+  it('returns all keys when the per-language cursor is empty', () => {
+    const keys = [makeKey('k1', 10), makeKey('k2', 20)];
+    expect(filterKeysByEventCursor(keys, {})).toEqual(keys);
+  });
+
+  it('skips keys whose event equals the stored event', () => {
+    const k1 = makeKey('k1', 10);
+    const k2 = makeKey('k2', 20);
+    expect(filterKeysByEventCursor([k1, k2], { k1: 10, k2: 15 })).toEqual([k2]);
+  });
+
+  it('skips keys whose event is less than the stored event', () => {
+    const k1 = makeKey('k1', 5);
+    expect(filterKeysByEventCursor([k1], { k1: 10 })).toEqual([]);
+  });
+
+  it('includes keys whose event is greater than the stored event', () => {
+    const k1 = makeKey('k1', 11);
+    expect(filterKeysByEventCursor([k1], { k1: 10 })).toEqual([k1]);
+  });
+
+  it('includes keys with undefined event (safe mode for server without event support)', () => {
+    const k1 = makeKey('k1');
+    expect(filterKeysByEventCursor([k1], { k1: 999 })).toEqual([k1]);
+  });
+
+  it('includes keys not present in the cursor (first time we see them)', () => {
+    const k1 = makeKey('k1', 10);
+    const k2 = makeKey('k2', 20);
+    expect(filterKeysByEventCursor([k1, k2], { k1: 10 })).toEqual([k2]);
+  });
+});
+
+describe('recordCursorEntry', () => {
+  it('creates a new per-language bucket if one does not exist', () => {
+    const cursor = createEmptyCursor();
+    recordCursorEntry(cursor, 'en', 'k1', 10);
+    expect(cursor.processed_keys).toEqual({ en: { k1: 10 } });
+  });
+
+  it('records into an existing bucket without disturbing other cells', () => {
+    const cursor = { processed_keys: { en: { k1: 5 } } };
+    recordCursorEntry(cursor, 'en', 'k2', 7);
+    expect(cursor.processed_keys).toEqual({ en: { k1: 5, k2: 7 } });
+  });
+
+  it('keeps the higher event when an entry already exists', () => {
+    const cursor = { processed_keys: { en: { k1: 10 } } };
+    recordCursorEntry(cursor, 'en', 'k1', 5);
+    expect(cursor.processed_keys.en).toEqual({ k1: 10 });
+  });
+
+  it('upgrades the entry when called with a higher event', () => {
+    const cursor = { processed_keys: { en: { k1: 10 } } };
+    recordCursorEntry(cursor, 'en', 'k1', 20);
+    expect(cursor.processed_keys.en).toEqual({ k1: 20 });
+  });
+
+  it('is a no-op when event is undefined', () => {
+    const cursor = { processed_keys: { en: { k1: 10 } } };
+    recordCursorEntry(cursor, 'en', 'k1', undefined);
+    expect(cursor.processed_keys.en).toEqual({ k1: 10 });
+  });
+
+  it('does not create a language bucket when event is undefined', () => {
+    const cursor = createEmptyCursor();
+    recordCursorEntry(cursor, 'fr', 'k1', undefined);
+    expect(cursor.processed_keys).toEqual({});
+  });
+});
+
+describe('mergeCursor', () => {
+  it('returns identity-equivalent of either cursor when the other is empty', () => {
+    const a = { processed_keys: { en: { k1: 10 } } };
+    const empty = createEmptyCursor();
+    expect(mergeCursor(a, empty)).toEqual(a);
+    expect(mergeCursor(empty, a)).toEqual(a);
+  });
+
+  it('combines disjoint languages', () => {
+    const a = { processed_keys: { en: { k1: 10 } } };
+    const b = { processed_keys: { fr: { k2: 20 } } };
+    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 10 }, fr: { k2: 20 } } });
+  });
+
+  it('combines disjoint keys within the same language', () => {
+    const a = { processed_keys: { en: { k1: 10 } } };
+    const b = { processed_keys: { en: { k2: 20 } } };
+    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 10, k2: 20 } } });
+  });
+
+  it('takes max for overlapping cells', () => {
+    const a = { processed_keys: { en: { k1: 10, k2: 30 } } };
+    const b = { processed_keys: { en: { k1: 20, k2: 25 } } };
+    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 20, k2: 30 } } });
+  });
+
+  it('does not mutate the inputs', () => {
+    const a = { processed_keys: { en: { k1: 10 } } };
+    const b = { processed_keys: { en: { k1: 20 } } };
+    mergeCursor(a, b);
+    expect(a).toEqual({ processed_keys: { en: { k1: 10 } } });
+    expect(b).toEqual({ processed_keys: { en: { k1: 20 } } });
+  });
+});
+
+describe('countCursorEntries', () => {
+  it('returns 0 for empty cursor', () => {
+    expect(countCursorEntries(createEmptyCursor())).toBe(0);
+  });
+
+  it('sums per-language map sizes', () => {
+    const cursor = { processed_keys: { en: { k1: 1, k2: 2 }, fr: { k3: 3 } } };
+    expect(countCursorEntries(cursor)).toBe(3);
+  });
+});

--- a/extensions/common/utilities/sync-cursor.ts
+++ b/extensions/common/utilities/sync-cursor.ts
@@ -1,0 +1,137 @@
+import { Key } from '@localazy/api-client';
+import { SyncCursor } from '../models/collections-data/sync-state';
+
+/**
+ * Pure helpers around the download-sync cursor. The cursor is a per-(language, key id)
+ * map storing the last `event` number we successfully wrote for that cell. Everything
+ * here is intentionally side-effect-free and synchronous — the orchestration (loading
+ * the singleton, persisting back) lives in the call site so this stays testable.
+ *
+ * The shape mirrors the Strapi-plugin implementation: `{ [lang]: { [keyId]: event } }`.
+ */
+
+export function createEmptyCursor(): SyncCursor {
+  return { processed_keys: {} };
+}
+
+/**
+ * Parse a JSON-serialized `processed_keys` blob (the on-disk format used by the
+ * `localazy_sync_state` singleton). Returns an empty cursor for any malformed input —
+ * the cursor is best-effort cache, not authoritative state, so we never throw and
+ * never let a corrupt row block sync. The worst case of an empty parse is "re-download
+ * everything once", which is the desired fallback.
+ */
+export function parseCursor(raw: string | null | undefined): SyncCursor {
+  if (!raw) return createEmptyCursor();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return createEmptyCursor();
+    const processed: SyncCursor['processed_keys'] = {};
+    for (const [lang, perLang] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!perLang || typeof perLang !== 'object') continue;
+      const cleaned: Record<string, number> = {};
+      for (const [keyId, event] of Object.entries(perLang as Record<string, unknown>)) {
+        if (typeof event === 'number' && Number.isFinite(event)) {
+          cleaned[keyId] = event;
+        }
+      }
+      processed[lang] = cleaned;
+    }
+    return { processed_keys: processed };
+  } catch {
+    return createEmptyCursor();
+  }
+}
+
+export function serializeCursor(cursor: SyncCursor): string {
+  return JSON.stringify(cursor.processed_keys);
+}
+
+/**
+ * Returns true iff the cursor was last written against the same Localazy project we're
+ * about to sync. Used at sync start to decide whether to treat the on-disk cursor as
+ * authoritative or wipe it in memory. Empty `storedProjectId` is treated as "no recorded
+ * project" — i.e. first sync — so the cursor is acceptable.
+ */
+export function cursorMatchesProject(storedProjectId: string, currentProjectId: string): boolean {
+  if (!storedProjectId) return true;
+  return storedProjectId === currentProjectId;
+}
+
+/**
+ * Filter keys for a single language down to those that need (re-)downloading according
+ * to the cursor.
+ *
+ * Rule (must match the Strapi plugin exactly):
+ *   - If we have no cursor entry for `(lang, key.id)` → include.
+ *   - If the server didn't return an `event` for the key → include (safe mode).
+ *   - Otherwise include iff `key.event > storedEvent`.
+ *
+ * The "include on undefined" rules protect us against either side of the sync getting
+ * confused: if Localazy ever rolls out a backend that doesn't echo `event`, we degrade to
+ * "always download" rather than "always skip".
+ */
+export function filterKeysByEventCursor(keys: Key[], perLanguageCursor: Record<string, number> | undefined): Key[] {
+  if (!perLanguageCursor) return keys;
+  return keys.filter((k) => {
+    const stored = perLanguageCursor[k.id];
+    if (stored === undefined) return true;
+    if (k.event === undefined) return true;
+    return k.event > stored;
+  });
+}
+
+/**
+ * Record one successfully-applied `(lang, keyId, event)` triple in the in-memory cursor.
+ * Mutates `cursor` for performance — sync writes happen in a hot loop. If the cell
+ * already holds a higher event (rare, but possible if a concurrent sync raced ahead),
+ * keep the higher value.
+ */
+export function recordCursorEntry(cursor: SyncCursor, lang: string, keyId: string, event: number | undefined): void {
+  if (event === undefined) return;
+  const bucket = cursor.processed_keys[lang] || (cursor.processed_keys[lang] = {});
+  const existing = bucket[keyId];
+  bucket[keyId] = existing === undefined ? event : Math.max(existing, event);
+}
+
+/**
+ * Merge two cursors cell-by-cell, taking `max(event)` per `(lang, keyId)`. Used when
+ * persisting the in-memory cursor: we re-read the on-disk cursor, merge so we don't
+ * clobber concurrent writers, and write the result back. Pure — neither input is
+ * mutated, the result is a fresh object.
+ */
+export function mergeCursor(a: SyncCursor, b: SyncCursor): SyncCursor {
+  const result: SyncCursor['processed_keys'] = {};
+  const allLangs = new Set([...Object.keys(a.processed_keys), ...Object.keys(b.processed_keys)]);
+  for (const lang of allLangs) {
+    const left = a.processed_keys[lang] || {};
+    const right = b.processed_keys[lang] || {};
+    const allKeys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    const merged: Record<string, number> = {};
+    for (const keyId of allKeys) {
+      const lv = left[keyId];
+      const rv = right[keyId];
+      if (lv === undefined) {
+        merged[keyId] = rv!;
+      } else if (rv === undefined) {
+        merged[keyId] = lv;
+      } else {
+        merged[keyId] = Math.max(lv, rv);
+      }
+    }
+    result[lang] = merged;
+  }
+  return { processed_keys: result };
+}
+
+/**
+ * Count the total cells in a cursor (sum of per-language map sizes). Useful for
+ * debugging / progress reporting, not for correctness.
+ */
+export function countCursorEntries(cursor: SyncCursor): number {
+  let total = 0;
+  for (const perLang of Object.values(cursor.processed_keys)) {
+    total += Object.keys(perLang).length;
+  }
+  return total;
+}

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -13,7 +13,8 @@
         :has-changes="hasChanges"
         :disable-sync="!someTranslatableFieldsChecked && !synchronizeTranslationStrings"
         @upload="onExport"
-        @download="onImport"
+        @download="onImport('incremental')"
+        @download-full="onImport('full')"
         @save-settings="onSaveSettings({ notify: true })"
       />
     </template>

--- a/extensions/module/src/components/Sync/SyncActionButtons.vue
+++ b/extensions/module/src/components/Sync/SyncActionButtons.vue
@@ -2,7 +2,22 @@
   <div>
     <div class="sync-action-buttons">
       <v-button :disabled="disableSyncButtons" secondary @click="$emit('upload')"> Export to Localazy </v-button>
-      <v-button :disabled="disableSyncButtons" secondary @click="$emit('download')"> Import to Directus </v-button>
+      <div class="import-group">
+        <v-button :disabled="disableSyncButtons" secondary @click="$emit('download')"> Import to Directus </v-button>
+        <v-menu show-arrow placement="bottom-end">
+          <template #activator="{ toggle }">
+            <v-button :disabled="disableSyncButtons" secondary class="import-options" @click="toggle">
+              <v-icon name="expand_more" />
+            </v-button>
+          </template>
+          <v-list>
+            <v-list-item clickable @click="$emit('download-full')">
+              <v-list-item-icon><v-icon name="refresh" /></v-list-item-icon>
+              <v-list-item-content>Full Sync (rebuild from scratch)</v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </div>
       <v-button :disabled="!hasChanges" secondary @click="$emit('save-settings')"> Save </v-button>
     </div>
   </div>
@@ -13,7 +28,9 @@ import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useLocalazyStore } from '../../stores/localazy-store';
 
-defineEmits(['download', 'upload', 'save-settings']);
+// `download` runs an incremental sync (default). `download-full` triggers a Full Sync,
+// which rebuilds from scratch by running the same flow with an empty in-memory cursor.
+defineEmits(['download', 'download-full', 'upload', 'save-settings']);
 
 const props = defineProps({
   hasChanges: {
@@ -37,5 +54,15 @@ const disableSyncButtons = computed(() => props.disableSync || isNotConnectedToL
   display: flex;
   justify-content: space-between;
   gap: 4px;
+}
+
+.import-group {
+  display: flex;
+  gap: 2px;
+}
+
+.import-options {
+  --v-button-min-width: 28px;
+  --v-button-padding: 0 8px;
 }
 </style>

--- a/extensions/module/src/composables/use-directus-localazy-adapter.ts
+++ b/extensions/module/src/composables/use-directus-localazy-adapter.ts
@@ -10,6 +10,7 @@ import {
 import { Settings } from '../../../common/models/collections-data/settings';
 import { createAsyncQueue } from '../../../common/utilities/async-queue';
 import { TranslationPayload } from '../models/directus/translation-payload';
+import { WrittenTriple } from '../models/sync-write-result';
 import { mergeTranslationPayload } from '../utils/merge-translation-payload';
 import { useErrorsStore } from '../stores/errors-store';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
@@ -123,7 +124,7 @@ export const useDirectusLocalazyAdapter = () => {
     );
   }
 
-  async function upsertItemFromLocalazyContent(data: UpsertItemFromLocalazyContent) {
+  async function upsertItemFromLocalazyContent(data: UpsertItemFromLocalazyContent): Promise<WrittenTriple[]> {
     const { itemsInCollection, itemId, translations, collection, translationFieldFkMap, languageCodeField } = data;
     // Stringify both sides — `+id` returns NaN for UUID primary keys, and NaN === NaN is
     // false, so the strict numeric equality used previously silently failed for any
@@ -132,9 +133,13 @@ export const useDirectusLocalazyAdapter = () => {
     let payload: TranslationPayload = {};
     const updateTranslationFields: Set<string> = new Set();
     let somethingToCreate = false;
+    // Track every `(lang, keyId, event)` triple that contributed to this PATCH. We only
+    // hand the list back to the caller after the PATCH resolves (PATCH-then-mark) — so a
+    // failed write never produces a cursor advance that would skip the same key next time.
+    const triples: WrittenTriple[] = [];
 
     if (!collectionItem) {
-      return;
+      return [];
     }
     translations.forEach((translation) => {
       translation.items.forEach((item) => {
@@ -148,6 +153,11 @@ export const useDirectusLocalazyAdapter = () => {
           languageCodeField,
         });
         payload = result.currentPayload;
+        triples.push({
+          language: translation.language,
+          keyId: item.localazyKey.id,
+          event: item.localazyKey.event,
+        });
         if (result.isCreateOperation) {
           somethingToCreate = true;
         } else {
@@ -158,10 +168,20 @@ export const useDirectusLocalazyAdapter = () => {
     const someUpdateChanges = madeUpdateChanges(updateTranslationFields, payload, collectionItem);
     if (someUpdateChanges || somethingToCreate) {
       await directusApi.updateDirectusItem(collection, itemId, payload);
+      return triples;
     }
+    // Nothing was sent to Directus (idempotent no-op) — still advance the cursor since
+    // the local row already matches the remote translation, otherwise we'd refetch it
+    // again every sync.
+    return triples;
   }
 
-  async function upsertItemsFromSingleCollection(collection: string, content: LocalazyCollectionBlock, settings: Settings) {
+  async function upsertItemsFromSingleCollection(
+    collection: string,
+    content: LocalazyCollectionBlock,
+    settings: Settings,
+    onWritten?: (triples: WrittenTriple[]) => void,
+  ) {
     try {
       // Build a map of translation field -> FK column for the language relation, and ask
       // Directus to expand each language reference (`${field}.${fk}.*`) so the FK column
@@ -191,7 +211,7 @@ export const useDirectusLocalazyAdapter = () => {
         });
 
         try {
-          await upsertItemFromLocalazyContent({
+          const triples = await upsertItemFromLocalazyContent({
             collection,
             itemsInCollection,
             itemId,
@@ -199,6 +219,11 @@ export const useDirectusLocalazyAdapter = () => {
             translationFieldFkMap,
             languageCodeField: settings.language_code_field,
           });
+          // PATCH-then-mark: only invoke the cursor sink after the write resolves. If the
+          // PATCH threw, we land in the catch below and `onWritten` is never called.
+          if (triples.length > 0 && onWritten) {
+            onWritten(triples);
+          }
         } catch (e: unknown) {
           addDirectusError(e);
           upsertProgressMessage(ProgressTrackerId.UPDATING_DIRECTUS_COLLECTION_ERROR, {
@@ -217,12 +242,31 @@ export const useDirectusLocalazyAdapter = () => {
     return {};
   }
 
-  async function upsertFromLocalazyContent(contentItems: LocalazyContent, settings: Settings) {
+  type UpsertFromLocalazyContentOptions = {
+    /**
+     * Invoked once per item with the list of `(lang, keyId, event)` triples that were
+     * successfully written. The orchestrator uses this to advance the in-memory cursor
+     * and trigger throttled flushes. Triples are reported in batches per item, not per
+     * key, to keep the callback overhead off the hot loop.
+     */
+    onWritten?: (triples: WrittenTriple[]) => void;
+  };
+
+  async function upsertFromLocalazyContent(
+    contentItems: LocalazyContent,
+    settings: Settings,
+    options: UpsertFromLocalazyContentOptions = {},
+  ) {
+    const { onWritten } = options;
     const { add, execute } = createAsyncQueue();
     contentItems.collections.forEach((content, collection) => {
-      add(async () => upsertItemsFromSingleCollection(collection, content, settings));
+      add(async () => upsertItemsFromSingleCollection(collection, content, settings, onWritten));
     });
-    add(async () => upsertTranslationStrings(Array.from(contentItems.translationStrings.values())));
+    add(async () =>
+      upsertTranslationStrings(Array.from(contentItems.translationStrings.values()), {
+        onWritten,
+      }),
+    );
 
     await execute({ delayBetween: 150 });
   }

--- a/extensions/module/src/composables/use-import-from-localazy.ts
+++ b/extensions/module/src/composables/use-import-from-localazy.ts
@@ -1,4 +1,5 @@
 import { storeToRefs } from 'pinia';
+import { Key } from '@localazy/api-client';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
 import { ContentFromLocalazyService } from '../services/content-from-localazy-service';
@@ -13,6 +14,12 @@ type ImportContentFromLocalazy = {
   languages: DirectusLocalazyLanguage[];
   enabledFields: EnabledField[];
   localazyData: LocalazyData;
+  /**
+   * Optional post-fetch filter applied per language before content parsing. The download
+   * orchestrator injects cursor-based filtering here; passing it through this composable
+   * keeps `use-import-from-localazy` agnostic of cursor mechanics.
+   */
+  filterKeysForLanguage?: (language: string, keys: Key[]) => Key[];
 };
 
 type ImportContentFromLocalazySuccessReturn = {
@@ -41,6 +48,7 @@ export const useImportFromLocalazy = () => {
         enabledFields: data.enabledFields,
         localazyData: data.localazyData,
         localazyProject: localazyProject.value,
+        filterKeysForLanguage: data.filterKeysForLanguage,
         progressCallbacks: {
           nothingToImport: () => {
             addProgressMessage({

--- a/extensions/module/src/composables/use-localazy-boot.ts
+++ b/extensions/module/src/composables/use-localazy-boot.ts
@@ -20,12 +20,18 @@ import { useLocalazyStore } from '../stores/localazy-store';
 export const useLocalazyBoot = () => {
   const installer = useLocalazyInstallerStore();
   const { installed } = storeToRefs(installer);
-  const { data: localazyData } = storeToRefs(useLocalazyConfigStore());
+  const configStore = useLocalazyConfigStore();
+  const { data: localazyData } = storeToRefs(configStore);
   const localazyStore = useLocalazyStore();
   const { hydrating, hydrated } = storeToRefs(localazyStore);
 
   async function boot(): Promise<void> {
     await installer.run();
+    // Wait for the config singleton's first reload to settle. Without this the
+    // hydrate below reads stale defaults (no access_token) on a hard refresh,
+    // which renders the Overview as "Not connected to Localazy" until the user
+    // navigates away and back.
+    await configStore.firstLoad;
     await localazyStore.hydrateLocalazyData({ localazyData });
   }
 

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -235,12 +235,15 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
         }
       };
 
-      await upsertFromLocalazyContent(result.content, settings.value, { onWritten });
-
       // Final flush — guarantees the last batch lands even if it didn't cross the
-      // throttle threshold. Await this one so progress UI's success state reflects a
-      // durably-persisted cursor.
-      await persistCursor(inMemoryCursor);
+      // throttle threshold. The `finally` makes the contract literal: even if
+      // `upsertFromLocalazyContent` throws midway, whatever the writers already
+      // accumulated via `onWritten` still gets persisted.
+      try {
+        await upsertFromLocalazyContent(result.content, settings.value, { onWritten });
+      } finally {
+        await persistCursor(inMemoryCursor);
+      }
 
       const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
       addProgressMessage({

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -9,6 +9,7 @@ import { useLocalazyStore } from '../stores/localazy-store';
 import { useLocalazySettingsStore } from '../stores/localazy-settings-store';
 import { useLocalazyConfigStore } from '../stores/localazy-config-store';
 import { useLocalazyTransferSetupStore } from '../stores/localazy-transfer-setup-store';
+import { useLocalazySyncStateStore } from '../stores/localazy-sync-state-store';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
 import { useDirectusLanguages } from './use-directus-languages';
 import { useCollectionsOrganizer } from './use-collections-organizer';
@@ -16,9 +17,23 @@ import { useDirectusLocalazyAdapter } from './use-directus-localazy-adapter';
 import { useTranslatableCollections } from './use-translatable-collections';
 import { useTranslationStringsContent } from './use-translation-strings-content';
 import { EnabledField } from '../../../common/models/collections-data/content-transfer-setup';
+import { summarizeLocalazyContent } from '../utils/summarize-localazy-content';
 import { AnalyticsService } from '../../../common/services/analytics-service';
 import { ExportToLocalazyCommonService } from '../../../common/services/export-to-localazy-common-service';
+import {
+  createEmptyCursor,
+  cursorMatchesProject,
+  filterKeysByEventCursor,
+  mergeCursor,
+  parseCursor,
+  recordCursorEntry,
+  serializeCursor,
+} from '../../../common/utilities/sync-cursor';
+import { CURSOR_VERSION, SyncCursor } from '../../../common/models/collections-data/sync-state';
+import { WrittenTriple } from '../models/sync-write-result';
 import { useDirectusNotificationsStore } from './use-directus-stores';
+
+type SyncMode = 'incremental' | 'full';
 
 type UseSyncContainerActions = {
   enabledFields: Ref<EnabledField[]>;
@@ -36,7 +51,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
 
   const notificationsStore = useDirectusNotificationsStore();
 
-  const { addProgressMessage, resetProgressTracker } = useProgressTrackerStore();
+  const { addProgressMessage, upsertProgressMessage, resetProgressTracker } = useProgressTrackerStore();
   const localazyStore = useLocalazyStore();
   const { localazyUser, localazyProject } = storeToRefs(localazyStore);
 
@@ -46,6 +61,8 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   const { data: localazyData } = storeToRefs(configStore);
   const transferSetupStore = useLocalazyTransferSetupStore();
   const { data: transferSetup } = storeToRefs(transferSetupStore);
+  const syncStateStore = useLocalazySyncStateStore();
+  const { data: syncStateData } = storeToRefs(syncStateStore);
 
   const accessToken = computed(() => localazyData.value.access_token);
   const exportService = useExportToLocalazy(accessToken);
@@ -106,9 +123,41 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     }
   }
 
-  async function onImport() {
+  /**
+   * Cursor save with merge-on-persist: re-read the latest on-disk cursor, take
+   * `max(event)` per cell, write the result. Makes concurrent syncs benign — the loser
+   * never clobbers the winner. `cursor_project_id` is bumped to the current project on
+   * every save so subsequent reads correctly auto-invalidate when the user reconnects to
+   * a different project.
+   */
+  async function persistCursor(inMemory: SyncCursor) {
+    try {
+      await syncStateStore.reload();
+      const onDisk = parseCursor(syncStateData.value.processed_keys);
+      const merged = mergeCursor(onDisk, inMemory);
+      await syncStateStore.save({
+        processed_keys: serializeCursor(merged),
+        cursor_project_id: localazyProject.value?.id || '',
+        cursor_version: CURSOR_VERSION,
+        last_sync_at: new Date().toISOString(),
+      });
+    } catch {
+      // The error has already been surfaced via the errors store inside `save`. We
+      // intentionally swallow it here so a flush failure can't take down the sync; the
+      // next flush attempt will retry, and the final flush at end-of-sync acts as a
+      // last-resort backstop.
+    }
+  }
+
+  async function onImport(mode: SyncMode = 'incremental') {
     showProgress.value = true;
     loading.value = true;
+    const startedAt = Date.now();
+
+    addProgressMessage({
+      id: ProgressTrackerId.SYNC_MODE_HEADER,
+      message: mode === 'full' ? 'Full sync — rebuilding from scratch' : 'Incremental sync',
+    });
     addProgressMessage({
       id: ProgressTrackerId.RETRIEVING_LANGUAGES,
       message: 'Retrieving target languages',
@@ -117,28 +166,98 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     void onSaveSettings();
     try {
       const importLanguages = await resolveImportLanguages(settings.value);
+
+      // Load + auto-invalidate the on-disk cursor against the current project.
+      //   - Incremental mode: use the on-disk cursor as the filter base, unless the
+      //     project id has changed (the user reconnected), in which case we treat it as
+      //     empty.
+      //   - Full Sync mode: start from an empty filter base. We do NOT wipe the
+      //     persisted cursor here — merge-on-persist takes `max(event)` per cell, so
+      //     prior entries for keys we didn't visit this run are preserved (still
+      //     correct), and entries we did visit are overwritten with their new events.
+      const baseCursor: SyncCursor =
+        mode === 'full' || !cursorMatchesProject(syncStateData.value.cursor_project_id, localazyProject.value?.id || '')
+          ? createEmptyCursor()
+          : parseCursor(syncStateData.value.processed_keys);
+      // The in-memory cursor tracks only what we successfully wrote this run.
+      // `persistCursor` merges it with whatever's on disk before each save.
+      const inMemoryCursor: SyncCursor = createEmptyCursor();
+
+      upsertProgressMessage(ProgressTrackerId.FETCHING_TRANSLATIONS, {
+        message: 'Fetching translations from Localazy...',
+      });
+
       const result = await useImportFromLocalazy().importContentFromLocalazy({
         languages: importLanguages,
         localazyData: localazyData.value,
         enabledFields: enabledFields.value,
+        filterKeysForLanguage: (language, keys) => filterKeysByEventCursor(keys, baseCursor.processed_keys[language]),
       });
-      if (result.success) {
-        await upsertFromLocalazyContent(result.content, settings.value);
-        addProgressMessage({
-          id: ProgressTrackerId.IMPORT_FINISHED,
-          message: 'Import finished',
-        });
-        // Analytics is fire-and-forget; download flow shouldn't block on telemetry.
-        void AnalyticsService.trackDownloadFromLocalazy(
-          ExportToLocalazyCommonService.getPayloadForUploadAnalytics({
-            userId: localazyUser.value.id,
-            orgId: localazyProject.value?.orgId || '',
-            localazyProject: localazyData.value.project_name,
-            settings: settings.value,
-            languages: Object.keys(importLanguages),
-          }),
-        );
+
+      if (!result.success) {
+        return;
       }
+
+      const summary = summarizeLocalazyContent(result.content);
+
+      if (summary.changes === 0) {
+        upsertProgressMessage(ProgressTrackerId.UP_TO_DATE, {
+          message: 'Already up to date — no changes since last sync',
+        });
+        // Still touch `last_sync_at` so the UX / debug field reflects the most recent
+        // successful run; merge-on-persist keeps the cursor itself unchanged.
+        await persistCursor(inMemoryCursor);
+        return;
+      }
+
+      upsertProgressMessage(ProgressTrackerId.CHANGES_SUMMARY, {
+        message: `Found ${summary.changes} changes across ${summary.languages} languages — applying to ${summary.items} items in ${summary.collections} collections`,
+      });
+
+      // Throttled flush: persist every `flushEvery` keys completed (capped at 10% of
+      // total work, minimum 50). Final flush happens unconditionally below.
+      const totalKeys = summary.changes;
+      const flushEvery = Math.max(50, Math.ceil(totalKeys / 10));
+      let sinceLastFlush = 0;
+      let writtenSinceStart = 0;
+
+      const onWritten = (triples: WrittenTriple[]) => {
+        triples.forEach((t) => {
+          recordCursorEntry(inMemoryCursor, t.language, t.keyId, t.event);
+        });
+        sinceLastFlush += triples.length;
+        writtenSinceStart += triples.length;
+        if (sinceLastFlush >= flushEvery) {
+          sinceLastFlush = 0;
+          // Fire-and-forget: the next persist will reload the disk cursor anyway, and we
+          // do not want write progress to stall on a slow Directus PATCH.
+          void persistCursor(inMemoryCursor);
+        }
+      };
+
+      await upsertFromLocalazyContent(result.content, settings.value, { onWritten });
+
+      // Final flush — guarantees the last batch lands even if it didn't cross the
+      // throttle threshold. Await this one so progress UI's success state reflects a
+      // durably-persisted cursor.
+      await persistCursor(inMemoryCursor);
+
+      const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+      addProgressMessage({
+        id: ProgressTrackerId.IMPORT_FINISHED,
+        message: `Imported ${writtenSinceStart} changes across ${summary.languages} languages. ${summary.items} items updated in ${elapsedSec}s.`,
+      });
+
+      // Analytics is fire-and-forget; download flow shouldn't block on telemetry.
+      void AnalyticsService.trackDownloadFromLocalazy(
+        ExportToLocalazyCommonService.getPayloadForUploadAnalytics({
+          userId: localazyUser.value.id,
+          orgId: localazyProject.value?.orgId || '',
+          localazyProject: localazyData.value.project_name,
+          settings: settings.value,
+          languages: Object.keys(importLanguages),
+        }),
+      );
     } finally {
       loading.value = false;
     }

--- a/extensions/module/src/composables/use-translation-strings-content.ts
+++ b/extensions/module/src/composables/use-translation-strings-content.ts
@@ -61,11 +61,11 @@ export const useTranslationStringsContent = () => {
       if (options.onWritten) {
         const triples: WrittenTriple[] = [];
         data.forEach((block) => {
-          Object.keys(block.translations).forEach((language) => {
+          Object.entries(block.localazyKeys).forEach(([language, localazyKey]) => {
             triples.push({
               language,
-              keyId: block.localazyKey.id,
-              event: block.localazyKey.event,
+              keyId: localazyKey.id,
+              event: localazyKey.event,
             });
           });
         });

--- a/extensions/module/src/composables/use-translation-strings-content.ts
+++ b/extensions/module/src/composables/use-translation-strings-content.ts
@@ -4,6 +4,9 @@ import { Settings } from '../../../common/models/collections-data/settings';
 import { TranslatableContent } from '../../../common/models/translatable-content';
 import { useErrorsStore } from '../stores/errors-store';
 import { LocalazyTranslationStringBlock } from '../../../common/models/localazy-content';
+import { WrittenTriple } from '../models/sync-write-result';
+import { ProgressTrackerId } from '../enums/progress-tracker-id';
+import { useProgressTrackerStore } from '../stores/progress-tracker-store';
 import { DirectusModuleApi } from '../services/directus-module-api';
 import { useDirectusCollectionsStore } from './use-directus-stores';
 
@@ -13,8 +16,18 @@ type FetchTranslationStrings = {
   settings: Settings;
 };
 
+type UpsertTranslationStringsOptions = {
+  /**
+   * Invoked after the translation-string upsert resolves with the list of `(lang, keyId,
+   * event)` triples that were successfully written. Mirrors the collection-content
+   * adapter so the cursor sees both write paths.
+   */
+  onWritten?: (triples: WrittenTriple[]) => void;
+};
+
 export const useTranslationStringsContent = () => {
   const { addDirectusError } = useErrorsStore();
+  const { upsertProgressMessage } = useProgressTrackerStore();
   const directusApi = new DirectusModuleApi(useApi(), useDirectusCollectionsStore());
   const translationStringsService = new TranslationStringsService(directusApi);
 
@@ -30,9 +43,36 @@ export const useTranslationStringsContent = () => {
     }
   }
 
-  async function upsertTranslationStrings(data: LocalazyTranslationStringBlock[]) {
+  /**
+   * Persist incoming translation-string blocks to Directus. `data` is one entry per
+   * Localazy translation-string key; each entry carries the per-language map plus the
+   * source `localazyKey` (id + event) the orchestrator needs to advance the cursor.
+   * PATCH-then-mark: only emit the triples after the underlying call resolves.
+   */
+  async function upsertTranslationStrings(data: LocalazyTranslationStringBlock[], options: UpsertTranslationStringsOptions = {}) {
+    if (data.length === 0) {
+      return;
+    }
+    upsertProgressMessage(ProgressTrackerId.UPDATING_TRANSLATION_STRINGS, {
+      message: `Updating ${data.length} translation ${data.length === 1 ? 'string' : 'strings'}`,
+    });
     try {
       await translationStringsService.upsertTranslationStrings(data);
+      if (options.onWritten) {
+        const triples: WrittenTriple[] = [];
+        data.forEach((block) => {
+          Object.keys(block.translations).forEach((language) => {
+            triples.push({
+              language,
+              keyId: block.localazyKey.id,
+              event: block.localazyKey.event,
+            });
+          });
+        });
+        if (triples.length > 0) {
+          options.onWritten(triples);
+        }
+      }
     } catch (e: unknown) {
       addDirectusError(e);
     }

--- a/extensions/module/src/data/default-configuration.test.ts
+++ b/extensions/module/src/data/default-configuration.test.ts
@@ -4,6 +4,7 @@ import { defaultConfiguration } from './default-configuration';
 import { createSettingsFields } from './fields/settings/create';
 import { createContentTransferSetupsFields } from './fields/content-transfer-setup/create';
 import { createLocalazyDataFields } from './fields/localazy-data/create';
+import { createSyncStateFields } from './fields/sync-state/create';
 
 /**
  * Guard test for the installer's heal path.
@@ -26,6 +27,7 @@ const SECTIONS: Array<{ section: Section; fields: () => Array<DeepPartial<Field>
   { section: 'settings', fields: createSettingsFields },
   { section: 'content_transfer_setup', fields: createContentTransferSetupsFields },
   { section: 'localazy_data', fields: createLocalazyDataFields },
+  { section: 'sync_state', fields: createSyncStateFields },
 ];
 
 describe('defaultConfiguration <-> field declarations', () => {

--- a/extensions/module/src/data/default-configuration.ts
+++ b/extensions/module/src/data/default-configuration.ts
@@ -1,4 +1,5 @@
 import { CreateMissingLanguagesInDirectus } from '../../../common/enums/create-missing-languages-in-directus';
+import { CURSOR_VERSION } from '../../../common/models/collections-data/sync-state';
 import { Configuration } from '../models/configuration';
 
 export const defaultConfiguration = (): Configuration => ({
@@ -27,5 +28,11 @@ export const defaultConfiguration = (): Configuration => ({
     project_url: '',
     project_name: '',
     org_id: '',
+  },
+  sync_state: {
+    processed_keys: '{}',
+    cursor_project_id: '',
+    cursor_version: CURSOR_VERSION,
+    last_sync_at: null,
   },
 });

--- a/extensions/module/src/data/fields/sync-state/create.ts
+++ b/extensions/module/src/data/fields/sync-state/create.ts
@@ -1,0 +1,78 @@
+import { Field, DeepPartial } from '@directus/types';
+import { CURSOR_VERSION } from '../../../../../common/models/collections-data/sync-state';
+import { getConfig } from '../../../../../common/config/get-config';
+
+/**
+ * Schema for the `localazy_sync_state` singleton. Mirrors the wiring pattern used by
+ * `localazy_settings` and `localazy_data` (see `localazy-installer-store.ts`).
+ *
+ * `processed_keys` holds the JSON-encoded download-sync cursor — a per-`(language, key id)`
+ * map of the last `event` number we successfully applied. `cursor_project_id` ties the
+ * cursor to a specific Localazy project; the sync code wipes the cursor in-memory if the
+ * stored value diverges from the current project id. `cursor_version` is reserved for
+ * future schema changes to the on-disk shape.
+ */
+export const createSyncStateFields = (): Array<DeepPartial<Field>> => [
+  {
+    field: 'id',
+    type: 'integer',
+    meta: {
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+      interface: 'numeric',
+    },
+    schema: {
+      is_nullable: false,
+      is_primary_key: true,
+    },
+  },
+  {
+    field: 'processed_keys',
+    type: 'text',
+    meta: {
+      interface: 'input-multiline',
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '{}',
+    },
+  },
+  {
+    field: 'cursor_project_id',
+    type: 'string',
+    meta: {
+      interface: 'input',
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '',
+    },
+  },
+  {
+    field: 'cursor_version',
+    type: 'integer',
+    meta: {
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+      interface: 'numeric',
+    },
+    schema: {
+      default_value: CURSOR_VERSION,
+    },
+  },
+  {
+    field: 'last_sync_at',
+    type: 'timestamp',
+    meta: {
+      interface: 'datetime',
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: null,
+      is_nullable: true,
+    },
+  },
+];

--- a/extensions/module/src/enums/progress-tracker-id.ts
+++ b/extensions/module/src/enums/progress-tracker-id.ts
@@ -7,6 +7,13 @@ export enum ProgressTrackerId {
   LOADED_LOCALAZY_PROJECT,
   IMPORTED_CONTENT_CHUNK,
   UPDATING_DIRECTUS_COLLECTION,
+  // Incremental download sync progress markers — keep IDs stable; the progress modal
+  // de-dupes by id so reusing one updates the existing line in place.
+  SYNC_MODE_HEADER,
+  FETCHING_TRANSLATIONS,
+  CHANGES_SUMMARY,
+  UPDATING_TRANSLATION_STRINGS,
+  UP_TO_DATE,
 
   NOTHING_TO_IMPORT,
   NOT_CONNECTED_TO_LOCALAZY,

--- a/extensions/module/src/models/configuration.ts
+++ b/extensions/module/src/models/configuration.ts
@@ -1,9 +1,11 @@
 import { ContentTransferSetupDatabase } from '../../../common/models/collections-data/content-transfer-setup';
 import { LocalazyData } from '../../../common/models/collections-data/localazy-data';
 import { Settings } from '../../../common/models/collections-data/settings';
+import { SyncState } from '../../../common/models/collections-data/sync-state';
 
 export type Configuration = {
   settings: Settings;
   content_transfer_setup: ContentTransferSetupDatabase;
   localazy_data: LocalazyData;
+  sync_state: SyncState;
 };

--- a/extensions/module/src/models/sync-write-result.ts
+++ b/extensions/module/src/models/sync-write-result.ts
@@ -1,0 +1,15 @@
+/**
+ * One `(language, Localazy key id, event)` triple successfully applied to Directus during
+ * a download sync. The orchestrator collects these from each write step and feeds them
+ * back into the in-memory cursor (PATCH-then-mark — we never mark before the write
+ * resolves, so a transient Directus failure can't leave us with a marked-but-not-written
+ * cell that would be skipped on the next sync).
+ *
+ * `event` is optional because the Localazy backend may omit it for unmodified keys; the
+ * cursor recording helper treats `undefined` as a no-op (`recordCursorEntry`).
+ */
+export type WrittenTriple = {
+  language: string;
+  keyId: string;
+  event: number | undefined;
+};

--- a/extensions/module/src/services/content-from-localazy-service.ts
+++ b/extensions/module/src/services/content-from-localazy-service.ts
@@ -64,13 +64,18 @@ export class ContentFromLocalazyService {
     const directusId = data.key.key[2] || '';
     const translationStringKey = translationStrings.get(directusKey) || {
       key: directusKey,
+      directusId,
+      localazyKeys: {},
       translations: {},
     };
 
     translationStrings.set(directusKey, {
       ...translationStringKey,
-      localazyKey: data.key,
       directusId,
+      localazyKeys: {
+        ...translationStringKey.localazyKeys,
+        [data.language]: data.key,
+      },
       translations: {
         ...translationStringKey.translations,
         [data.language]: data.key.value.toString(),

--- a/extensions/module/src/services/import-from-localazy-service.ts
+++ b/extensions/module/src/services/import-from-localazy-service.ts
@@ -1,5 +1,5 @@
 import { uniqWith } from 'lodash';
-import { Locales, Project } from '@localazy/api-client';
+import { Key, Locales, Project } from '@localazy/api-client';
 import { LocalazyApiThrottleService } from '../../../common/services/localazy-api-throttle-service';
 import { DirectusLocalazyLanguage } from '../../../common/models/directus-localazy-language';
 import { ContentFromLocalazyService } from './content-from-localazy-service';
@@ -13,6 +13,14 @@ type FetchContentInLanguage = {
   access_token: string;
 };
 
+/**
+ * Reduces a per-language keys list immediately after fetch, before the
+ * `ContentFromLocalazyService` parser runs. Used by the incremental-sync flow to drop
+ * keys that haven't changed since the last sync (cursor-filtered). When omitted the
+ * service behaves as before — pass-through everything.
+ */
+type FilterKeysForLanguage = (language: string, keys: Key[]) => Key[];
+
 type ImportContentFromLocalazy = {
   languages: DirectusLocalazyLanguage[];
   enabledFields: EnabledField[];
@@ -23,6 +31,12 @@ type ImportContentFromLocalazy = {
     nothingToImport: () => void;
     couldNotFetchContent: (language: string) => void;
   };
+
+  /**
+   * Optional. Called per language with the raw key list straight from Localazy; returns
+   * the subset that should reach the parser. The default (no filter) keeps every key.
+   */
+  filterKeysForLanguage?: FilterKeysForLanguage;
 };
 
 type ImportContentFromLocalazySuccessReturn = {
@@ -38,7 +52,7 @@ type ImportContentFromLocalazyReturn = ImportContentFromLocalazySuccessReturn | 
 
 class ImportFromLocalazyService {
   async importContentFromLocalazy(data: ImportContentFromLocalazy): Promise<ImportContentFromLocalazyReturn> {
-    const { languages, enabledFields, progressCallbacks, localazyProject, localazyData } = data;
+    const { languages, enabledFields, progressCallbacks, localazyProject, localazyData, filterKeysForLanguage } = data;
 
     const uniqueLocalazyFormLanguages = uniqWith(languages, (a, b) => a.localazyForm === b.localazyForm);
     const directusFile = await this.loadFile(localazyData.access_token, localazyProject?.id || '');
@@ -49,25 +63,29 @@ class ImportFromLocalazyService {
     }
 
     if (localazyProject && directusFile) {
-      const sourceKeysPerLanguage = (
-        await Promise.all(
-          uniqueLocalazyFormLanguages.map((lang) =>
-            this.fetchContentInLanguage(
-              {
-                lang,
-                directusFileId: directusFile.id,
-                localazyProject,
-                access_token: localazyData.access_token,
-              },
-              progressCallbacks,
-            ),
+      const sourceKeysPerLanguage = await Promise.all(
+        uniqueLocalazyFormLanguages.map((lang) =>
+          this.fetchContentInLanguage(
+            {
+              lang,
+              directusFileId: directusFile.id,
+              localazyProject,
+              access_token: localazyData.access_token,
+            },
+            progressCallbacks,
           ),
-        )
-      ).flat();
+        ),
+      );
+
+      // Apply the cursor filter (if any) immediately after fetch and before the parser —
+      // the parser shouldn't know or care about incremental sync.
+      const filtered = filterKeysForLanguage
+        ? sourceKeysPerLanguage.map(({ language, keys }) => ({ language, keys: filterKeysForLanguage(language, keys) }))
+        : sourceKeysPerLanguage;
 
       return {
         success: true,
-        content: ContentFromLocalazyService.parseLocalazyContent(sourceKeysPerLanguage, enabledFields),
+        content: ContentFromLocalazyService.parseLocalazyContent(filtered, enabledFields),
       };
     }
     return { success: false };
@@ -89,10 +107,15 @@ class ImportFromLocalazyService {
 
   private async fetchContentInLanguage(data: FetchContentInLanguage, progressCallbacks: ImportContentFromLocalazy['progressCallbacks']) {
     const { lang, directusFileId, localazyProject, access_token } = data;
+    // `event: true` makes Localazy include the per-key modification `event` number on the
+    // response, which the cursor filter uses to drop already-synced keys. The API ignores
+    // the flag when the server doesn't support it, and the cursor's safe-mode rule
+    // (undefined event = always include) means we degrade gracefully.
     const keys = await LocalazyApiThrottleService.listAllKeysInFileForLanguage(access_token, {
       project: localazyProject.id,
       file: directusFileId,
       lang: lang.localazyForm as Locales,
+      event: true,
     }).catch((e) => {
       progressCallbacks.couldNotFetchContent(lang.directusForm);
       throw e;

--- a/extensions/module/src/stores/localazy-installer-store.ts
+++ b/extensions/module/src/stores/localazy-installer-store.ts
@@ -10,6 +10,7 @@ import { defaultConfiguration } from '../data/default-configuration';
 import { createSettingsFields } from '../data/fields/settings/create';
 import { createContentTransferSetupsFields } from '../data/fields/content-transfer-setup/create';
 import { createLocalazyDataFields } from '../data/fields/localazy-data/create';
+import { createSyncStateFields } from '../data/fields/sync-state/create';
 
 /**
  * Collection names owned by this extension. Used by the installer and the per-singleton
@@ -20,6 +21,7 @@ export const LOCALAZY_COLLECTIONS = {
   settings: 'localazy_settings',
   contentTransferSetup: 'localazy_content_transfer_setup',
   config: 'localazy_config_data',
+  syncState: 'localazy_sync_state',
 } as const;
 
 type CollectionPlan = {
@@ -136,6 +138,11 @@ export const useLocalazyInstallerStore = defineStore('localazyInstaller', () => 
           name: LOCALAZY_COLLECTIONS.config,
           fields: createLocalazyDataFields,
           defaults: defaultConfiguration().localazy_data,
+        });
+        await ensureCollection({
+          name: LOCALAZY_COLLECTIONS.syncState,
+          fields: createSyncStateFields,
+          defaults: defaultConfiguration().sync_state,
         });
         installed.value = true;
       } catch (e: unknown) {

--- a/extensions/module/src/stores/localazy-sync-state-store.ts
+++ b/extensions/module/src/stores/localazy-sync-state-store.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia';
+import { createSingletonStore } from './singleton-factory';
+import { LOCALAZY_COLLECTIONS } from './localazy-installer-store';
+import { defaultConfiguration } from '../data/default-configuration';
+import type { SyncState } from '../../../common/models/collections-data/sync-state';
+
+/**
+ * Singleton store for the download-sync cursor (`localazy_sync_state`).
+ *
+ * The store itself is a thin singleton wrapper — the orchestration logic
+ * (auto-invalidate by project, merge-on-persist, throttled flush) lives in
+ * `use-sync-container-actions.ts`. Keeping this store minimal mirrors how the
+ * other singletons (settings, config, transfer setup) work.
+ */
+export const useLocalazySyncStateStore = defineStore(
+  'localazySyncState',
+  createSingletonStore<SyncState>(LOCALAZY_COLLECTIONS.syncState, defaultConfiguration().sync_state),
+);

--- a/extensions/module/src/stores/singleton-factory.ts
+++ b/extensions/module/src/stores/singleton-factory.ts
@@ -37,6 +37,17 @@ export function createSingletonStore<T extends Record<string, unknown>>(collecti
     const loading = ref(false);
     const error = ref<unknown>(null);
 
+    // Resolves once the first installer-driven reload settles (success or error).
+    // Lets `useLocalazyBoot.boot()` await the singleton's data being populated before
+    // handing the store off to downstream consumers — without this, the boot proceeds
+    // while the watcher's fire-and-forget `void reload()` is still in flight, and the
+    // first hard-refresh consumer reads stale defaults (visible bug: Overview shows
+    // "Not connected to Localazy" until you navigate away and back).
+    let firstLoadResolve!: () => void;
+    const firstLoad = new Promise<void>((resolve) => {
+      firstLoadResolve = resolve;
+    });
+
     async function reload(): Promise<void> {
       loading.value = true;
       try {
@@ -70,11 +81,11 @@ export function createSingletonStore<T extends Record<string, unknown>>(collecti
     watch(
       () => installer.installed,
       (done) => {
-        if (done) void reload();
+        if (done) void reload().finally(() => firstLoadResolve());
       },
       { immediate: true },
     );
 
-    return { data, loading, error, save, reload };
+    return { data, loading, error, save, reload, firstLoad };
   };
 }

--- a/extensions/module/src/utils/summarize-localazy-content.test.ts
+++ b/extensions/module/src/utils/summarize-localazy-content.test.ts
@@ -20,7 +20,7 @@ function makeTranslationStringBlock(key: string, translations: Record<string, st
   return {
     key,
     directusId: '',
-    localazyKey: k(key),
+    localazyKeys: Object.fromEntries(Object.keys(translations).map((lang) => [lang, k(`${key}-${lang}`)])),
     translations,
   };
 }

--- a/extensions/module/src/utils/summarize-localazy-content.test.ts
+++ b/extensions/module/src/utils/summarize-localazy-content.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import type { Key } from '@localazy/api-client';
+import { LocalazyContent, LocalazyCollectionBlock, LocalazyTranslationStringBlock } from '../../../common/models/localazy-content';
+import { summarizeLocalazyContent } from './summarize-localazy-content';
+
+const k = (id: string, event = 0): Key => ({ id, key: ['k'], value: 'v', event }) as Key;
+
+function makeCollectionBlock(items: Record<string, Array<{ language: string; fields: string[] }>>): LocalazyCollectionBlock {
+  const block: LocalazyCollectionBlock = { translationFields: ['translations'], items: {} };
+  for (const [itemId, perLangList] of Object.entries(items)) {
+    block.items[Number(itemId)] = perLangList.map(({ language, fields }) => ({
+      language,
+      items: fields.map((field) => ({ field, translationField: 'translations', value: 'val', localazyKey: k(`${language}-${field}`) })),
+    }));
+  }
+  return block;
+}
+
+function makeTranslationStringBlock(key: string, translations: Record<string, string>): LocalazyTranslationStringBlock {
+  return {
+    key,
+    directusId: '',
+    localazyKey: k(key),
+    translations,
+  };
+}
+
+describe('summarizeLocalazyContent', () => {
+  it('returns all zeroes for an empty payload', () => {
+    const content: LocalazyContent = { collections: new Map(), translationStrings: new Map() };
+    expect(summarizeLocalazyContent(content)).toEqual({ changes: 0, items: 0, collections: 0, languages: 0 });
+  });
+
+  it('counts collections, items, languages and changes for a single collection', () => {
+    const content: LocalazyContent = {
+      collections: new Map([
+        [
+          'posts',
+          makeCollectionBlock({
+            '1': [
+              { language: 'fr', fields: ['title', 'body'] },
+              { language: 'de', fields: ['title'] },
+            ],
+            '2': [{ language: 'fr', fields: ['title'] }],
+          }),
+        ],
+      ]),
+      translationStrings: new Map(),
+    };
+    expect(summarizeLocalazyContent(content)).toEqual({
+      changes: 2 + 1 + 1, // fr+de on item 1, fr on item 2
+      items: 2,
+      collections: 1,
+      languages: 2,
+    });
+  });
+
+  it('counts translation-string keys as items and counts each language as one change', () => {
+    const content: LocalazyContent = {
+      collections: new Map(),
+      translationStrings: new Map([
+        ['greeting', makeTranslationStringBlock('greeting', { fr: 'Bonjour', de: 'Hallo' })],
+        ['farewell', makeTranslationStringBlock('farewell', { fr: 'Au revoir' })],
+      ]),
+    };
+    expect(summarizeLocalazyContent(content)).toEqual({
+      changes: 3,
+      items: 2,
+      collections: 0,
+      languages: 2,
+    });
+  });
+
+  it('merges language sets across collections and translation strings', () => {
+    const content: LocalazyContent = {
+      collections: new Map([['posts', makeCollectionBlock({ '1': [{ language: 'fr', fields: ['title'] }] })]]),
+      translationStrings: new Map([['greeting', makeTranslationStringBlock('greeting', { de: 'Hallo' })]]),
+    };
+    expect(summarizeLocalazyContent(content).languages).toBe(2);
+  });
+
+  it('counts distinct collections separately', () => {
+    const content: LocalazyContent = {
+      collections: new Map([
+        ['posts', makeCollectionBlock({ '1': [{ language: 'fr', fields: ['title'] }] })],
+        ['pages', makeCollectionBlock({ '1': [{ language: 'fr', fields: ['title'] }] })],
+      ]),
+      translationStrings: new Map(),
+    };
+    expect(summarizeLocalazyContent(content).collections).toBe(2);
+  });
+});

--- a/extensions/module/src/utils/summarize-localazy-content.ts
+++ b/extensions/module/src/utils/summarize-localazy-content.ts
@@ -1,0 +1,48 @@
+import { LocalazyContent } from '../../../common/models/localazy-content';
+
+export type LocalazyContentSummary = {
+  /** Total per-(item, language, field) cells to write. Drives the "N changes" wording. */
+  changes: number;
+  /** Distinct Directus items that need updating (collection rows + translation-string keys). */
+  items: number;
+  /** Number of distinct collections receiving updates. */
+  collections: number;
+  /** Number of distinct languages that have at least one change. */
+  languages: number;
+};
+
+/**
+ * Build the headline summary stats the sync orchestrator emits to the progress modal
+ * (e.g. "Found 42 changes across 3 languages — applying to 12 items in 4 collections").
+ *
+ * Pure and synchronous — extracted from `use-sync-container-actions` so the message
+ * arithmetic can be unit-tested without standing up Pinia. The shape mirrors what the
+ * design's decision-19 messages reference; counts are intentionally aggregate (no
+ * per-language drilldown here — that's reserved for an optional expansion in the modal).
+ */
+export function summarizeLocalazyContent(content: LocalazyContent): LocalazyContentSummary {
+  let changes = 0;
+  let items = 0;
+  const collections = content.collections.size;
+  const languages = new Set<string>();
+
+  content.collections.forEach((block) => {
+    items += Object.keys(block.items).length;
+    Object.values(block.items).forEach((perLang) => {
+      perLang.forEach(({ language, items: localazyItems }) => {
+        languages.add(language);
+        changes += localazyItems.length;
+      });
+    });
+  });
+
+  content.translationStrings.forEach((block) => {
+    items += 1;
+    Object.entries(block.translations).forEach(([language]) => {
+      languages.add(language);
+      changes += 1;
+    });
+  });
+
+  return { changes, items, collections, languages: languages.size };
+}

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.test.ts
@@ -189,9 +189,12 @@ describe('translationStringsSynchronizationService.deprecateDeletedTranslationSt
         success: true,
         content: {
           translationStrings: [
-            { directusId: 'kept-id', localazyKey: { id: 'lk-kept' } },
-            { directusId: 'deleted-id-a', localazyKey: { id: 'lk-a' } },
-            { directusId: 'deleted-id-b', localazyKey: { id: 'lk-b' } },
+            // Each Directus translation string has one Localazy key per language;
+            // we exercise both single-language and multi-language cases here so the
+            // deprecation flow emits IDs for every language a deleted string had.
+            { directusId: 'kept-id', localazyKeys: { en: { id: 'lk-kept' } } },
+            { directusId: 'deleted-id-a', localazyKeys: { en: { id: 'lk-a-en' }, de: { id: 'lk-a-de' } } },
+            { directusId: 'deleted-id-b', localazyKeys: { en: { id: 'lk-b' } } },
           ],
         },
       },
@@ -208,6 +211,6 @@ describe('translationStringsSynchronizationService.deprecateDeletedTranslationSt
     expect(deprecateSpy).toHaveBeenCalledOnce();
     const [, projectId, keyIds] = deprecateSpy.mock.calls[0]!;
     expect(projectId).toBe('p1');
-    expect(new Set(keyIds as string[])).toEqual(new Set(['lk-a', 'lk-b']));
+    expect(new Set(keyIds as string[])).toEqual(new Set(['lk-a-en', 'lk-a-de', 'lk-b']));
   });
 });

--- a/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
+++ b/extensions/sync-hook/src/services/content-synchronization/translation-strings-synchronization-service.ts
@@ -122,7 +122,10 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
           importContent.content.translationStrings.forEach((translationString) => {
             const { directusId } = translationString;
             if (itemIds.includes(directusId)) {
-              deleletedTranslationStrings.add(translationString.localazyKey.id);
+              // Each language has its own Localazy key id; deprecate them all, not just one.
+              Object.values(translationString.localazyKeys).forEach((localazyKey) => {
+                deleletedTranslationStrings.add(localazyKey.id);
+              });
             }
           });
 


### PR DESCRIPTION
## Summary

- New `localazy_sync_state` singleton (per-(language, Localazy key id) event cursor) wired through the installer alongside the other singletons. Auto-invalidates when `cursor_project_id` diverges from the connected project.
- Import service now fetches with `event: true` and applies a cursor-based filter immediately after fetch, before the parser. PATCH-then-mark write ordering: triples are only recorded after the Directus write resolves successfully.
- Throttled persistence (every ~10% of total work, min 50 keys) with merge-on-persist (take `max(event)` per cell on every save). Final flush at end-of-sync guarantees durability.
- "Import to Directus" button now runs incremental by default; a dropdown next to it exposes "Full Sync" which re-runs the same path with an empty in-memory cursor.
- Progress messages updated to match the design's decision 19 (`"Fetching translations from Localazy..."`, `"Found N changes across M languages..."`, `"Already up to date..."`, `"Full sync — rebuilding from scratch"`, final summary with elapsed time).

## Design

Settled in a grilling session captured in `Work/Localazy/Development/Directus extension 2.0 release - progress.md` (Obsidian). Key decisions:
- Cursor shape mirrors the Strapi plugin: `{ [lang]: { [keyId]: event } }`, stored as JSON on a singleton row.
- Auto-invalidate by project id — no manual reset on reconnect.
- Filter point: immediately after fetch, before parse. Parser stays oblivious to incremental sync.
- Filter predicate: include if no stored event, no API event, or `event > stored`. Undefined-event keys always included (safe mode).
- Persistence cadence: throttled flush + final flush; merge-on-persist makes concurrent syncs benign.

## Test plan

- [x] `npm run check` clean (lint + format + typecheck + tests; 101 → 143)
- [x] `npm run build` clean (both extensions, minified production build)
- [ ] Manual UI verification — not exercised in this worktree to avoid racing the dev server in the main session. The first-Import / second-Import-shows-up-to-date / Full-Sync-from-dropdown / change-translation-and-resync flows need to be exercised before merge.

## Out of scope (tracked follow-ups)

- Upload-side incremental sync (separate session is grilling the user on this now).
- Soft DB lock for concurrent sync prevention (needed once automated import lands).
- Orphan deletion handling (pre-existing gap).
- Cursor stale-entry pruning (Full Sync rebuilds; sufficient escape hatch).
- Per-language drilldown in the progress modal (decision 19 marked this optional; default view aggregates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)