### PR TITLE
PR 40/N: fix Admin-user filter for Directus 11

### DIFF
--- a/extensions/module/src/components/Automation/AutomationForm.filter.test.ts
+++ b/extensions/module/src/components/Automation/AutomationForm.filter.test.ts
@@ -5,22 +5,23 @@ import { dirname, resolve } from 'node:path';
 
 /**
  * Lightweight static-source assertion that the Admin-role filter passed to
- * `GET /users` keeps its expected shape — `role.admin_access._eq: true`.
+ * `GET /users` keeps its Directus-11 shape — `role.policies.policy.admin_access._eq: true`.
  *
  * The full form mounts in Vue and would need `@directus/extensions-sdk` plus
  * `useStores()` to instantiate, which isn't worth the harness cost for this single
  * invariant. Reading the source is enough to catch the regression we care about:
- * someone "tidying" the filter into a shape Directus' API rejects (e.g.
- * `admin_access: true` without the relation traversal) would silently render an
- * empty dropdown.
+ * someone "tidying" the filter into a shape Directus' API rejects (e.g. the v10 shape
+ * `role.admin_access._eq` — Directus 11 moved `admin_access` from `directus_roles` to
+ * `directus_policies`) would silently render an empty dropdown.
  */
 const here = dirname(fileURLToPath(import.meta.url));
 const formSource = readFileSync(resolve(here, 'AutomationForm.vue'), 'utf8');
 
 describe('AutomationForm — Admin-role user filter', () => {
-  it('declares ADMIN_USERS_FILTER with the relation-traversal shape Directus expects', () => {
-    // Match `{ role: { admin_access: { _eq: true } } }` while tolerating whitespace.
-    const re = /ADMIN_USERS_FILTER\s*=\s*\{\s*role:\s*\{\s*admin_access:\s*\{\s*_eq:\s*true\s*\}\s*\}\s*\}/;
+  it('declares ADMIN_USERS_FILTER with the relation-traversal shape Directus 11 expects', () => {
+    // Match `{ role: { policies: { policy: { admin_access: { _eq: true } } } } }` while tolerating whitespace.
+    const re =
+      /ADMIN_USERS_FILTER\s*=\s*\{\s*role:\s*\{\s*policies:\s*\{\s*policy:\s*\{\s*admin_access:\s*\{\s*_eq:\s*true\s*\}\s*\}\s*\}\s*\}\s*\}/;
     expect(formSource).toMatch(re);
   });
 

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -95,13 +95,15 @@ const adminUsers = ref<AdminUser[]>([]);
 const loadingUsers = ref(false);
 
 /**
- * Filter to `role.admin_access._eq: true`. Directus' standard filter syntax for traversing
- * relations — same shape the Directus admin uses internally. The role lookup walks one
- * level: `directus_users.role` is m2o → `directus_roles`, which has an `admin_access`
- * boolean. Excluding non-admin users client-side instead would still leak their existence
+ * Filter for users whose role has at least one policy with `admin_access = true`.
+ * In Directus 11, `admin_access` lives on `directus_policies`, not on `directus_roles`
+ * (which was the v10 shape). The traversal is
+ * `directus_users.role` (m2o) → `directus_roles.policies` (o2m to `directus_access`)
+ * → `directus_access.policy` (m2o to `directus_policies`) → `admin_access`.
+ * Excluding non-admin users client-side instead would still leak their existence
  * via the API response, and we'd pay the bandwidth for a list we then discard.
  */
-const ADMIN_USERS_FILTER = { role: { admin_access: { _eq: true } } } as const;
+const ADMIN_USERS_FILTER = { role: { policies: { policy: { admin_access: { _eq: true } } } } } as const;
 
 async function loadAdminUsers(): Promise<void> {
   loadingUsers.value = true;


### PR DESCRIPTION
## Summary

- The Automation page's Webhook-user dropdown rendered empty on any Directus 11 install — the filter on `GET /users` traversed `role.admin_access._eq: true`, which is the v10 shape.
- In Directus 11, `admin_access` was moved from `directus_roles` to `directus_policies`, joined m2m via `directus_access`. Filter now traverses `directus_users.role` → `directus_roles.policies` → `directus_access.policy` → `directus_policies.admin_access`.
- Updates the static-source regression test (`AutomationForm.filter.test.ts`) so future "tidy" refactors that revert to the v10 shape get caught at CI.

## Test plan

- [x] `vitest run AutomationForm.filter.test.ts` — passes against the new regex.
- [ ] Manual: visit Automation page on a live Directus 11 instance, confirm the Webhook-user dropdown lists admin-role users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)