### PR TITLE
PR 42/N: SHA-256 fallback for non-secure-context browsers

### DIFF
--- a/extensions/common/utilities/sha256.test.ts
+++ b/extensions/common/utilities/sha256.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sha256 } from './sha256';
+
+function hex(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    s += bytes[i]!.toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+function bytes(input: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(input);
+}
+
+describe('sha256 (pure-JS fallback)', () => {
+  // FIPS 180-4 / NIST CAVS known-answer vectors.
+  it('hashes the empty string', () => {
+    expect(hex(sha256(new Uint8Array(0)))).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  it('hashes "abc"', () => {
+    expect(hex(sha256(bytes('abc')))).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('hashes the 448-bit ASCII vector', () => {
+    expect(hex(sha256(bytes('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq')))).toBe(
+      '248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1',
+    );
+  });
+
+  it('hashes the canonical JSON payloads used by computeItemHash', () => {
+    // SHA-256("{}") — pinned so we can detect any unintended drift between this
+    // implementation and Web Crypto.
+    expect(hex(sha256(bytes('{}')))).toBe('44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a');
+  });
+
+  it('matches crypto.subtle.digest output byte-for-byte (when available)', async () => {
+    if (typeof crypto === 'undefined' || !crypto.subtle) return;
+    const inputs = ['', 'abc', '{}', '{"a":1,"b":[1,2,3]}', 'a'.repeat(1000)];
+    for (const input of inputs) {
+      const buf = bytes(input);
+      const native = new Uint8Array(await crypto.subtle.digest('SHA-256', buf));
+      expect(hex(sha256(buf))).toBe(hex(native));
+    }
+  });
+});

--- a/extensions/common/utilities/sha256.ts
+++ b/extensions/common/utilities/sha256.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure-JS SHA-256 (FIPS 180-4). Used as a fallback when Web Crypto's
+ * `crypto.subtle.digest` is unavailable — specifically on non-secure-context browser
+ * origins (plain HTTP outside `localhost`/`127.0.0.1`), where `crypto.subtle` is
+ * `undefined`. Output is byte-identical to `crypto.subtle.digest('SHA-256', ...)` so
+ * call sites can swap between paths without invalidating downstream hashes.
+ *
+ * Not intended as a hot path — Web Crypto is preferred when available. This is here
+ * so the upload-cursor hash keeps working in non-secure contexts (e.g. Directus
+ * served on a LAN IP) instead of crashing Export.
+ */
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be,
+  0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa,
+  0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85,
+  0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+  0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+  0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+export function sha256(bytes: Uint8Array): Uint8Array {
+  const H = new Uint32Array([0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]);
+
+  // Padding: append 0x80, then zeros, then the 64-bit big-endian bit-length so the
+  // total length is a multiple of 64 bytes. Bit-length is computed as two 32-bit
+  // halves via plain JS division — payloads fed to this function are small (single
+  // upload-cursor item content), well inside the 2^53 safe-integer range.
+  const padLen = (56 - ((bytes.length + 1) % 64) + 64) % 64;
+  const totalLen = bytes.length + 1 + padLen + 8;
+  const padded = new Uint8Array(totalLen);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const msgLenBits = bytes.length * 8;
+  const hi = Math.floor(msgLenBits / 0x100000000) >>> 0;
+  const lo = msgLenBits >>> 0;
+  padded[totalLen - 8] = (hi >>> 24) & 0xff;
+  padded[totalLen - 7] = (hi >>> 16) & 0xff;
+  padded[totalLen - 6] = (hi >>> 8) & 0xff;
+  padded[totalLen - 5] = hi & 0xff;
+  padded[totalLen - 4] = (lo >>> 24) & 0xff;
+  padded[totalLen - 3] = (lo >>> 16) & 0xff;
+  padded[totalLen - 2] = (lo >>> 8) & 0xff;
+  padded[totalLen - 1] = lo & 0xff;
+
+  const W = new Uint32Array(64);
+  for (let chunkStart = 0; chunkStart < padded.length; chunkStart += 64) {
+    for (let i = 0; i < 16; i += 1) {
+      const o = chunkStart + i * 4;
+      W[i] = ((padded[o]! << 24) | (padded[o + 1]! << 16) | (padded[o + 2]! << 8) | padded[o + 3]!) >>> 0;
+    }
+    for (let i = 16; i < 64; i += 1) {
+      const w15 = W[i - 15]!;
+      const s0 = ((w15 >>> 7) | (w15 << 25)) ^ ((w15 >>> 18) | (w15 << 14)) ^ (w15 >>> 3);
+      const w2 = W[i - 2]!;
+      const s1 = ((w2 >>> 17) | (w2 << 15)) ^ ((w2 >>> 19) | (w2 << 13)) ^ (w2 >>> 10);
+      W[i] = (W[i - 16]! + s0 + W[i - 7]! + s1) >>> 0;
+    }
+
+    let a = H[0]!;
+    let b = H[1]!;
+    let c = H[2]!;
+    let d = H[3]!;
+    let e = H[4]!;
+    let f = H[5]!;
+    let g = H[6]!;
+    let h = H[7]!;
+
+    for (let i = 0; i < 64; i += 1) {
+      const S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+      const ch = (e & f) ^ (~e & g);
+      const t1 = (h + S1 + ch + K[i]! + W[i]!) >>> 0;
+      const S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const t2 = (S0 + maj) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + t1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (t1 + t2) >>> 0;
+    }
+
+    H[0] = (H[0]! + a) >>> 0;
+    H[1] = (H[1]! + b) >>> 0;
+    H[2] = (H[2]! + c) >>> 0;
+    H[3] = (H[3]! + d) >>> 0;
+    H[4] = (H[4]! + e) >>> 0;
+    H[5] = (H[5]! + f) >>> 0;
+    H[6] = (H[6]! + g) >>> 0;
+    H[7] = (H[7]! + h) >>> 0;
+  }
+
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 8; i += 1) {
+    const word = H[i]!;
+    out[i * 4] = (word >>> 24) & 0xff;
+    out[i * 4 + 1] = (word >>> 16) & 0xff;
+    out[i * 4 + 2] = (word >>> 8) & 0xff;
+    out[i * 4 + 3] = word & 0xff;
+  }
+  return out;
+}

--- a/extensions/common/utilities/upload-cursor.ts
+++ b/extensions/common/utilities/upload-cursor.ts
@@ -1,4 +1,5 @@
 import { UploadCursor } from '../models/collections-data/sync-state';
+import { sha256 } from './sha256';
 
 /**
  * Pure helpers around the upload-sync cursor. The cursor is a per-(collection, itemId)
@@ -164,8 +165,13 @@ function canonicalizeValue(value: unknown): unknown {
 
 /**
  * Compute the 16-hex-character truncated SHA-256 hash of an arbitrary JSON-compatible
- * value. Uses Web Crypto's `crypto.subtle.digest('SHA-256', ...)`, which is available in
- * both browser (module) and Node 22 (sync-hook + test) runtimes.
+ * value. Prefers Web Crypto's `crypto.subtle.digest('SHA-256', ...)`; falls back to a
+ * pure-JS SHA-256 when `crypto.subtle` is unavailable. The fallback path matters because
+ * browsers only expose `crypto.subtle` in "secure contexts" — HTTPS, `localhost`, or
+ * `127.0.0.1`. Directus served on a plain-HTTP LAN address (e.g. `http://0.0.0.0:8055`)
+ * would otherwise crash Export with "Cannot read properties of undefined (reading
+ * 'digest')". Both paths produce identical SHA-256 bytes, so existing on-disk cursors
+ * stay valid across the switch.
  *
  * 16 hex chars = 64 bits of collision space. At expected scales (tens of thousands of
  * items per install), this is well below the birthday-paradox threshold and adequate for
@@ -175,11 +181,19 @@ function canonicalizeValue(value: unknown): unknown {
 export async function computeItemHash(value: unknown): Promise<string> {
   const canonical = canonicalizeForHash(value);
   const bytes = new TextEncoder().encode(canonical);
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
-  const view = new Uint8Array(digest);
+  const view = await digestSha256(bytes);
   let hex = '';
   for (let i = 0; i < 8; i += 1) {
     hex += view[i]!.toString(16).padStart(2, '0');
   }
   return hex;
+}
+
+async function digestSha256(bytes: Uint8Array<ArrayBuffer>): Promise<Uint8Array> {
+  const subtle = typeof crypto !== 'undefined' ? crypto.subtle : undefined;
+  if (subtle && typeof subtle.digest === 'function') {
+    const buf = await subtle.digest('SHA-256', bytes);
+    return new Uint8Array(buf);
+  }
+  return sha256(bytes);
 }


### PR DESCRIPTION
## Summary

Fixes Export crashing on Directus deployments served from plain-HTTP LAN addresses (e.g. `http://0.0.0.0:8055`) with `"Cannot read properties of undefined (reading 'digest')"`. Browsers only expose `crypto.subtle` in **secure contexts** — HTTPS, `localhost`, or `127.0.0.1` — and the upload-cursor item-hash sits in the hot path of every Export.

- New `extensions/common/utilities/sha256.ts` — pure-JS FIPS 180-4 SHA-256, byte-identical to `crypto.subtle.digest('SHA-256', ...)` so existing on-disk cursors stay valid across the switch.
- New `sha256.test.ts` — asserts parity against the standard NIST vectors and the empty-input baseline.
- `upload-cursor.ts` routes through a new `digestSha256()` helper that prefers `crypto.subtle.digest` and falls back to the pure-JS path when `crypto.subtle` is `undefined`. No behaviour change in secure contexts; Node 22 (sync-hook + tests) keeps using Web Crypto.

## Test plan

- [x] `vitest run sha256 upload-cursor` — 55 tests pass.
- [ ] Manual: serve Directus on `http://<LAN-IP>:8055` and trigger Export; previously crashed, should now succeed with hashes matching the Web-Crypto path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)