### PR TITLE
PR 39/N: docs — CONTEXT.md glossary + ADR-0001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# directus-extension-localazy
+
+Glossary for the Localazy ↔ Directus integration: a Directus module (admin UI) plus a server-side bundle (hook + endpoint) that keep translatable Directus content in sync with a Localazy project in both directions.
+
+## Language
+
+### Sync directions
+
+**Automated import**:
+Inbound sync from Localazy to Directus, triggered by a Localazy webhook (`project_published` event). Master toggle: `Settings.automated_import`.
+_Avoid_: "auto pull", "incoming sync"
+
+**Automated export**:
+Outbound sync from Directus to Localazy, triggered by Directus item / translation lifecycle events (`items.*`, `settings.*`, `translations.*`). Master toggle persisted as `Settings.automated_upload` for historical reasons — surfaced to users as "Automated export."
+_Avoid_: "automated upload" (legacy term, still the field name in code; only acceptable when referring to the persisted field, never in user-facing copy)
+
+### Building blocks
+
+**Module**:
+The Vue 3 / Pinia admin-UI extension. Runs in the browser. Owns the Automation page and other configuration pages.
+_Avoid_: "frontend extension"
+
+**Sync-hook bundle** (or just **bundle**):
+The server-side Directus bundle that contains the hook + endpoint. Runs in the Directus Node process. Performs the actual export work in response to Directus events and the actual import work in response to incoming webhooks.
+_Avoid_: "the hook" (the bundle is more than a hook), "server extension"
+
+**Source key**:
+Localazy's identity for a translatable string. Both export and import operate on source keys, not on raw text.
+_Avoid_: "translation key"
+
+**Deprecation**:
+A Localazy operation that marks a source key as no-longer-active without deleting it. Triggered on Directus delete events when `automated_deprecation` is on. Distinct from deletion.
+
+**Webhook user**:
+The Directus user (Admin role required) whose identity webhook-triggered writes are attributed to. Required for automated import to function — the bundle refuses to act on webhook events until this is set. Persisted as `Settings.automated_import_user`.
+
+## Relationships
+
+- **Automated export** is a property of the **Sync-hook bundle**; it cannot run when the bundle is not installed.
+- **Automated import** also requires the **Sync-hook bundle** (to handle the inbound webhook) and additionally requires a configured **Webhook user**.
+- **Deprecation** is a sub-behavior of **Automated export** (today gated by an independent `automated_deprecation` flag; surfaced to users as a sub-setting under "Automated export").
+
+## Flagged ambiguities
+
+- "upload" vs "export" was used inconsistently across code and UI. **Resolved (2026-05-15)**: user-facing copy says "export"; code/field names keep "upload" for now to avoid a migration. Future contributors should not "fix" this inconsistency without a coordinated rename.

--- a/docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md
+++ b/docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md
@@ -1,0 +1,19 @@
+# Automation page is the single home for sync master toggles; export master gates all outbound activity
+
+## Context
+
+Outbound sync (Directus → Localazy) was historically governed by two independent flags on the **Additional Settings** page: `automated_upload` (gate for create/update push) and `automated_deprecation` (gate for delete-propagation). Inbound sync (Localazy → Directus) was governed by `automated_import` on the separate **Automation** page. This split meant users had to visit two pages to understand or change the sync regime, and the two outbound flags allowed a confusing combination — "deprecate on delete but don't push on update" — that no user mental model accommodates.
+
+## Decision
+
+1. **Page purpose.** The **Automation** page is the single home for *automation master toggles* — the on/off switches that decide whether a sync direction runs at all. The **Additional Settings** page holds *behaviour-shaping knobs* — settings that decide *how* sync behaves once it runs (skip empty strings, source-language direction, language mappings, etc.). New automation-enable controls go on the Automation page; new behaviour controls go on Additional Settings.
+
+2. **Master gates everything.** The "Automated export" master toggle is persisted as `Settings.automated_upload` and surfaces deprecation as a sub-setting. The runtime gating in `collection-content-synchronization-service.ts` and `translation-strings-synchronization-service.ts` was tightened so deprecation also requires `automated_upload === true` — meaning master OFF guarantees zero outbound activity, including for legacy installs that had the niche `upload=false, deprecate=true` combination.
+
+3. **Field names stay.** `Settings.automated_upload` and `Settings.automated_deprecation` keep their persisted names; only the user-facing labels switched to "Automated export" / "Also deprecate keys on delete." This avoids a schema migration and analytics-payload coordination, at the cost of an existing inconsistency between code and UI terminology (also present in `upload_existing_translations` → "Export translations from Directus").
+
+## Consequences
+
+- Legacy users with `automated_upload = false` and `automated_deprecation = true` will lose deprecation firing after upgrade. This is intentional — the UI no longer allows that state, and the runtime now matches.
+- Contributors adding sync-related settings must classify them as "automation toggle" (Automation page) or "behaviour knob" (Additional Settings) and place them accordingly.
+- Future renames of `automated_upload` → `automated_export` (field, code, analytics) remain possible but require coordinated migration + dashboard updates and are not in scope here.


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` — codebase-wide glossary fixing terminology for export/import directions, sync-hook bundle vs. "the hook", source key, webhook user, deprecation; flags the still-active "upload" vs. "export" code-vs-UI inconsistency so future contributors don't try to "fix" it without a coordinated rename.
- Adds `docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md` — records the decision to consolidate the sync automation master toggles on the Automation page (Export above, Import below) with deprecation as a sub-behavior of the export master rather than an independent flag.

Implementation of the ADR lands in the next PR (PR 41/N).

## Test plan

- [x] No code changes — docs only.
- [ ] Confirm rendered ADR + glossary read as intended on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)