### PR TITLE
PR 41/N (Stage 5+): move sync master toggles to Automation page (ADR-0001)

### DIFF
--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -2,30 +2,6 @@
   <div>
     <div class="form grid">
       <div class="half">
-        <p class="type-label">Automated upload to Localazy</p>
-        <v-select v-model="localEdits.automated_upload" :items="automatedUploadOptions" />
-      </div>
-      <div class="half-right">
-        <p class="configuration-description note">
-          When enabled, content will be automatically uploaded to Localazy after its creation or update in Directus.
-        </p>
-      </div>
-
-      <div class="half">
-        <p class="type-label">Automated deprecation of Localazy source keys on deletion</p>
-        <v-select v-model="localEdits.automated_deprecation" :items="automatedDeprecationOptions" />
-      </div>
-      <div class="half-right">
-        <p class="configuration-description note">
-          When enabled, Localazy source keys will be automatically set as
-          <a href="https://localazy.com/faq/localazy/what-is-the-difference-between-hidden-and-deprecated-source-keys" target="_blank">
-            deprecated
-          </a>
-          if an entry in source language is deleted in Directus.
-        </p>
-      </div>
-
-      <div class="half">
         <p class="type-label">Source language synchronization</p>
         <v-select v-model="localEdits.import_source_language" :items="importSourceLanguageOptions" />
       </div>
@@ -139,27 +115,6 @@ const directusMissingLanguagesOptions = ref<Item[]>([
   },
 ]);
 
-const automatedUploadOptions = ref<Item[]>([
-  {
-    text: 'Allow automated upload',
-    value: true,
-  },
-  {
-    text: 'Disable automated upload',
-    value: false,
-  },
-]);
-
-const automatedDeprecationOptions = ref<Item[]>([
-  {
-    text: 'Allow automated deprecation',
-    value: true,
-  },
-  {
-    text: 'Disable automated deprecation',
-    value: false,
-  },
-]);
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/module/src/components/Automation/AutomationForm.structure.test.ts
+++ b/extensions/module/src/components/Automation/AutomationForm.structure.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Static-source assertions that the Automation page keeps its dual-section shape
+ * (Export above Import, each section's master toggle + sub-settings wired to the
+ * correct `Settings` fields). Sibling of AutomationForm.filter.test.ts — same trade-off:
+ * static-source matching is cheap and catches the regressions we care about
+ * (someone deleting the export master, or rewiring the sub-toggle to the wrong field)
+ * without needing to mount the Vue tree with `@directus/extensions-sdk`.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const formSource = readFileSync(resolve(here, 'AutomationForm.vue'), 'utf8');
+
+describe('AutomationForm — section structure', () => {
+  it('renders an Export header above an Import header', () => {
+    const exportIdx = formSource.indexOf('>Export</h2>');
+    const importIdx = formSource.indexOf('>Import</h2>');
+    expect(exportIdx).toBeGreaterThanOrEqual(0);
+    expect(importIdx).toBeGreaterThanOrEqual(0);
+    expect(exportIdx).toBeLessThan(importIdx);
+  });
+});
+
+describe('AutomationForm — Export section wiring', () => {
+  it('binds the master toggle to `automated_upload`', () => {
+    // <v-select v-model="localEdits.automated_upload" :items="enabledOptions" />
+    expect(formSource).toMatch(/v-model="localEdits\.automated_upload"[^>]*:items="enabledOptions"/);
+  });
+
+  it('binds the deprecation sub-toggle to `automated_deprecation`', () => {
+    expect(formSource).toMatch(/v-model="localEdits\.automated_deprecation"/);
+  });
+
+  it('disables the deprecation sub-toggle when the master is off', () => {
+    expect(formSource).toMatch(/v-model="localEdits\.automated_deprecation"[\s\S]*?:disabled="!localEdits\.automated_upload"/);
+  });
+
+  it('wraps the deprecation sub-toggle in a settings-group gated by `automated_upload`', () => {
+    expect(formSource).toMatch(/settings-group[^"]*['"][^>]*\{\s*disabled:\s*!localEdits\.automated_upload\s*\}/);
+  });
+});
+
+describe('AutomationForm — Import section wiring', () => {
+  it('binds the master toggle to `automated_import`', () => {
+    expect(formSource).toMatch(/v-model="localEdits\.automated_import"[^>]*:items="enabledOptions"/);
+  });
+
+  it('wraps the import sub-settings in a settings-group gated by `automated_import`', () => {
+    expect(formSource).toMatch(/settings-group[^"]*['"][^>]*\{\s*disabled:\s*!localEdits\.automated_import\s*\}/);
+  });
+});

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -1,6 +1,49 @@
 <template>
   <div class="automation-form">
     <div class="form grid">
