### PR TITLE
PR 31/N (Stage 4): incremental upload sync

### DIFF
--- a/extensions/common/models/collections-data/sync-state.ts
+++ b/extensions/common/models/collections-data/sync-state.ts
@@ -47,7 +47,7 @@ export type SyncState = {
   cursor_project_id: string;
   /** Schema version of the cursor data. Bump when the storage shape changes. */
   cursor_version: number;
-  /** ISO timestamp of the last successful download sync. */
+  /** ISO timestamp of the last successful sync (upload or download — whichever ran last). */
   last_sync_at: string | null;
 };
 

--- a/extensions/common/models/collections-data/sync-state.ts
+++ b/extensions/common/models/collections-data/sync-state.ts
@@ -13,15 +13,36 @@ export type SyncCursor = {
 };
 
 /**
+ * Upload-sync cursor data, indexed by (collection, itemId). The recorded string is a
+ * 16-hex-character truncated SHA-256 of the canonical KV payload that would currently be
+ * uploaded to Localazy for that item. On the next upload sync we skip any (collection,
+ * itemId) whose currently-computed hash matches the stored value — meaning nothing about
+ * the upload payload has changed since the last successful push.
+ *
+ * Hash inputs intentionally include everything that affects the wire payload (enabled
+ * fields, source-language code, `upload_existing_translations` mode, the per-item field
+ * values), so any user-facing change (settings, schema, content edits) naturally yields a
+ * different hash and a re-push.
+ */
+export type UploadCursor = {
+  /** `{ [collection]: { [itemId]: hexHash16 } }` */
+  uploaded_hashes: Record<string, Record<string, string>>;
+};
+
+/**
  * Shape of the `localazy_sync_state` singleton row. Persisted as a single record per
- * Directus install; the cursor is serialized as JSON in `processed_keys`.
+ * Directus install; the download cursor is serialized as JSON in `processed_keys`, the
+ * upload cursor in `uploaded_hashes`.
  */
 export type SyncState = {
   /** JSON-encoded `SyncCursor['processed_keys']`. Default `'{}'`. */
   processed_keys: string;
+  /** JSON-encoded `UploadCursor['uploaded_hashes']`. Default `'{}'`. */
+  uploaded_hashes: string;
   /**
    * Localazy project id the cursor was last written against. If it changes (user
    * reconnected to a different project), the next sync auto-invalidates the cursor.
+   * Shared between download and upload — both flows invalidate on project change.
    */
   cursor_project_id: string;
   /** Schema version of the cursor data. Bump when the storage shape changes. */

--- a/extensions/common/services/translatable-collections-service.ts
+++ b/extensions/common/services/translatable-collections-service.ts
@@ -8,6 +8,7 @@ import { TranslatableContent } from '../models/translatable-content';
 import { FieldsUtilsService } from '../utilities/fields-utils-service';
 import { DirectusApi } from '../interfaces/directus-api';
 import { DirectusDataModel } from '../interfaces/directus-data-model';
+import { computeItemHash } from '../utilities/upload-cursor';
 
 type ResolveContentForCollectionReturn = {
   collection: string;
@@ -16,6 +17,25 @@ type ResolveContentForCollectionReturn = {
     fieldLanguageCodeField: string;
   }[];
   items: Item[];
+};
+
+/**
+ * Per-item slice returned by `fetchContentWithHashesByCollection`. `id` is the Directus
+ * item id; `hash` is the 16-hex-char SHA-256 of the canonical KV payload that would be
+ * uploaded for this item right now (using the current `enabledFields`, source language,
+ * `upload_existing_translations` mode, etc.); `content` is the assembled
+ * `TranslatableContent` slice covering only this item. The orchestrator filters by hash
+ * against the upload cursor, then merges the surviving slices into the global payload.
+ */
+export type CollectionItemWithHash = {
+  id: string | number;
+  hash: string;
+  content: TranslatableContent;
+};
+
+export type CollectionContentWithHashes = {
+  collection: string;
+  items: CollectionItemWithHash[];
 };
 
 export type TranslatableCollectionsServiceOptions = {
@@ -162,5 +182,69 @@ export class TranslatableCollectionsService {
     }
 
     return translatableContent;
+  }
+
+  /**
+   * Same fetch shape as `fetchContentFromTranslatableCollections`, but returns per-item
+   * slices with stable content hashes attached. The caller (the user-clicked Export
+   * orchestrator) filters the per-item list against the upload cursor and only assembles
+   * what remains.
+   *
+   * Hash inputs are the per-item slice of the canonical assembly output for "this item
+   * with the current settings" — meaning anything that affects the wire payload (enabled
+   * fields, source language code, `upload_existing_translations` mode via the fetched
+   * language set, field values) naturally changes the hash. We deliberately do NOT hash a
+   * synthetic "settings fingerprint" — the assembled per-item payload already reflects
+   * every settings effect that matters.
+   */
+  async fetchContentWithHashesByCollection(options: TranslatableCollectionsServiceOptions): Promise<CollectionContentWithHashes[]> {
+    const { enabledFields, settings, languages, translatableCollections } = options;
+    const { add, execute } = createAsyncQueue();
+
+    const enabledTranslatableCollections = translatableCollections.filter((collection) =>
+      enabledFields.find((field) => field.collection === collection.collection),
+    );
+
+    enabledTranslatableCollections.forEach((data) => {
+      add(async () =>
+        this.resolveContentForCollection({
+          collection: data.collection,
+          itemIds: data.itemIds || [],
+          translationTypeFields: await this.getTranslationTypeFieldsForCollection(data.collection),
+          languages,
+          languagesCollection: settings.language_collection,
+          languagesCollectionCodeField: settings.language_code_field,
+        }),
+      );
+    });
+
+    const results = await execute<ResolveContentForCollectionReturn>({ delayBetween: 50 });
+    const output: CollectionContentWithHashes[] = [];
+
+    for (const result of results) {
+      if (!result.data) continue;
+      const collectionFields = (await this.translatableCollectionsContent.getFieldsForCollection(result.data.collection)) || [];
+      const itemsWithHashes: CollectionItemWithHash[] = [];
+
+      for (const item of result.data.items) {
+        // Build the per-item content slice using the same assembly the multi-item path
+        // uses — so the hash mechanically reflects exactly what would go on the wire for
+        // this item under the current settings + enabled-fields configuration.
+        const content = ContentFromCollections.createContentFromCollectionItems({
+          collection: result.data.collection,
+          items: [item],
+          enabledFields,
+          collectionFields,
+          translatableFieldAttributes: result.data.translatableFieldAttributes,
+          settings,
+        });
+        const hash = await computeItemHash(content);
+        itemsWithHashes.push({ id: item.id, hash, content });
+      }
+
+      output.push({ collection: result.data.collection, items: itemsWithHashes });
+    }
+
+    return output;
   }
 }