+      <header class="section-header">
+        <h2 class="section-title">Export</h2>
+        <p class="note section-description">From Directus to Localazy &mdash; triggered by changes to translatable content inside Directus.</p>
+      </header>
+
+      <div class="half">
+        <p class="type-label">Enable automated export</p>
+        <v-select v-model="localEdits.automated_upload" :items="enabledOptions" />
+      </div>
+      <div class="half-right">
+        <p class="note configuration-description">
+          When enabled, content saved in Directus is pushed to Localazy automatically &mdash; create and update events on translatable
+          collections and translation strings.
+        </p>
+      </div>
+
+      <div :class="['settings-group', { disabled: !localEdits.automated_upload }]">
+        <div class="grid">
+          <div class="half">
+            <p class="type-label">Also deprecate Localazy source keys on Directus delete</p>
+            <v-select v-model="localEdits.automated_deprecation" :items="enabledOptions" :disabled="!localEdits.automated_upload" />
+            <p class="note hint">
+              When on, deleting a translatable entry in Directus marks the matching Localazy source keys as
+              <a href="https://localazy.com/faq/localazy/what-is-the-difference-between-hidden-and-deprecated-source-keys" target="_blank">
+                deprecated
+              </a>
+              rather than leaving them active.
+            </p>
+          </div>
+          <div class="half-right">
+            <p class="note configuration-description">
+              Deprecation is a sub-behaviour of automated export &mdash; if export is off, deletes are not propagated to Localazy regardless
+              of this setting.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <header class="section-header section-header-divider">
+        <h2 class="section-title">Import</h2>
+        <p class="note section-description">From Localazy to Directus &mdash; triggered by Localazy's <code>project_published</code> webhook.</p>
+      </header>
+
       <div class="half">
         <p class="type-label">Enable automated import</p>
         <v-select v-model="localEdits.automated_import" :items="enabledOptions" />
@@ -59,8 +102,8 @@
           <div class="webhook-section">
             <h3 class="webhook-title">Webhook registration</h3>
             <p class="note webhook-description">
-              Localazy needs a public URL to post events to. This block registers / removes the webhook on Localazy directly — no Directus
-              server round-trip required.
+              Automated import relies on a webhook: Localazy calls this Directus site whenever translations are ready. Use the button below
+              to register the webhook, or remove it later.
             </p>
             <WebhookSetup />
           </div>
@@ -189,6 +232,28 @@ onMounted(() => {
   &.disabled {
     opacity: 0.55;
   }
+}
+
+.section-header {
+  grid-column: 1 / span 2;
+  margin-bottom: 8px;
+}
+
+.section-header-divider {
+  margin-top: 16px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-subdued);
+}
+
+.section-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  color: var(--foreground-normal);
+}
+
+.section-description {
+  margin: 0;
 }
 
 .webhook-section {

--- a/extensions/sync-hook/src/hook/services/content-synchronization/collection-content-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/collection-content-synchronization-service.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { collectionContentSynchronizationService } from './collection-content-synchronization-service';
+import { BaseContentSynchronizationService } from './base-content-synchronization-service';
+import type { DirectusLogger } from '../../types/directus-services';
+
+// Sibling of translation-strings-synchronization-service.test.ts. Covers only the
+// gating behaviour of `deprecateDeletedCollectionItems` — the broader orchestration
+// is shared with the translation-strings service and is exercised over there.
+
+type AnyFn = (...args: unknown[]) => unknown;
+
+const proto = BaseContentSynchronizationService.prototype as unknown as Record<string, AnyFn>;
+
+function makeLogger() {
+  return {
+    level: 'info',
+    fatal: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+  } as unknown as DirectusLogger;
+}
+
+function makeSchema() {
+  return {
+    collections: {
+      localazy_settings: {},
+      localazy_content_transfer_setup: {},
+    },
+  };
+}
+
+const sampleTransferSetup = { translation_strings: false, enabled_fields: '[]' };
+const sampleLocalazyData = { access_token: 'tok' };
+
+describe('collectionContentSynchronizationService.deprecateDeletedCollectionItems', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when automated_deprecation is disabled', async () => {
+    const logger = makeLogger();
+    vi.spyOn(proto, 'resolveLocalazySettings').mockResolvedValue({
+      settings: { automated_upload: true, automated_deprecation: false },
+      contentTransferSetup: sampleTransferSetup,
+    });
+    vi.spyOn(proto, 'resolveLocalazyData').mockResolvedValue({ localazyData: sampleLocalazyData });
+    const loadProjectSpy = vi.spyOn(proto, 'loadProject');
+    const deprecateSpy = vi.spyOn(proto, 'deprecateLocalazyKeys').mockResolvedValue(undefined);
+
+    await collectionContentSynchronizationService.deprecateDeletedCollectionItems({
+      schema: makeSchema() as never,
+      collection: 'articles',
+      itemIds: ['id1'],
+      logger,
+      ItemsService: vi.fn(),
+    });
+
+    expect(loadProjectSpy).not.toHaveBeenCalled();
+    expect(deprecateSpy).not.toHaveBeenCalled();
+  });
+
+  // ADR-0001: deprecation is a sub-behavior of the "automated export" master toggle;
+  // a `automated_upload: false` setting guarantees no outbound activity, even if
+  // `automated_deprecation` remained `true` from a legacy install.
+  it('does nothing when automated_upload (the master export gate) is disabled', async () => {
+    const logger = makeLogger();
+    vi.spyOn(proto, 'resolveLocalazySettings').mockResolvedValue({
+      settings: { automated_upload: false, automated_deprecation: true },
+      contentTransferSetup: sampleTransferSetup,
+    });
+    vi.spyOn(proto, 'resolveLocalazyData').mockResolvedValue({ localazyData: sampleLocalazyData });
+    const loadProjectSpy = vi.spyOn(proto, 'loadProject');
+    const deprecateSpy = vi.spyOn(proto, 'deprecateLocalazyKeys').mockResolvedValue(undefined);
+
+    await collectionContentSynchronizationService.deprecateDeletedCollectionItems({
+      schema: makeSchema() as never,
+      collection: 'articles',
+      itemIds: ['id1'],
+      logger,
+      ItemsService: vi.fn(),
+    });
+
+    expect(loadProjectSpy).not.toHaveBeenCalled();
+    expect(deprecateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/sync-hook/src/hook/services/content-synchronization/collection-content-synchronization-service.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/collection-content-synchronization-service.ts
@@ -95,7 +95,9 @@ class CollectionContentSynchronizationService extends BaseContentSynchronization
         return;
       }
 
-      if (!settings.automated_deprecation) {
+      // Deprecation is a sub-behavior of automated export — gated by both flags so the master
+      // toggle on the Automation page guarantees zero outbound activity when off. See ADR-0001.
+      if (!settings.automated_upload || !settings.automated_deprecation) {
         return;
       }
 

--- a/extensions/sync-hook/src/hook/services/content-synchronization/translation-strings-synchronization-service.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/translation-strings-synchronization-service.test.ts
@@ -39,7 +39,7 @@ function makeSchema() {
   };
 }
 
-const sampleSettings = { automated_deprecation: true };
+const sampleSettings = { automated_upload: true, automated_deprecation: true };
 const sampleTransferSetup = { translation_strings: true, enabled_fields: '[]' };
 const sampleLocalazyData = { access_token: 'tok' };
 const sampleProject = { id: 'p1' };
@@ -156,7 +156,7 @@ describe('translationStringsSynchronizationService.deprecateDeletedTranslationSt
   it('does nothing when automated_deprecation is disabled', async () => {
     const logger = makeLogger();
     vi.spyOn(proto, 'resolveLocalazySettings').mockResolvedValue({
-      settings: { automated_deprecation: false },
+      settings: { automated_upload: true, automated_deprecation: false },
       contentTransferSetup: sampleTransferSetup,
     });
     vi.spyOn(proto, 'resolveLocalazyData').mockResolvedValue({ localazyData: sampleLocalazyData });
@@ -171,6 +171,30 @@ describe('translationStringsSynchronizationService.deprecateDeletedTranslationSt
     });
 
     // The function returns before any project load / deprecate happens.
+    expect(loadProjectSpy).not.toHaveBeenCalled();
+    expect(deprecateSpy).not.toHaveBeenCalled();
+  });
+
+  // ADR-0001: deprecation is a sub-behavior of the "automated export" master toggle;
+  // a `automated_upload: false` setting guarantees no outbound activity, even if
+  // `automated_deprecation` remained `true` from a legacy install.
+  it('does nothing when automated_upload (the master export gate) is disabled', async () => {
+    const logger = makeLogger();
+    vi.spyOn(proto, 'resolveLocalazySettings').mockResolvedValue({
+      settings: { automated_upload: false, automated_deprecation: true },
+      contentTransferSetup: sampleTransferSetup,
+    });
+    vi.spyOn(proto, 'resolveLocalazyData').mockResolvedValue({ localazyData: sampleLocalazyData });
+    const loadProjectSpy = vi.spyOn(proto, 'loadProject');
+    const deprecateSpy = vi.spyOn(proto, 'deprecateLocalazyKeys').mockResolvedValue(undefined);
+
+    await translationStringsSynchronizationService.deprecateDeletedTranslationStrings({
+      schema: makeSchema() as never,
+      itemIds: ['id1'],
+      logger,
+      ItemsService: vi.fn(),
+    });
+
     expect(loadProjectSpy).not.toHaveBeenCalled();
     expect(deprecateSpy).not.toHaveBeenCalled();
   });

--- a/extensions/sync-hook/src/hook/services/content-synchronization/translation-strings-synchronization-service.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/translation-strings-synchronization-service.ts
@@ -93,7 +93,9 @@ class TranslationStringsSynchronizationService extends BaseContentSynchronizatio
         return;
       }
 
-      if (!settings.automated_deprecation) {
+      // Deprecation is a sub-behavior of automated export — gated by both flags so the master
+      // toggle on the Automation page guarantees zero outbound activity when off. See ADR-0001.
+      if (!settings.automated_upload || !settings.automated_deprecation) {
         return;
       }
       const localazyProject = await this.loadProject(localazyData.access_token);


### PR DESCRIPTION
## Summary

Implements ADR-0001 (`docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md`).

- `AutomationForm.vue` now hosts an **Export** section above the existing **Import** section. The Export master is `Settings.automated_upload`; deprecation becomes a sub-toggle inside the Export block, disabled and dimmed when the master is off.
- `AdvancedSettingsForm.vue` drops the standalone "Automated upload" + "Automated deprecation" fields and their option arrays — these are master toggles per ADR, not behaviour knobs.
- Server-side gating in `collection-content-synchronization-service.ts` and `translation-strings-synchronization-service.ts` tightened from `!automated_deprecation` to `!automated_upload || !automated_deprecation`. Legacy installs with the niche `upload=false, deprecate=true` combination lose deprecation firing after upgrade — intentional per ADR.
- `AutomationForm.structure.test.ts` (new) — static-source regression test asserting Export-above-Import order plus the `automated_upload` / `automated_deprecation` wiring (mirrors the sibling filter test).
- `collection-content-synchronization-service.test.ts` (new) — covers the master-gate short-circuit. Updated translation-strings sibling test for the same case.

Persisted field names (`automated_upload`, `automated_deprecation`) keep their shape — no schema migration.

## Test plan

- [x] `vitest run` — all 16 affected tests pass (structure, filter, both deprecation services).
- [ ] Manual: load Automation page, confirm Export section appears above Import, master gates the sub-toggle.
- [ ] Manual: with `automated_upload = false`, delete a translatable item — confirm no deprecation request fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)