--- a/extensions/common/utilities/upload-cursor.test.ts
+++ b/extensions/common/utilities/upload-cursor.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptyUploadCursor,
+  parseUploadCursor,
+  serializeUploadCursor,
+  recordUploadEntry,
+  mergeUploadCursor,
+  filterItemsByUploadCursor,
+  countUploadCursorEntries,
+  canonicalizeForHash,
+  computeItemHash,
+} from './upload-cursor';
+
+describe('createEmptyUploadCursor', () => {
+  it('returns a cursor with an empty uploaded_hashes map', () => {
+    expect(createEmptyUploadCursor()).toEqual({ uploaded_hashes: {} });
+  });
+});
+
+describe('parseUploadCursor', () => {
+  it('returns empty cursor for null / undefined / empty string', () => {
+    expect(parseUploadCursor(null)).toEqual({ uploaded_hashes: {} });
+    expect(parseUploadCursor(undefined)).toEqual({ uploaded_hashes: {} });
+    expect(parseUploadCursor('')).toEqual({ uploaded_hashes: {} });
+  });
+
+  it('parses a well-formed JSON map', () => {
+    const raw = JSON.stringify({ posts: { '1': 'abc123', '2': 'def456' }, pages: { '1': 'aaa' } });
+    expect(parseUploadCursor(raw)).toEqual({
+      uploaded_hashes: { posts: { '1': 'abc123', '2': 'def456' }, pages: { '1': 'aaa' } },
+    });
+  });
+
+  it('returns empty cursor for malformed JSON', () => {
+    expect(parseUploadCursor('{not-json')).toEqual({ uploaded_hashes: {} });
+  });
+
+  it('returns empty cursor for non-object JSON (array / string / number)', () => {
+    expect(parseUploadCursor('[1,2,3]')).toEqual({ uploaded_hashes: {} });
+    expect(parseUploadCursor('"hello"')).toEqual({ uploaded_hashes: {} });
+    expect(parseUploadCursor('42')).toEqual({ uploaded_hashes: {} });
+  });
+
+  it('drops non-string hash values silently', () => {
+    const raw = JSON.stringify({ posts: { '1': 'abc', '2': 42, '3': null, '4': 'def' } });
+    expect(parseUploadCursor(raw)).toEqual({ uploaded_hashes: { posts: { '1': 'abc', '4': 'def' } } });
+  });
+
+  it('drops empty-string hash values', () => {
+    const raw = JSON.stringify({ posts: { '1': 'abc', '2': '' } });
+    expect(parseUploadCursor(raw)).toEqual({ uploaded_hashes: { posts: { '1': 'abc' } } });
+  });
+
+  it('drops non-object per-collection buckets', () => {
+    const raw = JSON.stringify({ posts: { '1': 'abc' }, pages: 'broken', users: null });
+    expect(parseUploadCursor(raw)).toEqual({ uploaded_hashes: { posts: { '1': 'abc' } } });
+  });
+});
+
+describe('serializeUploadCursor', () => {
+  it('serializes the uploaded_hashes map to JSON', () => {
+    expect(serializeUploadCursor({ uploaded_hashes: { posts: { '1': 'abc' } } })).toBe('{"posts":{"1":"abc"}}');
+  });
+
+  it('serializes empty cursor to empty object string', () => {
+    expect(serializeUploadCursor(createEmptyUploadCursor())).toBe('{}');
+  });
+
+  it('round-trips through parseUploadCursor', () => {
+    const original = { uploaded_hashes: { posts: { '1': 'abc', '2': 'def' }, pages: { '1': 'aaa' } } };
+    expect(parseUploadCursor(serializeUploadCursor(original))).toEqual(original);
+  });
+});
+
+describe('recordUploadEntry', () => {
+  it('creates a new per-collection bucket if one does not exist', () => {
+    const cursor = createEmptyUploadCursor();
+    recordUploadEntry(cursor, 'posts', '1', 'abc');
+    expect(cursor.uploaded_hashes).toEqual({ posts: { '1': 'abc' } });
+  });
+
+  it('records into an existing bucket without disturbing other cells', () => {
+    const cursor = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    recordUploadEntry(cursor, 'posts', '2', 'def');
+    expect(cursor.uploaded_hashes).toEqual({ posts: { '1': 'abc', '2': 'def' } });
+  });
+
+  it('overwrites the prior hash for the same cell', () => {
+    const cursor = { uploaded_hashes: { posts: { '1': 'oldhash' } } };
+    recordUploadEntry(cursor, 'posts', '1', 'newhash');
+    expect(cursor.uploaded_hashes.posts).toEqual({ '1': 'newhash' });
+  });
+
+  it('is a no-op when hash is empty string', () => {
+    const cursor = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    recordUploadEntry(cursor, 'posts', '1', '');
+    expect(cursor.uploaded_hashes.posts).toEqual({ '1': 'abc' });
+  });
+
+  it('does not create a bucket when hash is empty', () => {
+    const cursor = createEmptyUploadCursor();
+    recordUploadEntry(cursor, 'pages', '1', '');
+    expect(cursor.uploaded_hashes).toEqual({});
+  });
+});
+
+describe('mergeUploadCursor', () => {
+  it('returns identity-equivalent of either cursor when the other is empty', () => {
+    const a = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    const empty = createEmptyUploadCursor();
+    expect(mergeUploadCursor(a, empty)).toEqual(a);
+    expect(mergeUploadCursor(empty, a)).toEqual(a);
+  });
+
+  it('combines disjoint collections', () => {
+    const a = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    const b = { uploaded_hashes: { pages: { '2': 'def' } } };
+    expect(mergeUploadCursor(a, b)).toEqual({ uploaded_hashes: { posts: { '1': 'abc' }, pages: { '2': 'def' } } });
+  });
+
+  it('combines disjoint items within the same collection', () => {
+    const a = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    const b = { uploaded_hashes: { posts: { '2': 'def' } } };
+    expect(mergeUploadCursor(a, b)).toEqual({ uploaded_hashes: { posts: { '1': 'abc', '2': 'def' } } });
+  });
+
+  it('right-hand cursor wins for overlapping cells (latest run is the truth)', () => {
+    const a = { uploaded_hashes: { posts: { '1': 'oldhash', '2': 'kept' } } };
+    const b = { uploaded_hashes: { posts: { '1': 'newhash' } } };
+    expect(mergeUploadCursor(a, b)).toEqual({ uploaded_hashes: { posts: { '1': 'newhash', '2': 'kept' } } });
+  });
+
+  it('does not mutate the inputs', () => {
+    const a = { uploaded_hashes: { posts: { '1': 'abc' } } };
+    const b = { uploaded_hashes: { posts: { '1': 'def' } } };
+    mergeUploadCursor(a, b);
+    expect(a).toEqual({ uploaded_hashes: { posts: { '1': 'abc' } } });
+    expect(b).toEqual({ uploaded_hashes: { posts: { '1': 'def' } } });
+  });
+});
+
+describe('filterItemsByUploadCursor', () => {
+  it('returns all items when no bucket exists for the collection (first-time export)', () => {
+    const items = [
+      { id: 1, hash: 'a' },
+      { id: 2, hash: 'b' },
+    ];
+    expect(filterItemsByUploadCursor('posts', items, createEmptyUploadCursor())).toEqual(items);
+  });
+
+  it('skips items whose current hash matches the stored hash', () => {
+    const items = [
+      { id: 1, hash: 'a' },
+      { id: 2, hash: 'b' },
+    ];
+    const cursor = { uploaded_hashes: { posts: { '1': 'a', '2': 'b' } } };
+    expect(filterItemsByUploadCursor('posts', items, cursor)).toEqual([]);
+  });
+
+  it('includes items whose current hash differs from the stored hash', () => {
+    const items = [{ id: 1, hash: 'newhash' }];
+    const cursor = { uploaded_hashes: { posts: { '1': 'oldhash' } } };
+    expect(filterItemsByUploadCursor('posts', items, cursor)).toEqual(items);
+  });
+
+  it('includes items not present in the cursor (newly-added items)', () => {
+    const items = [
+      { id: 1, hash: 'a' },
+      { id: 2, hash: 'b' },
+    ];
+    const cursor = { uploaded_hashes: { posts: { '1': 'a' } } };
+    expect(filterItemsByUploadCursor('posts', items, cursor)).toEqual([{ id: 2, hash: 'b' }]);
+  });
+
+  it('handles numeric item ids by stringifying for lookup', () => {
+    const items = [{ id: 42, hash: 'a' }];
+    const cursor = { uploaded_hashes: { posts: { '42': 'a' } } };
+    expect(filterItemsByUploadCursor('posts', items, cursor)).toEqual([]);
+  });
+
+  it('handles string item ids (UUIDs)', () => {
+    const items = [{ id: 'uuid-xyz', hash: 'a' }];
+    const cursor = { uploaded_hashes: { posts: { 'uuid-xyz': 'a' } } };
+    expect(filterItemsByUploadCursor('posts', items, cursor)).toEqual([]);
+  });
+});
+
+describe('countUploadCursorEntries', () => {
+  it('returns 0 for empty cursor', () => {
+    expect(countUploadCursorEntries(createEmptyUploadCursor())).toBe(0);
+  });
+
+  it('sums per-collection map sizes', () => {
+    const cursor = { uploaded_hashes: { posts: { '1': 'a', '2': 'b' }, pages: { '1': 'c' } } };
+    expect(countUploadCursorEntries(cursor)).toBe(3);
+  });
+});
+
+describe('canonicalizeForHash', () => {
+  it('sorts object keys deterministically', () => {
+    expect(canonicalizeForHash({ b: 1, a: 2 })).toBe(canonicalizeForHash({ a: 2, b: 1 }));
+  });
+
+  it('sorts nested object keys recursively', () => {
+    expect(canonicalizeForHash({ outer: { z: 1, a: 2 } })).toBe(canonicalizeForHash({ outer: { a: 2, z: 1 } }));
+  });
+
+  it('omits undefined values from objects (treats as absent)', () => {
+    expect(canonicalizeForHash({ a: 1, b: undefined })).toBe(canonicalizeForHash({ a: 1 }));
+  });
+
+  it('preserves null verbatim (distinct from absent)', () => {
+    expect(canonicalizeForHash({ a: null })).not.toBe(canonicalizeForHash({}));
+  });
+
+  it('preserves empty strings verbatim', () => {
+    expect(canonicalizeForHash({ a: '' })).not.toBe(canonicalizeForHash({}));
+  });
+
+  it('preserves whitespace verbatim', () => {
+    expect(canonicalizeForHash({ a: '  hello  ' })).not.toBe(canonicalizeForHash({ a: 'hello' }));
+  });
+
+  it('preserves array order (order is part of identity)', () => {
+    expect(canonicalizeForHash([1, 2, 3])).not.toBe(canonicalizeForHash([3, 2, 1]));
+  });
+
+  it('normalizes undefined inside arrays to null (JSON does not allow undefined elements)', () => {
+    // Both canonicalizations resolve undefined-in-array → null, so they should be equal.
+    expect(canonicalizeForHash([1, undefined, 3])).toBe(canonicalizeForHash([1, null, 3]));
+  });
+
+  it('distinguishes numbers from their string representations', () => {
+    expect(canonicalizeForHash({ a: 1 })).not.toBe(canonicalizeForHash({ a: '1' }));
+  });
+
+  it('handles deeply nested structures', () => {
+    const v1 = { collection: 'posts', items: { 1: { en: { title: 'hi' } } } };
+    const v2 = { items: { 1: { en: { title: 'hi' } } }, collection: 'posts' };
+    expect(canonicalizeForHash(v1)).toBe(canonicalizeForHash(v2));
+  });
+
+  it('returns "{}" for an empty object', () => {
+    expect(canonicalizeForHash({})).toBe('{}');
+  });
+
+  it('returns "[]" for an empty array', () => {
+    expect(canonicalizeForHash([])).toBe('[]');
+  });
+});
+
+describe('computeItemHash', () => {
+  it('produces a 16-character hex string', async () => {
+    const hash = await computeItemHash({ a: 1 });
+    expect(hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('produces the same hash for equivalent inputs (key order independent)', async () => {
+    const h1 = await computeItemHash({ a: 1, b: 2 });
+    const h2 = await computeItemHash({ b: 2, a: 1 });
+    expect(h1).toBe(h2);
+  });
+
+  it('produces different hashes for different inputs', async () => {
+    const h1 = await computeItemHash({ a: 1 });
+    const h2 = await computeItemHash({ a: 2 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('produces different hashes for null vs absent fields', async () => {
+    const h1 = await computeItemHash({ a: null });
+    const h2 = await computeItemHash({});
+    expect(h1).not.toBe(h2);
+  });
+
+  it('produces equal hashes for undefined vs absent fields', async () => {
+    const h1 = await computeItemHash({ a: 1, b: undefined });
+    const h2 = await computeItemHash({ a: 1 });
+    expect(h1).toBe(h2);
+  });
+
+  it('produces equal hashes for empty objects regardless of construction', async () => {
+    const h1 = await computeItemHash({});
+    const h2 = await computeItemHash(Object.create(null));
+    expect(h1).toBe(h2);
+  });
+
+  it('produces stable hashes across calls for the same input', async () => {
+    const input = { collection: 'posts', items: { 1: { en: { title: 'hello' } } } };
+    const h1 = await computeItemHash(input);
+    const h2 = await computeItemHash(input);
+    expect(h1).toBe(h2);
+  });
+
+  it('distinguishes empty string from absent', async () => {
+    const h1 = await computeItemHash({ a: '' });
+    const h2 = await computeItemHash({});
+    expect(h1).not.toBe(h2);
+  });
+
+  it('distinguishes whitespace differences', async () => {
+    const h1 = await computeItemHash({ a: 'hello' });
+    const h2 = await computeItemHash({ a: 'hello ' });
+    expect(h1).not.toBe(h2);
+  });
+});

--- a/extensions/common/utilities/upload-cursor.ts
+++ b/extensions/common/utilities/upload-cursor.ts
@@ -1,0 +1,185 @@
+import { UploadCursor } from '../models/collections-data/sync-state';
+
+/**
+ * Pure helpers around the upload-sync cursor. The cursor is a per-(collection, itemId)
+ * map storing the 16-hex-character SHA-256 hash of the canonical KV payload last
+ * successfully uploaded for that item. Everything here is intentionally side-effect-free
+ * — the orchestration (loading the singleton, persisting back) lives in the call site so
+ * this stays testable.
+ *
+ * Shape: `{ [collection]: { [itemId]: hexHash16 } }`. Mirrors the download cursor's
+ * (`sync-cursor.ts`) `parse/serialize/merge/filter` quartet so the call site can stay
+ * symmetric.
+ */
+
+export function createEmptyUploadCursor(): UploadCursor {
+  return { uploaded_hashes: {} };
+}
+
+/**
+ * Parse a JSON-serialized `uploaded_hashes` blob (the on-disk format used by the
+ * `localazy_sync_state` singleton). Returns an empty cursor for any malformed input —
+ * the cursor is a best-effort cache, not authoritative state, so we never throw and
+ * never let a corrupt row block sync. The worst case of an empty parse is "re-upload
+ * everything once", which is the desired fallback.
+ */
+export function parseUploadCursor(raw: string | null | undefined): UploadCursor {
+  if (!raw) return createEmptyUploadCursor();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return createEmptyUploadCursor();
+    const uploaded: UploadCursor['uploaded_hashes'] = {};
+    for (const [collection, perCollection] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!perCollection || typeof perCollection !== 'object') continue;
+      const cleaned: Record<string, string> = {};
+      for (const [itemId, hash] of Object.entries(perCollection as Record<string, unknown>)) {
+        if (typeof hash === 'string' && hash.length > 0) {
+          cleaned[itemId] = hash;
+        }
+      }
+      uploaded[collection] = cleaned;
+    }
+    return { uploaded_hashes: uploaded };
+  } catch {
+    return createEmptyUploadCursor();
+  }
+}
+
+export function serializeUploadCursor(cursor: UploadCursor): string {
+  return JSON.stringify(cursor.uploaded_hashes);
+}
+
+/**
+ * Record one successfully-uploaded `(collection, itemId, hash)` triple in the in-memory
+ * cursor. Mutates `cursor` for performance — sync writes happen in a hot loop. Overwrites
+ * any prior hash for the same cell (the new hash, by definition, reflects what we just
+ * pushed).
+ */
+export function recordUploadEntry(cursor: UploadCursor, collection: string, itemId: string, hash: string): void {
+  if (!hash) return;
+  const bucket = cursor.uploaded_hashes[collection] || (cursor.uploaded_hashes[collection] = {});
+  bucket[itemId] = hash;
+}
+
+/**
+ * Merge two cursors cell-by-cell, taking the right-hand value when both sides have an
+ * entry. The use case (persisting after a sync) treats `b` (the in-memory cursor from
+ * this run) as the source of truth — `a` is whatever was on disk before we started, and
+ * if both sides claim a hash for the same cell, the just-completed run wins. Pure —
+ * neither input is mutated, the result is a fresh object.
+ */
+export function mergeUploadCursor(a: UploadCursor, b: UploadCursor): UploadCursor {
+  const result: UploadCursor['uploaded_hashes'] = {};
+  const allCollections = new Set([...Object.keys(a.uploaded_hashes), ...Object.keys(b.uploaded_hashes)]);
+  for (const collection of allCollections) {
+    const left = a.uploaded_hashes[collection] || {};
+    const right = b.uploaded_hashes[collection] || {};
+    const allItems = new Set([...Object.keys(left), ...Object.keys(right)]);
+    const merged: Record<string, string> = {};
+    for (const itemId of allItems) {
+      const rv = right[itemId];
+      const lv = left[itemId];
+      // Right-hand wins when present; otherwise keep the left-hand entry.
+      merged[itemId] = rv !== undefined ? rv : lv!;
+    }
+    result[collection] = merged;
+  }
+  return { uploaded_hashes: result };
+}
+
+/**
+ * Filter a list of `(itemId, currentHash)` pairs down to those that need (re-)uploading
+ * according to the cursor. An item is included iff its current hash differs from the
+ * stored hash for the same `(collection, itemId)` cell — i.e. something about its
+ * upload payload has changed since the last successful push.
+ *
+ * If the cursor doesn't have an entry for this `(collection, itemId)`, the item is
+ * included (first-time export, or a previously-skipped item now needing push).
+ */
+export function filterItemsByUploadCursor<T extends { id: string | number; hash: string }>(
+  collection: string,
+  items: T[],
+  cursor: UploadCursor,
+): T[] {
+  const bucket = cursor.uploaded_hashes[collection];
+  if (!bucket) return items;
+  return items.filter((it) => {
+    const stored = bucket[String(it.id)];
+    if (stored === undefined) return true;
+    return stored !== it.hash;
+  });
+}
+
+/**
+ * Count the total cells in a cursor (sum of per-collection map sizes). Useful for
+ * debugging / progress reporting, not for correctness.
+ */
+export function countUploadCursorEntries(cursor: UploadCursor): number {
+  let total = 0;
+  for (const perCollection of Object.values(cursor.uploaded_hashes)) {
+    total += Object.keys(perCollection).length;
+  }
+  return total;
+}
+
+/**
+ * Canonicalize an arbitrary JSON-compatible value into a stable string form suitable for
+ * hashing.
+ *
+ * Invariants:
+ *   - Object keys are deep-sorted (recursive) so `{ a, b }` and `{ b, a }` hash equal.
+ *   - `undefined` is treated as absent (omitted from both top-level and nested objects),
+ *     matching the design's "what would actually go on the wire" semantics — Localazy
+ *     never sees `undefined`, so two payloads differing only by an undefined field are
+ *     identical.
+ *   - `null` is preserved verbatim (semantically distinct from absent).
+ *   - Empty strings are preserved verbatim.
+ *   - Whitespace is preserved (no trimming) — Localazy sees what we send.
+ *   - Numbers use `JSON.stringify` defaults (NaN/Infinity → `null`, but we don't expect
+ *     those in real upload payloads). Booleans, strings: native `JSON.stringify`.
+ *   - Arrays: positional, NOT sorted (order is part of identity).
+ */
+export function canonicalizeForHash(value: unknown): string {
+  return JSON.stringify(canonicalizeValue(value));
+}
+
+function canonicalizeValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (Array.isArray(value)) {
+    return value.map((v) => (v === undefined ? null : canonicalizeValue(v)));
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const sorted: Record<string, unknown> = {};
+    for (const [k, v] of entries) {
+      sorted[k] = canonicalizeValue(v);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Compute the 16-hex-character truncated SHA-256 hash of an arbitrary JSON-compatible
+ * value. Uses Web Crypto's `crypto.subtle.digest('SHA-256', ...)`, which is available in
+ * both browser (module) and Node 22 (sync-hook + test) runtimes.
+ *
+ * 16 hex chars = 64 bits of collision space. At expected scales (tens of thousands of
+ * items per install), this is well below the birthday-paradox threshold and adequate for
+ * a cache-busting cursor where the cost of a collision is "we skipped an item that
+ * actually changed" — which the next manual Full Upload trivially resolves.
+ */
+export async function computeItemHash(value: unknown): Promise<string> {
+  const canonical = canonicalizeForHash(value);
+  const bytes = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const view = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < 8; i += 1) {
+    hex += view[i]!.toString(16).padStart(2, '0');
+  }
+  return hex;
+}

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -12,7 +12,8 @@
       <sync-action-buttons
         :has-changes="hasChanges"
         :disable-sync="!someTranslatableFieldsChecked && !synchronizeTranslationStrings"
-        @upload="onExport"
+        @upload="onExport('incremental')"
+        @upload-full="onExport('full')"
         @download="onImport('incremental')"
         @download-full="onImport('full')"
         @save-settings="onSaveSettings({ notify: true })"

--- a/extensions/module/src/components/Sync/SyncActionButtons.vue
+++ b/extensions/module/src/components/Sync/SyncActionButtons.vue
@@ -1,12 +1,27 @@
 <template>
   <div>
     <div class="sync-action-buttons">
-      <v-button :disabled="disableSyncButtons" secondary @click="$emit('upload')"> Export to Localazy </v-button>
-      <div class="import-group">
+      <div class="sync-group">
+        <v-button :disabled="disableSyncButtons" secondary @click="$emit('upload')"> Export to Localazy </v-button>
+        <v-menu show-arrow placement="bottom-end">
+          <template #activator="{ toggle }">
+            <v-button :disabled="disableSyncButtons" secondary class="sync-options" @click="toggle">
+              <v-icon name="expand_more" />
+            </v-button>
+          </template>
+          <v-list>
+            <v-list-item clickable @click="$emit('upload-full')">
+              <v-list-item-icon><v-icon name="refresh" /></v-list-item-icon>
+              <v-list-item-content>Full Upload (re-push everything)</v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </div>
+      <div class="sync-group">
         <v-button :disabled="disableSyncButtons" secondary @click="$emit('download')"> Import to Directus </v-button>
         <v-menu show-arrow placement="bottom-end">
           <template #activator="{ toggle }">
-            <v-button :disabled="disableSyncButtons" secondary class="import-options" @click="toggle">
+            <v-button :disabled="disableSyncButtons" secondary class="sync-options" @click="toggle">
               <v-icon name="expand_more" />
             </v-button>
           </template>
@@ -30,7 +45,9 @@ import { useLocalazyStore } from '../../stores/localazy-store';
 
 // `download` runs an incremental sync (default). `download-full` triggers a Full Sync,
 // which rebuilds from scratch by running the same flow with an empty in-memory cursor.
-defineEmits(['download', 'download-full', 'upload', 'save-settings']);
+// `upload` mirrors `download` for the export flow (incremental by default), and
+// `upload-full` triggers a Full Upload (re-push every item regardless of cursor state).
+defineEmits(['download', 'download-full', 'upload', 'upload-full', 'save-settings']);
 
 const props = defineProps({
   hasChanges: {
@@ -56,12 +73,12 @@ const disableSyncButtons = computed(() => props.disableSync || isNotConnectedToL
   gap: 4px;
 }
 
-.import-group {
+.sync-group {
   display: flex;
   gap: 2px;
 }
 
-.import-options {
+.sync-options {
   --v-button-min-width: 28px;
   --v-button-padding: 0 8px;
 }

--- a/extensions/module/src/composables/use-export-to-localazy.ts
+++ b/extensions/module/src/composables/use-export-to-localazy.ts
@@ -12,11 +12,41 @@ import { useProgressTrackerStore } from '../stores/progress-tracker-store';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { useErrorsStore } from '../stores/errors-store';
 import { ExportToLocalazyCommonService } from '../../../common/services/export-to-localazy-common-service';
+import { UploadedTriple } from '../models/upload-write-result';
+
+/**
+ * Per-collection list of upload-tracked items. The orchestrator passes only the items it
+ * wants written back to the upload cursor; translation strings are intentionally absent
+ * (decision 2: always full re-push, never cursor-tracked).
+ */
+export type UploadTrackedItem = { id: string | number; hash: string };
 
 type ExportContentToLocalazy = {
   content: TranslatableContent;
   settings: Settings;
+  /**
+   * Items the caller wants reported back via `onWritten` after all containing chunks
+   * resolve successfully. Keyed by collection. The cursor write step happens here so the
+   * caller doesn't have to replicate the chunk-splitting math.
+   */
+  trackedItems?: Map<string, UploadTrackedItem[]>;
+  /**
+   * Invoked once per item, after every chunk that item contributed to has resolved
+   * successfully. Per-item-after-all-chunks-succeed: a partial upload (some languages
+   * succeeded, others failed) must NOT advance the cursor.
+   */
+  onWritten?: (uploads: UploadedTriple[]) => void;
 };
+
+/**
+ * Returns the non-meta top-level keys of a chunk in deterministic order. Mirrors the
+ * filter `splitContentIntoChunks` applies; used to figure out which `(collection, item)`
+ * pairs belong to which chunk so the orchestrator can mark items only after all their
+ * chunks succeed.
+ */
+function nonMetaTopLevelKeys(chunk: KeyValueEntry): string[] {
+  return Object.keys(chunk).filter((k) => !k.startsWith('@meta:'));
+}
 
 export const useExportToLocalazy = (token: Ref<string>) => {
   const loading = ref(false);
@@ -25,10 +55,27 @@ export const useExportToLocalazy = (token: Ref<string>) => {
   const { addLocalazyError } = useErrorsStore();
   const { localazyProject, projectId, localazyUser } = storeToRefs(useLocalazyStore());
 
-  const createExportPromisesForLanguage = (content: KeyValueEntry, language: string) => {
+  /**
+   * Build the export task list for one language. Returns the queued tasks plus a list of
+   * `(chunkId, topLevelKeys)` pairs so the orchestrator can compute per-item chunk
+   * membership before the queue executes.
+   */
+  const createExportTasksForLanguage = (
+    content: KeyValueEntry,
+    language: string,
+    chunkSuccesses: Set<string>,
+  ): {
+    tasks: Array<() => Promise<void>>;
+    chunkAssignments: Array<{ chunkId: string; topLevelKeys: string[] }>;
+  } => {
     const contentChunks = ContentFromCollections.splitContentIntoChunks(content);
+    const chunkAssignments = contentChunks.map((chunk, index) => ({
+      chunkId: `${language}:${index}`,
+      topLevelKeys: nonMetaTopLevelKeys(chunk),
+    }));
 
-    const importPromises = contentChunks.map((chunk, index) => async () => {
+    const tasks = contentChunks.map((chunk, index) => async () => {
+      const chunkId = `${language}:${index}`;
       addProgressMessage({
         id: ProgressTrackerId.IMPORTED_CONTENT_CHUNK,
         message: `(${language}) Exporting ${index + 1} / ${contentChunks.length} content chunks`,
@@ -36,6 +83,7 @@ export const useExportToLocalazy = (token: Ref<string>) => {
 
       return ExportToLocalazyCommonService.exportToLocalazy(token.value, projectId.value, chunk, language)
         .then(() => {
+          chunkSuccesses.add(chunkId);
           upsertProgressMessage(ProgressTrackerId.IMPORTED_CONTENT_CHUNK, {
             message: `(${language}) Export ${index + 1} / ${contentChunks.length} content chunks`,
           });
@@ -45,11 +93,11 @@ export const useExportToLocalazy = (token: Ref<string>) => {
         });
     });
 
-    return importPromises;
+    return { tasks, chunkAssignments };
   };
 
   const exportContentToLocalazy = async (data: ExportContentToLocalazy) => {
-    const { content, settings } = data;
+    const { content, settings, trackedItems, onWritten } = data;
     loading.value = true;
 
     const directusSourceLanguageAsLocalazyLanguage = ExportToLocalazyCommonService.getDirectusSourceLanguageAsLocalazyLanguage({
@@ -59,9 +107,36 @@ export const useExportToLocalazy = (token: Ref<string>) => {
 
     const nothingToExport = isEmpty(content.sourceLanguage) && Object.values(content.otherLanguages).every(isEmpty);
 
-    add(createExportPromisesForLanguage(content.sourceLanguage, directusSourceLanguageAsLocalazyLanguage));
+    // Chunk-level success tracking. Items report success only after every chunk they
+    // contributed to has landed in this set.
+    const chunkSuccesses = new Set<string>();
+    // Per-(collection, itemId) chunk membership. An item's translations may land in
+    // multiple chunks (different languages, or — pathologically — different chunk slots
+    // when collection count exceeds CHUNK_LIMIT).
+    const chunkMembership = new Map<string /* collection.itemId */, Set<string /* chunkId */>>();
+
+    function recordChunkAssignment(chunkId: string, topLevelKeys: string[]) {
+      if (!trackedItems) return;
+      topLevelKeys.forEach((collectionName) => {
+        const items = trackedItems.get(collectionName);
+        if (!items) return;
+        items.forEach((item) => {
+          const cellKey = `${collectionName}.${String(item.id)}`;
+          const set = chunkMembership.get(cellKey) || new Set<string>();
+          set.add(chunkId);
+          chunkMembership.set(cellKey, set);
+        });
+      });
+    }
+
+    const sourceLangPlan = createExportTasksForLanguage(content.sourceLanguage, directusSourceLanguageAsLocalazyLanguage, chunkSuccesses);
+    sourceLangPlan.chunkAssignments.forEach(({ chunkId, topLevelKeys }) => recordChunkAssignment(chunkId, topLevelKeys));
+    add(sourceLangPlan.tasks);
+
     Object.entries(content.otherLanguages).forEach(([language, languageContent]) => {
-      add(createExportPromisesForLanguage(languageContent, language));
+      const plan = createExportTasksForLanguage(languageContent, language, chunkSuccesses);
+      plan.chunkAssignments.forEach(({ chunkId, topLevelKeys }) => recordChunkAssignment(chunkId, topLevelKeys));
+      add(plan.tasks);
     });
 
     if (localazyProject.value) {
@@ -71,6 +146,31 @@ export const useExportToLocalazy = (token: Ref<string>) => {
       });
 
       await execute({ delayBetween: 150 });
+
+      // After all chunks resolve, fire onWritten for every tracked item whose membership
+      // is a subset of `chunkSuccesses`. Items that didn't end up in any chunk (e.g. they
+      // assembled to empty content) have an empty membership set, and ∅ ⊆ any set —
+      // they're correctly reported as written (the empty hash is recorded so subsequent
+      // syncs skip them too).
+      if (trackedItems && onWritten) {
+        const uploads: UploadedTriple[] = [];
+        trackedItems.forEach((items, collection) => {
+          items.forEach((item) => {
+            const cellKey = `${collection}.${String(item.id)}`;
+            const membership = chunkMembership.get(cellKey) || new Set<string>();
+            let allSucceeded = true;
+            membership.forEach((chunkId) => {
+              if (!chunkSuccesses.has(chunkId)) allSucceeded = false;
+            });
+            if (allSucceeded) {
+              uploads.push({ collection, itemId: String(item.id), hash: item.hash });
+            }
+          });
+        });
+        if (uploads.length > 0) {
+          onWritten(uploads);
+        }
+      }
 
       loading.value = false;
       addProgressMessage({

--- a/extensions/module/src/composables/use-export-to-localazy.ts
+++ b/extensions/module/src/composables/use-export-to-localazy.ts
@@ -1,6 +1,5 @@
 import { storeToRefs } from 'pinia';
 import { Ref, ref } from 'vue';
-import { isEmpty } from 'lodash';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 import { Settings } from '../../../common/models/collections-data/settings';
 import { KeyValueEntry } from '../../../common/models/localazy-key-entry';
@@ -105,8 +104,6 @@ export const useExportToLocalazy = (token: Ref<string>) => {
       directusSourceLanguage: settings.source_language,
     });
 
-    const nothingToExport = isEmpty(content.sourceLanguage) && Object.values(content.otherLanguages).every(isEmpty);
-
     // Chunk-level success tracking. Items report success only after every chunk they
     // contributed to has landed in this set.
     const chunkSuccesses = new Set<string>();
@@ -173,10 +170,10 @@ export const useExportToLocalazy = (token: Ref<string>) => {
       }
 
       loading.value = false;
-      addProgressMessage({
-        id: ProgressTrackerId.EXPORT_FINISHED,
-        message: nothingToExport ? 'Nothing to export from selected sources' : 'Export finished',
-      });
+      // The orchestrator (`onExport`) owns the final summary message — including the
+      // empty-content short-circuit ("All items already uploaded — nothing to push") and
+      // the populated summary ("Uploaded N items in T.Ts."). Adding `EXPORT_FINISHED`
+      // here too would render a duplicate row in the progress modal.
       // Analytics is fire-and-forget; export completion shouldn't block on telemetry.
       void AnalyticsService.trackUploadToLocalazy(
         ExportToLocalazyCommonService.getPayloadForUploadAnalytics({

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -255,9 +255,18 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       }
 
       const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+      // `writtenSinceStart` counts only collection-content items successfully marked via
+      // the cursor — translation strings always full-re-push and aren't tracked. When
+      // only translation strings flow through, that counter stays at 0 even though work
+      // happened; the generic "Upload completed" message reflects that case honestly
+      // without claiming a count we can't verify.
+      const finalMessage =
+        writtenSinceStart > 0
+          ? `Uploaded ${writtenSinceStart} ${writtenSinceStart === 1 ? 'item' : 'items'} in ${elapsedSec}s.`
+          : `Upload completed in ${elapsedSec}s.`;
       addProgressMessage({
         id: ProgressTrackerId.UPLOAD_FINISHED,
-        message: `Uploaded ${writtenSinceStart} ${writtenSinceStart === 1 ? 'item' : 'items'} in ${elapsedSec}s.`,
+        message: finalMessage,
       });
     } finally {
       loading.value = false;

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -3,7 +3,7 @@ import { Ref, computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 import { EnabledFieldsService } from '../../../common/utilities/enabled-fields-service';
-import { useExportToLocalazy } from './use-export-to-localazy';
+import { useExportToLocalazy, UploadTrackedItem } from './use-export-to-localazy';
 import { useImportFromLocalazy } from './use-import-from-localazy';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { useLocalazySettingsStore } from '../stores/localazy-settings-store';
@@ -18,6 +18,7 @@ import { useTranslatableCollections } from './use-translatable-collections';
 import { useTranslationStringsContent } from './use-translation-strings-content';
 import { EnabledField } from '../../../common/models/collections-data/content-transfer-setup';
 import { summarizeLocalazyContent } from '../utils/summarize-localazy-content';
+import { summarizeUploadContent } from '../utils/summarize-upload-content';
 import { AnalyticsService } from '../../../common/services/analytics-service';
 import { ExportToLocalazyCommonService } from '../../../common/services/export-to-localazy-common-service';
 import {
@@ -29,8 +30,18 @@ import {
   recordCursorEntry,
   serializeCursor,
 } from '../../../common/utilities/sync-cursor';
-import { CURSOR_VERSION, SyncCursor } from '../../../common/models/collections-data/sync-state';
+import {
+  createEmptyUploadCursor,
+  filterItemsByUploadCursor,
+  mergeUploadCursor,
+  parseUploadCursor,
+  recordUploadEntry,
+  serializeUploadCursor,
+} from '../../../common/utilities/upload-cursor';
+import { CURSOR_VERSION, SyncCursor, UploadCursor } from '../../../common/models/collections-data/sync-state';
+import { TranslatableContent } from '../../../common/models/translatable-content';
 import { WrittenTriple } from '../models/sync-write-result';
+import { UploadedTriple } from '../models/upload-write-result';
 import { useDirectusNotificationsStore } from './use-directus-stores';
 
 type SyncMode = 'incremental' | 'full';
@@ -44,7 +55,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   const { enabledFields, synchronizeTranslationStrings } = data;
 
   const { resolveExportLanguages, resolveImportLanguages } = useDirectusLanguages();
-  const { fetchContentFromTranslatableCollections } = useTranslatableCollections();
+  const { fetchContentWithHashesByCollection } = useTranslatableCollections();
   const { fetchTranslationStrings } = useTranslationStringsContent();
   const { translatableCollections } = useCollectionsOrganizer();
   const { upsertFromLocalazyContent } = useDirectusLocalazyAdapter();
@@ -89,24 +100,75 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     }
   }
 
-  async function onExport() {
+  /**
+   * Upload-cursor save with merge-on-persist: re-read the latest on-disk cursor, take the
+   * just-completed run's hashes as truth, write the result. Makes concurrent syncs benign
+   * — the loser never clobbers the winner. `cursor_project_id` is bumped to the current
+   * project on every save so subsequent reads correctly auto-invalidate when the user
+   * reconnects to a different project.
+   *
+   * The merge prefers the in-memory cursor on overlapping cells: the in-memory hash
+   * reflects what we *just* pushed, so it supersedes any stale on-disk hash. Cells we
+   * didn't touch this run are preserved from disk.
+   */
+  async function persistUploadCursor(inMemory: UploadCursor) {
+    try {
+      await syncStateStore.reload();
+      const onDisk = parseUploadCursor(syncStateData.value.uploaded_hashes);
+      const merged = mergeUploadCursor(onDisk, inMemory);
+      await syncStateStore.save({
+        uploaded_hashes: serializeUploadCursor(merged),
+        cursor_project_id: localazyProject.value?.id || '',
+        cursor_version: CURSOR_VERSION,
+        last_sync_at: new Date().toISOString(),
+      });
+    } catch {
+      // The error has already been surfaced via the errors store inside `save`. We
+      // intentionally swallow it here so a flush failure can't take down the sync; the
+      // next flush attempt will retry, and the final flush at end-of-sync acts as a
+      // last-resort backstop.
+    }
+  }
+
+  async function onExport(mode: SyncMode = 'incremental') {
     loading.value = true;
     showProgress.value = true;
+    const startedAt = Date.now();
+
+    addProgressMessage({
+      id: ProgressTrackerId.UPLOAD_MODE_HEADER,
+      message: mode === 'full' ? 'Full upload — re-pushing everything' : 'Incremental upload',
+    });
     addProgressMessage({
       id: ProgressTrackerId.PREPARING_EXPORT,
-      message: 'Preparing Directus data for export',
+      message: 'Preparing items for upload...',
     });
     // Save settings is fire-and-forget; errors surface via the errors store inside onSaveSettings.
     void onSaveSettings();
     try {
       const exportLanguages = await resolveExportLanguages(settings.value);
-      const [translationStrings, collectionsContent] = await Promise.all([
+
+      // Load + auto-invalidate the on-disk upload cursor against the current project.
+      //   - Incremental mode: use the on-disk cursor unless the project id has changed,
+      //     in which case we treat it as empty (fresh project = fresh cursor).
+      //   - Full Upload mode: start from an empty cursor. We do NOT wipe the persisted
+      //     cursor here — merge-on-persist gives precedence to the in-memory cursor for
+      //     cells we touched, and preserves disk entries for cells we didn't.
+      const baseUploadCursor: UploadCursor =
+        mode === 'full' || syncStateData.value.cursor_project_id !== (localazyProject.value?.id || '')
+          ? createEmptyUploadCursor()
+          : parseUploadCursor(syncStateData.value.uploaded_hashes);
+      // Tracks only what we successfully pushed in this run. Merged with on-disk on flush.
+      const inMemoryUploadCursor: UploadCursor = createEmptyUploadCursor();
+
+      // Fetch translation strings (always full re-push) + per-item-hashed collection content in parallel.
+      const [translationStrings, perCollectionWithHashes] = await Promise.all([
         fetchTranslationStrings({
           languages: exportLanguages,
           settings: settings.value,
           synchronizeTranslationStrings: synchronizeTranslationStrings.value,
         }),
-        fetchContentFromTranslatableCollections({
+        fetchContentWithHashesByCollection({
           languages: exportLanguages,
           translatableCollections: translatableCollections.value,
           enabledFields: enabledFields.value,
@@ -114,9 +176,88 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
         }),
       ]);
 
-      await exportService.exportContentToLocalazy({
-        content: merge(collectionsContent, translationStrings),
-        settings: settings.value,
+      // Filter each collection's items against the upload cursor. Translation strings
+      // bypass cursor logic entirely (decision 2 — they always full re-push).
+      const trackedItems = new Map<string, UploadTrackedItem[]>();
+      const collectionsContent: TranslatableContent = { sourceLanguage: {}, otherLanguages: {} };
+
+      perCollectionWithHashes.forEach(({ collection, items }) => {
+        const filteredItems = filterItemsByUploadCursor(collection, items, baseUploadCursor);
+        if (filteredItems.length === 0) return;
+        trackedItems.set(
+          collection,
+          filteredItems.map((it) => ({ id: it.id, hash: it.hash })),
+        );
+        filteredItems.forEach((it) => {
+          merge(collectionsContent, it.content);
+        });
+      });
+
+      const mergedContent: TranslatableContent = merge(collectionsContent, translationStrings);
+      const summary = summarizeUploadContent(mergedContent);
+
+      // Total tracked items across collections (drives the cursor-throttle math).
+      let totalTrackedItems = 0;
+      trackedItems.forEach((items) => {
+        totalTrackedItems += items.length;
+      });
+
+      // Short-circuit when there's nothing to push AND no translation strings to refresh.
+      if (totalTrackedItems === 0 && summary.sourceLangEntries === 0 && summary.translationEntries === 0) {
+        addProgressMessage({
+          id: ProgressTrackerId.UPLOAD_UP_TO_DATE,
+          message: 'All items already uploaded — nothing to push',
+        });
+        // Touch last_sync_at so the UX reflects the most recent successful run; merge
+        // preserves the on-disk cursor verbatim.
+        await persistUploadCursor(inMemoryUploadCursor);
+        return;
+      }
+
+      addProgressMessage({
+        id: ProgressTrackerId.UPLOAD_CHANGES_SUMMARY,
+        message: `Found ${summary.items} changed ${summary.items === 1 ? 'item' : 'items'} across ${summary.collections} ${summary.collections === 1 ? 'collection' : 'collections'} — pushing ${summary.sourceLangEntries} source-lang + ${summary.translationEntries} translation entries`,
+      });
+
+      // Throttled flush: persist every `flushEvery` items completed (capped at 10% of
+      // total work, minimum 50). Final flush in `finally` is unconditional.
+      const flushEvery = Math.max(50, Math.ceil(totalTrackedItems / 10));
+      let sinceLastFlush = 0;
+      let writtenSinceStart = 0;
+
+      const onWritten = (uploads: UploadedTriple[]) => {
+        uploads.forEach((u) => {
+          recordUploadEntry(inMemoryUploadCursor, u.collection, u.itemId, u.hash);
+        });
+        sinceLastFlush += uploads.length;
+        writtenSinceStart += uploads.length;
+        if (sinceLastFlush >= flushEvery) {
+          sinceLastFlush = 0;
+          // Fire-and-forget: the next persist will reload the disk cursor anyway, and we
+          // do not want upload progress to stall on a slow Directus PATCH.
+          void persistUploadCursor(inMemoryUploadCursor);
+        }
+      };
+
+      // Final flush — guarantees the last batch lands even if it didn't cross the
+      // throttle threshold. The `finally` makes the contract literal: even if the export
+      // throws midway, whatever the writer already accumulated via `onWritten` still
+      // gets persisted.
+      try {
+        await exportService.exportContentToLocalazy({
+          content: mergedContent,
+          settings: settings.value,
+          trackedItems,
+          onWritten,
+        });
+      } finally {
+        await persistUploadCursor(inMemoryUploadCursor);
+      }
+
+      const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+      addProgressMessage({
+        id: ProgressTrackerId.UPLOAD_FINISHED,
+        message: `Uploaded ${writtenSinceStart} ${writtenSinceStart === 1 ? 'item' : 'items'} in ${elapsedSec}s.`,
       });
     } finally {
       loading.value = false;

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -133,6 +133,11 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   async function onExport(mode: SyncMode = 'incremental') {
     loading.value = true;
     showProgress.value = true;
+    // Clear any messages left over from a prior run so the modal starts fresh. Without
+    // this the tracker accumulates across syncs — `resetProgressTracker` previously only
+    // ran when the user explicitly closed the modal via the Done button, and any other
+    // dismissal path (re-clicking Export, switching pages) left stale messages behind.
+    resetProgressTracker();
     const startedAt = Date.now();
 
     addProgressMessage({
@@ -155,7 +160,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       //     cursor here — merge-on-persist gives precedence to the in-memory cursor for
       //     cells we touched, and preserves disk entries for cells we didn't.
       const baseUploadCursor: UploadCursor =
-        mode === 'full' || syncStateData.value.cursor_project_id !== (localazyProject.value?.id || '')
+        mode === 'full' || !cursorMatchesProject(syncStateData.value.cursor_project_id, localazyProject.value?.id || '')
           ? createEmptyUploadCursor()
           : parseUploadCursor(syncStateData.value.uploaded_hashes);
       // Tracks only what we successfully pushed in this run. Merged with on-disk on flush.
@@ -302,6 +307,9 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   async function onImport(mode: SyncMode = 'incremental') {
     showProgress.value = true;
     loading.value = true;
+    // See the matching call in `onExport` — without this the tracker accumulates
+    // messages across runs whenever the user dismisses the modal without clicking Done.
+    resetProgressTracker();
     const startedAt = Date.now();
 
     addProgressMessage({

--- a/extensions/module/src/composables/use-translatable-collections.ts
+++ b/extensions/module/src/composables/use-translatable-collections.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
 import {
+  CollectionContentWithHashes,
   TranslatableCollectionsService,
   TranslatableCollectionsServiceOptions,
 } from '../../../common/services/translatable-collections-service';
@@ -51,8 +52,29 @@ export const useTranslatableCollections = () => {
     }
   }
 
+  /**
+   * Per-item fetch path used by the user-clicked Export orchestrator. Returns per-item
+   * content slices with content hashes attached so the orchestrator can filter by the
+   * upload cursor before assembling the final payload. Errors are routed through the
+   * errors store and degrade to an empty result.
+   */
+  async function fetchContentWithHashesByCollection(
+    options: TranslatableCollectionsServiceOptions,
+  ): Promise<CollectionContentWithHashes[]> {
+    loading.value = true;
+    try {
+      return await translatableCollectionsService.fetchContentWithHashesByCollection(options);
+    } catch (e: unknown) {
+      addDirectusError(e);
+      return [];
+    } finally {
+      loading.value = false;
+    }
+  }
+
   return {
     fetchContentFromTranslatableCollections,
+    fetchContentWithHashesByCollection,
     loading,
   };
 };

--- a/extensions/module/src/data/default-configuration.ts
+++ b/extensions/module/src/data/default-configuration.ts
@@ -31,6 +31,7 @@ export const defaultConfiguration = (): Configuration => ({
   },
   sync_state: {
     processed_keys: '{}',
+    uploaded_hashes: '{}',
     cursor_project_id: '',
     cursor_version: CURSOR_VERSION,
     last_sync_at: null,

--- a/extensions/module/src/data/fields/sync-state/create.ts
+++ b/extensions/module/src/data/fields/sync-state/create.ts
@@ -7,10 +7,12 @@ import { getConfig } from '../../../../../common/config/get-config';
  * `localazy_settings` and `localazy_data` (see `localazy-installer-store.ts`).
  *
  * `processed_keys` holds the JSON-encoded download-sync cursor — a per-`(language, key id)`
- * map of the last `event` number we successfully applied. `cursor_project_id` ties the
- * cursor to a specific Localazy project; the sync code wipes the cursor in-memory if the
- * stored value diverges from the current project id. `cursor_version` is reserved for
- * future schema changes to the on-disk shape.
+ * map of the last `event` number we successfully applied. `uploaded_hashes` holds the
+ * JSON-encoded upload-sync cursor — a per-`(collection, item id)` map of the 16-hex-char
+ * SHA-256 of the canonical KV payload we last successfully uploaded for that item.
+ * `cursor_project_id` ties both cursors to a specific Localazy project; the sync code
+ * wipes them in-memory if the stored value diverges from the current project id.
+ * `cursor_version` is reserved for future schema changes to the on-disk shape.
  */
 export const createSyncStateFields = (): Array<DeepPartial<Field>> => [
   {
@@ -28,6 +30,18 @@ export const createSyncStateFields = (): Array<DeepPartial<Field>> => [
   },
   {
     field: 'processed_keys',
+    type: 'text',
+    meta: {
+      interface: 'input-multiline',
+      readonly: getConfig().APP_MODE === 'production',
+      hidden: getConfig().APP_MODE === 'production',
+    },
+    schema: {
+      default_value: '{}',
+    },
+  },
+  {
+    field: 'uploaded_hashes',
     type: 'text',
     meta: {
       interface: 'input-multiline',

--- a/extensions/module/src/enums/progress-tracker-id.ts
+++ b/extensions/module/src/enums/progress-tracker-id.ts
@@ -18,4 +18,13 @@ export enum ProgressTrackerId {
   NOTHING_TO_IMPORT,
   NOT_CONNECTED_TO_LOCALAZY,
   UPDATING_DIRECTUS_COLLECTION_ERROR,
+
+  // Incremental upload sync progress markers — same de-dupe-by-id contract as the
+  // download markers above. UPLOAD_MODE_HEADER mirrors SYNC_MODE_HEADER but for the
+  // export flow; UPLOAD_CHANGES_SUMMARY mirrors CHANGES_SUMMARY; UPLOAD_UP_TO_DATE is
+  // the "nothing changed" short-circuit message.
+  UPLOAD_MODE_HEADER,
+  UPLOAD_CHANGES_SUMMARY,
+  UPLOAD_UP_TO_DATE,
+  UPLOAD_FINISHED,
 }

--- a/extensions/module/src/models/upload-write-result.ts
+++ b/extensions/module/src/models/upload-write-result.ts
@@ -1,0 +1,16 @@
+/**
+ * One `(collection, itemId, hash)` triple successfully uploaded to Localazy during an
+ * upload sync. The orchestrator collects these from `useExportToLocalazy` after all
+ * containing chunks resolve successfully, then advances the in-memory upload cursor.
+ *
+ * Per-item-after-all-chunks-succeed semantics: if a single item's content lands in
+ * multiple chunks (across languages, or across collection-split boundaries on huge
+ * installs), every one of those chunks must succeed before we mark the item as uploaded.
+ * A partial upload — where some languages landed but others failed — must NOT advance
+ * the cursor, otherwise the next sync would skip the failed languages.
+ */
+export type UploadedTriple = {
+  collection: string;
+  itemId: string;
+  hash: string;
+};

--- a/extensions/module/src/utils/summarize-upload-content.test.ts
+++ b/extensions/module/src/utils/summarize-upload-content.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { TranslatableContent } from '../../../common/models/translatable-content';
+import { summarizeUploadContent } from './summarize-upload-content';
+
+/**
+ * The runtime shape goes deeper than `TranslatableContent`'s declared 2-level
+ * `KeyValueEntry` allows. Cast to the target type at construction so tests can describe
+ * the real on-wire structure — the production code does the same dance via lodash merge.
+ */
+type DeepRecord = Record<string, unknown>;
+const asContent = (v: { sourceLanguage: DeepRecord; otherLanguages: Record<string, DeepRecord> }): TranslatableContent =>
+  v as TranslatableContent;
+
+describe('summarizeUploadContent', () => {
+  it('returns all zeros for empty content', () => {
+    const content: TranslatableContent = { sourceLanguage: {}, otherLanguages: {} };
+    expect(summarizeUploadContent(content)).toEqual({
+      items: 0,
+      collections: 0,
+      sourceLangEntries: 0,
+      translationEntries: 0,
+    });
+  });
+
+  it('counts items and source-language string entries', () => {
+    const content = asContent({
+      sourceLanguage: {
+        posts: {
+          '1': { translations: { title: 'Hello', body: 'World' } },
+          '2': { translations: { title: 'Foo' } },
+        },
+      },
+      otherLanguages: {},
+    });
+    expect(summarizeUploadContent(content)).toEqual({
+      items: 2,
+      collections: 1,
+      sourceLangEntries: 3,
+      translationEntries: 0,
+    });
+  });
+
+  it('counts items across multiple collections', () => {
+    const content = asContent({
+      sourceLanguage: {
+        posts: { '1': { translations: { title: 'Hi' } } },
+        pages: { '5': { translations: { title: 'Hi' } } },
+      },
+      otherLanguages: {},
+    });
+    expect(summarizeUploadContent(content)).toEqual({
+      items: 2,
+      collections: 2,
+      sourceLangEntries: 2,
+      translationEntries: 0,
+    });
+  });
+
+  it('sums translation-language entries across languages', () => {
+    const content = asContent({
+      sourceLanguage: {
+        posts: { '1': { translations: { title: 'Hi' } } },
+      },
+      otherLanguages: {
+        fr: { posts: { '1': { translations: { title: 'Salut' } } } },
+        de: { posts: { '1': { translations: { title: 'Hallo' } } } },
+      },
+    });
+    expect(summarizeUploadContent(content)).toEqual({
+      items: 1,
+      collections: 1,
+      sourceLangEntries: 1,
+      translationEntries: 2,
+    });
+  });
+
+  it('excludes @meta: keys from entry counts', () => {
+    const content = asContent({
+      sourceLanguage: {
+        posts: {
+          '1': {
+            translations: { title: 'Hi' },
+            '@meta:title': { add: { directus: { collection: 'posts', field: 'title', itemId: 1 } } },
+          },
+        },
+        '@meta:something': { add: { directus: { collection: 'posts', field: 'x', itemId: 1 } } },
+      },
+      otherLanguages: {},
+    });
+    const summary = summarizeUploadContent(content);
+    expect(summary.sourceLangEntries).toBe(1);
+    expect(summary.items).toBe(1);
+  });
+
+  it('counts translation_string entries but does not list them under items/collections', () => {
+    const content = asContent({
+      sourceLanguage: {
+        translation_string: { greeting: { key1: 'Hello', key2: 'Hi' } },
+      },
+      otherLanguages: {
+        fr: { translation_string: { greeting: { key1: 'Salut' } } },
+      },
+    });
+    expect(summarizeUploadContent(content)).toEqual({
+      items: 0,
+      collections: 0,
+      sourceLangEntries: 2,
+      translationEntries: 1,
+    });
+  });
+
+  it('deduplicates the same item id appearing in source + translation languages', () => {
+    const content = asContent({
+      sourceLanguage: { posts: { '1': { translations: { title: 'Hi' } } } },
+      otherLanguages: {
+        fr: { posts: { '1': { translations: { title: 'Salut' } } } },
+      },
+    });
+    expect(summarizeUploadContent(content).items).toBe(1);
+  });
+});

--- a/extensions/module/src/utils/summarize-upload-content.ts
+++ b/extensions/module/src/utils/summarize-upload-content.ts
@@ -1,0 +1,105 @@
+import { TranslatableContent } from '../../../common/models/translatable-content';
+
+export type UploadContentSummary = {
+  /** Number of distinct items (collection rows) being uploaded across all collections. */
+  items: number;
+  /** Number of distinct collections contributing at least one item. */
+  collections: number;
+  /** Number of source-language string entries that will be sent (post-filter). */
+  sourceLangEntries: number;
+  /**
+   * Number of translation-language string entries that will be sent (post-filter).
+   * Excludes source-language entries; sums across all non-source languages.
+   */
+  translationEntries: number;
+};
+
+/**
+ * The on-wire content is deeper than `TranslatableContent`'s declared 2-level
+ * `KeyValueEntry` shape (the runtime structure is 4 levels: collection → item → field →
+ * value). The traversal helpers operate on the runtime shape directly, so we use a
+ * recursive permissive type internally rather than re-typing `KeyValueEntry` (which
+ * would ripple across the codebase).
+ */
+type NestedNode = string | number | null | undefined | NestedNode[] | { [key: string]: NestedNode };
+
+/**
+ * Build the headline summary stats the upload sync orchestrator emits to the progress
+ * modal (e.g. "Found N changed items across M collections — pushing N source-lang + K
+ * translation entries"). Pure and synchronous — extracted from the orchestrator so the
+ * message arithmetic can be unit-tested without standing up Pinia.
+ *
+ * Item-count caveat: "items" counts every `(collection, itemId)` pair that contributes
+ * at least one string in the assembled content, with item id deduplication scoped per
+ * collection. Translation strings (top-level `translation_string` key) are not counted
+ * here — they are always full-re-pushed and tracked separately.
+ */
+export function summarizeUploadContent(content: TranslatableContent): UploadContentSummary {
+  const itemsByCollection = new Map<string, Set<string>>();
+  let sourceLangEntries = 0;
+  let translationEntries = 0;
+
+  countEntries(content.sourceLanguage as Record<string, NestedNode>, itemsByCollection, (n) => {
+    sourceLangEntries += n;
+  });
+
+  Object.entries(content.otherLanguages).forEach(([, langContent]) => {
+    countEntries(langContent as Record<string, NestedNode>, itemsByCollection, (n) => {
+      translationEntries += n;
+    });
+  });
+
+  let totalItems = 0;
+  itemsByCollection.forEach((ids) => {
+    totalItems += ids.size;
+  });
+
+  return {
+    items: totalItems,
+    collections: itemsByCollection.size,
+    sourceLangEntries,
+    translationEntries,
+  };
+}
+
+/**
+ * Count leaf string entries in one language's KV map while recording per-collection
+ * item-id sets. Top-level entries whose key is `translation_string` are counted as
+ * entries but their nested structure does NOT contribute to the items-by-collection map
+ * (they're tracked separately by the orchestrator and are always full re-push).
+ *
+ * `@meta:`-prefixed keys are part of the upload payload but represent metadata, not
+ * user-visible strings — exclude them from the entry count.
+ */
+function countEntries(
+  langContent: Record<string, NestedNode>,
+  itemsByCollection: Map<string, Set<string>>,
+  addEntries: (n: number) => void,
+) {
+  Object.entries(langContent).forEach(([topKey, topValue]) => {
+    if (topKey.startsWith('@meta:')) return;
+    if (topKey === 'translation_string') {
+      addEntries(countLeafStringsExcludingMeta(topValue));
+      return;
+    }
+    if (topValue && typeof topValue === 'object' && !Array.isArray(topValue)) {
+      const collectionItems = itemsByCollection.get(topKey) || new Set<string>();
+      Object.entries(topValue).forEach(([itemId, itemValue]) => {
+        collectionItems.add(itemId);
+        addEntries(countLeafStringsExcludingMeta(itemValue));
+      });
+      itemsByCollection.set(topKey, collectionItems);
+    }
+  });
+}
+
+function countLeafStringsExcludingMeta(value: NestedNode): number {
+  if (typeof value === 'string') return 1;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return 0;
+  let n = 0;
+  Object.entries(value).forEach(([k, child]) => {
+    if (k.startsWith('@meta:')) return;
+    n += countLeafStringsExcludingMeta(child);
+  });
+  return n;
+}


### PR DESCRIPTION
## Summary

Mirror of PR 30's download-side machinery for the Export flow. User-clicked Export now defaults to incremental: items are filtered against a per-item content-hash cursor, only changed items are pushed, and the cursor rebuilds on Full Upload. Schema / settings / enabled-fields changes are naturally reflected in the hash — no special-case invalidation needed.

- **Cursor** — per-item content hashes `{ [collection]: { [itemId]: hex16 } }` on the existing `localazy_sync_state` singleton (new `uploaded_hashes` text JSON field).
- **Hash** — canonicalised KV payload of "what would be uploaded right now", SHA-256 truncated to 16 hex chars. Computed inside `resolveContentForCollection`.
- **Filter** — after fetch, before parse. Items whose current hash matches the stored hash are skipped entirely.
- **Marking** — per-item-after-all-chunks-succeed. Orchestrator tracks chunk membership + chunk successes; an item is marked iff its chunks all succeeded.
- **Persistence** — throttled to `max(50, ceil(totalItems / 10))` items, plus a `try/finally` final flush. Merge-on-persist for concurrency. In-tab disable for v1; soft DB lock deferred until automated import.
- **UI** — same v-menu split-button as Import/Full Sync. New "Full Upload (re-push from scratch)" dropdown entry next to "Export to Localazy".
- **Progress messages** — parallel set to download: "Preparing items for upload...", "Found N changed items across M collections — pushing N source-lang + K translation entries", "Pushing chunks (i/N)", "Uploaded N items in T.Ts.", "All items already uploaded — nothing to push", "Full upload — re-pushing everything".
- **Translation strings** — always full re-push, no cursor entries (unchanged behaviour).

## Design

Captured in the upload-side grilling notes in `Work/Localazy/Development/Directus extension 2.0 release - progress.md` (Obsidian). 15 decisions settled with the user before implementation. Notable: the hash mechanism subsumes three separate concerns into one signal — enabled-fields changes, `upload_existing_translations` toggles, and non-translatable-field bumps to `date_updated` — eliminating the need for fingerprints, UI hints, and forced-full rules.

## Test plan

- [x] `npm run check` clean (lint + format + typecheck + 200 tests pass — up from 143; +57 new cursor + summarize-upload-content tests)
- [x] `npm run build` clean (verified via build watcher during agent run)
- [ ] Manual UI verification — **NOT performed**: port 8055 was occupied by the main session's dev server running PR 30's code, so the implementation agent didn't run `npm run dev`. Reviewer flow:
  1. Switch dev server to this branch
  2. Edit a translatable field on an existing article → click Export → progress should show ~1 changed item
  3. Click Export again → "All items already uploaded — nothing to push"
  4. Click Full Upload from the dropdown → header shows "Full upload — re-pushing everything", cursor rebuilds, all items pushed
  5. Verify `localazy_sync_state.uploaded_hashes` populates with `{ articles: { 1: hex16, 2: hex16 } }` shape

## Out of scope (tracked follow-ups)

- Hook-side cursor updates from `items.update` (stretch goal not taken — implementation cost > the agreed ~30-line ceiling)
- Soft DB lock once automated import lands (needed when concurrent syncs become frequent)
- Orphan deletion handling (shared follow-up with PR 30 — Localazy keys deleted by translators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)