### PR TITLE
PR 43/N: language-display utility + v-select LanguageMappingsEditor

### DIFF
--- a/extensions/common/services/synchronization-languages-service.ts
+++ b/extensions/common/services/synchronization-languages-service.ts
@@ -5,7 +5,13 @@ import { DirectusApi } from '../interfaces/directus-api';
 import { CreateMissingLanguagesInDirectus } from '../enums/create-missing-languages-in-directus';
 import { Settings } from '../models/collections-data/settings';
 import { DirectusLocalazyLanguage } from '../models/directus-localazy-language';
+import { pickLanguageName } from '../utilities/language-display';
 import { DirectusLocalazyAdapter } from './directus-localazy-adapter';
+
+export type DirectusLanguageRow = {
+  code: string;
+  name: string | null;
+};
 
 type GetDirectusSourceLanguageAsLocalazyLanguage = {
   localazySourceLanguage: number;
@@ -24,6 +30,19 @@ export class SynchronizationLanguagesService {
       fields: [languageCodeField],
     });
     return result.map((item) => item[languageCodeField] as string);
+  }
+
+  async fetchDirectusLanguageRows(languageCollection: string, languageCodeField: string): Promise<DirectusLanguageRow[]> {
+    const result = await this.directusApi.fetchDirectusItems(languageCollection, {
+      fields: ['*'],
+    });
+    return result
+      .map((item) => {
+        const code = item[languageCodeField];
+        if (typeof code !== 'string' || code.length === 0) return null;
+        return { code, name: pickLanguageName(item as Record<string, unknown>) };
+      })
+      .filter((row): row is DirectusLanguageRow => row !== null);
   }
 
   async createLanguages(settings: Settings, localazyLanguages: Language[]) {

--- a/extensions/common/utilities/language-display.test.ts
+++ b/extensions/common/utilities/language-display.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { pickLanguageName, formatLanguageOption } from './language-display';
+
+describe('pickLanguageName', () => {
+  it('prefers `name` over other candidates', () => {
+    expect(pickLanguageName({ name: 'English', english_name: 'EN', label: 'Lang' })).toBe('English');
+  });
+
+  it('falls back through the candidate list in order', () => {
+    expect(pickLanguageName({ english_name: 'English (US)' })).toBe('English (US)');
+    expect(pickLanguageName({ label: 'English' })).toBe('English');
+    expect(pickLanguageName({ language: 'English' })).toBe('English');
+    expect(pickLanguageName({ title: 'English' })).toBe('English');
+  });
+
+  it('returns null when no candidate field has a usable string', () => {
+    expect(pickLanguageName({})).toBeNull();
+    expect(pickLanguageName(null)).toBeNull();
+    expect(pickLanguageName(undefined)).toBeNull();
+    expect(pickLanguageName({ name: '' })).toBeNull();
+    expect(pickLanguageName({ name: '   ' })).toBeNull();
+    expect(pickLanguageName({ name: 42 })).toBeNull();
+  });
+
+  it('ignores non-string values and unrelated columns', () => {
+    expect(pickLanguageName({ name: null, code: 'en', direction: 'ltr' })).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(pickLanguageName({ name: '  English  ' })).toBe('English');
+  });
+});
+
+describe('formatLanguageOption', () => {
+  it('renders `Name (code)` when a name is provided', () => {
+    expect(formatLanguageOption('en', 'English')).toBe('English (en)');
+  });
+
+  it('returns just the code when no name is provided', () => {
+    expect(formatLanguageOption('en', null)).toBe('en');
+    expect(formatLanguageOption('en', undefined)).toBe('en');
+    expect(formatLanguageOption('en', '')).toBe('en');
+  });
+
+  it('returns just the code when name equals the code', () => {
+    expect(formatLanguageOption('en', 'en')).toBe('en');
+  });
+});

--- a/extensions/common/utilities/language-display.ts
+++ b/extensions/common/utilities/language-display.ts
@@ -1,0 +1,19 @@
+const NAME_FIELD_CANDIDATES = ['name', 'english_name', 'label', 'language', 'title'] as const;
+
+export function pickLanguageName(row: Record<string, unknown> | null | undefined): string | null {
+  if (!row) return null;
+  for (const field of NAME_FIELD_CANDIDATES) {
+    const value = row[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+export function formatLanguageOption(code: string, name: string | null | undefined): string {
+  if (name && name !== code) {
+    return `${name} (${code})`;
+  }
+  return code;
+}

--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -46,7 +46,11 @@
         </p>
       </div>
 
-      <LanguageMappingsEditor v-model="localEdits.language_mappings" />
+      <LanguageMappingsEditor
+        v-model="localEdits.language_mappings"
+        :language-collection="localEdits.language_collection"
+        :language-code-field="localEdits.language_code_field"
+      />
     </div>
   </div>
 </template>

--- a/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
+++ b/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
@@ -2,82 +2,326 @@
   <div class="language-mappings">
     <v-divider :inline-title="false" large>Custom language mappings</v-divider>
 
-    <p class="note description">
-      Define custom mappings between Directus and Localazy language codes. Use this when the default transformation isn't enough — e.g.,
-      Directus's <code>zh-Hans</code> needs to map to Localazy's <code>zh-CN#Hans</code>.
-    </p>
+    <div class="description">
+      <p class="note">
+        Define custom mappings between Directus and Localazy language codes. Use this when the default transformation isn't enough — e.g.,
+        Directus's <code>zh-Hans</code> needs to map to Localazy's <code>zh-CN#Hans</code>.
+      </p>
+      <p class="note">
+        Pick the Directus language from your configured collection, and the matching Localazy locale from the supported list.
+      </p>
+    </div>
 
-    <div v-if="parsedMappings.length > 0" class="mappings-list">
-      <div class="mapping-row header">
-        <span class="type-label">Directus code</span>
-        <span class="type-label">Localazy code</span>
-        <span class="type-label">Actions</span>
+    <v-notice v-if="!isConfigured" type="info">
+      Configure the Directus languages collection in the
+      <router-link to="/localazy/project-setup">Project setup page</router-link>
+      before defining custom mappings.
+    </v-notice>
+
+    <template v-else>
+      <div v-if="rows.length > 0" class="mappings-list">
+        <div class="mapping-row header">
+          <span class="type-label">Directus code</span>
+          <span class="type-label">Localazy code</span>
+          <span class="type-label actions-header">Actions</span>
+        </div>
+
+        <div v-for="row in rows" :key="row.id" class="mapping-row" :class="{ 'is-editing': row.editing !== null }">
+          <template v-if="row.editing !== null">
+            <div class="field-cell">
+              <v-select
+                v-model="row.editing.directusCode"
+                :items="directusOptionsForRow(row)"
+                placeholder="Select Directus language"
+                :class="{ 'has-error': showError(row, 'directusCode') }"
+                @update:model-value="onFieldChange(row, 'directusCode')"
+              />
+              <p v-if="showError(row, 'directusCode')" class="field-error">{{ row.errors.directusCode }}</p>
+            </div>
+            <div class="field-cell">
+              <v-select
+                v-model="row.editing.localazyCode"
+                :items="localazyOptionsForRow(row)"
+                placeholder="Select Localazy locale"
+                :class="{ 'has-error': showError(row, 'localazyCode') }"
+                @update:model-value="onFieldChange(row, 'localazyCode')"
+              />
+              <p v-if="showError(row, 'localazyCode')" class="field-error">{{ row.errors.localazyCode }}</p>
+            </div>
+            <div class="actions">
+              <v-button v-tooltip="'Cancel'" icon rounded secondary @click="cancelEdit(row)">
+                <v-icon name="close" />
+              </v-button>
+              <v-button v-tooltip="'Save'" icon rounded :disabled="!isRowValid(row)" @click="saveEdit(row)">
+                <v-icon name="check" />
+              </v-button>
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="value-cell">
+              <code>{{ row.saved!.directusCode }}</code>
+              <v-icon
+                v-if="isDirectusCodeStale(row.saved!.directusCode)"
+                v-tooltip="'No longer present in the Directus languages collection'"
+                name="warning"
+                small
+                class="stale-icon"
+              />
+            </div>
+            <div class="value-cell">
+              <code>{{ row.saved!.localazyCode }}</code>
+              <v-icon
+                v-if="isLocalazyCodeStale(row.saved!.localazyCode)"
+                v-tooltip="'Not a known Localazy locale'"
+                name="warning"
+                small
+                class="stale-icon"
+              />
+            </div>
+            <div class="actions">
+              <v-button v-tooltip="'Edit'" icon rounded secondary :disabled="isAnyEditing" @click="startEdit(row)">
+                <v-icon name="edit" />
+              </v-button>
+              <v-button v-tooltip="'Delete'" icon rounded secondary :disabled="isAnyEditing" @click="removeRow(row)">
+                <v-icon name="delete" />
+              </v-button>
+            </div>
+          </template>
+        </div>
       </div>
-      <div v-for="(mapping, index) in parsedMappings" :key="index" class="mapping-row">
-        <v-input v-model="mapping.directusCode" placeholder="e.g., zh-Hans" @update:model-value="emitChange" />
-        <v-input v-model="mapping.localazyCode" placeholder="e.g., zh-CN#Hans" @update:model-value="emitChange" />
-        <v-button icon rounded secondary @click="removeMapping(index)">
-          <v-icon name="delete" />
-        </v-button>
+
+      <div v-else class="empty-state">
+        <p class="note">No custom mappings configured. Default behaviour swaps <code>-</code> and <code>_</code> in both directions.</p>
       </div>
-    </div>
 
-    <div v-else class="empty-state">
-      <p class="note">No custom mappings configured. Default behaviour swaps <code>-</code> and <code>_</code> in both directions.</p>
-    </div>
-
-    <v-button class="add-button" secondary @click="addMapping">
-      <v-icon name="add" left />
-      Add mapping
-    </v-button>
-
-    <div v-if="validationErrors.length > 0" class="validation-errors">
-      <v-notice type="danger">
-        <ul>
-          <li v-for="error in validationErrors" :key="error">{{ error }}</li>
-        </ul>
-      </v-notice>
-    </div>
+      <v-button class="add-button" secondary :disabled="isAnyEditing" @click="addMapping">
+        <v-icon name="add" left />
+        Add mapping
+      </v-button>
+    </template>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
+import { computed, ref, toRef, watch } from 'vue';
+import { useItems } from '@directus/extensions-sdk';
+import { Item } from '@directus/types';
+import { getLocalazyLanguages } from '@localazy/languages';
 import { LanguageMappings } from '../../../../common/models/language-mapping';
-import { LanguageMappingService } from '../../../../common/services/language-mapping-service';
+import { SelectItem } from '../../models/directus/internals/select-item';
+import { formatLanguageOption, pickLanguageName } from '../../../../common/utilities/language-display';
+
+type FieldKey = 'directusCode' | 'localazyCode';
+
+type Codes = { directusCode: string; localazyCode: string };
+
+type Row = {
+  id: number;
+  saved: Codes | null;
+  editing: Codes | null;
+  touched: Record<FieldKey, boolean>;
+  errors: Record<FieldKey, string | null>;
+};
+
+const props = defineProps<{
+  languageCollection: string;
+  languageCodeField: string;
+}>();
 
 const modelValue = defineModel<string>({ default: '[]' });
 
-const parsedMappings = ref<LanguageMappings>([]);
-const validationErrors = ref<string[]>([]);
+const isConfigured = computed(() => !!props.languageCollection && !!props.languageCodeField);
+
+const languageCollectionRef = toRef(props, 'languageCollection');
+
+const { items: languageItems } = useItems(languageCollectionRef, {
+  fields: ref(['*']),
+  limit: ref(-1),
+  sort: ref(null),
+  search: ref(null),
+  filter: ref(null),
+  page: ref(null),
+});
+
+const directusCodeOptions = computed<SelectItem[]>(() => {
+  if (!isConfigured.value || !languageItems.value) return [];
+  const field = props.languageCodeField;
+  return (languageItems.value as Item[])
+    .map((item) => ({ code: item[field] as unknown, item }))
+    .filter((entry): entry is { code: string; item: Item } => typeof entry.code === 'string' && entry.code.length > 0)
+    .map(({ code, item }) => ({
+      text: formatLanguageOption(code, pickLanguageName(item as Record<string, unknown>)),
+      value: code,
+    }));
+});
+
+const directusCodeSet = computed(() => new Set(directusCodeOptions.value.map((o) => o.value)));
+
+const localazyCodeOptions = computed<SelectItem[]>(() =>
+  getLocalazyLanguages()
+    .map((lang) => ({ text: `${lang.name} (${lang.locale})`, value: lang.locale }))
+    .sort((a, b) => a.text.localeCompare(b.text)),
+);
+
+const localazyCodeSet = computed(() => new Set(localazyCodeOptions.value.map((o) => o.value)));
+
+let nextId = 1;
+let lastEmitted: string | null = null;
+const rows = ref<Row[]>([]);
+
+const isAnyEditing = computed(() => rows.value.some((r) => r.editing !== null));
 
 watch(
   modelValue,
   (value) => {
+    if (value === lastEmitted) return;
     try {
-      parsedMappings.value = JSON.parse(value || '[]') as LanguageMappings;
+      const parsed = JSON.parse(value || '[]') as LanguageMappings;
+      rows.value = parsed.map((m) => createRow({ directusCode: m.directusCode, localazyCode: m.localazyCode }));
     } catch {
-      parsedMappings.value = [];
+      rows.value = [];
     }
   },
   { immediate: true },
 );
 
-function emitChange() {
-  const json = JSON.stringify(parsedMappings.value);
-  const validation = LanguageMappingService.validateMappings(json);
-  validationErrors.value = validation.errors;
-  modelValue.value = json;
+watch([directusCodeOptions, localazyCodeOptions], () => {
+  rows.value.forEach((row) => {
+    if (row.editing) validateRow(row);
+  });
+});
+
+function createRow(saved: Codes | null): Row {
+  return {
+    id: nextId++,
+    saved,
+    editing: null,
+    touched: { directusCode: false, localazyCode: false },
+    errors: { directusCode: null, localazyCode: null },
+  };
+}
+
+function startEdit(row: Row) {
+  if (!row.saved || isAnyEditing.value) return;
+  row.editing = { ...row.saved };
+  row.touched = { directusCode: false, localazyCode: false };
+  validateRow(row);
+}
+
+function cancelEdit(row: Row) {
+  if (row.saved === null) {
+    rows.value = rows.value.filter((r) => r.id !== row.id);
+    return;
+  }
+  row.editing = null;
+  row.touched = { directusCode: false, localazyCode: false };
+  row.errors = { directusCode: null, localazyCode: null };
+}
+
+function saveEdit(row: Row) {
+  if (!row.editing || !isRowValid(row)) return;
+  row.saved = { ...row.editing };
+  row.editing = null;
+  row.touched = { directusCode: false, localazyCode: false };
+  row.errors = { directusCode: null, localazyCode: null };
+  emitChange();
+}
+
+function removeRow(row: Row) {
+  rows.value = rows.value.filter((r) => r.id !== row.id);
+  emitChange();
 }
 
 function addMapping() {
-  parsedMappings.value.push({ directusCode: '', localazyCode: '' });
-  emitChange();
+  if (isAnyEditing.value) return;
+  const newRow = createRow(null);
+  newRow.editing = { directusCode: '', localazyCode: '' };
+  rows.value.push(newRow);
 }
 
-function removeMapping(index: number) {
-  parsedMappings.value.splice(index, 1);
-  emitChange();
+function onFieldChange(row: Row, field: FieldKey) {
+  row.touched[field] = true;
+  validateRow(row);
+}
+
+function validateRow(row: Row) {
+  if (!row.editing) {
+    row.errors = { directusCode: null, localazyCode: null };
+    return;
+  }
+  row.errors = {
+    directusCode: fieldError(row, 'directusCode'),
+    localazyCode: fieldError(row, 'localazyCode'),
+  };
+}
+
+function fieldError(row: Row, field: FieldKey): string | null {
+  const value = row.editing![field];
+  if (value === '' || value === null) {
+    return field === 'directusCode' ? 'Select a Directus language' : 'Select a Localazy locale';
+  }
+  const duplicate = rows.value.some((other) => other.id !== row.id && effectiveCode(other, field) === value);
+  if (duplicate) {
+    const label = field === 'directusCode' ? 'Directus' : 'Localazy';
+    return `Duplicate ${label} code "${value}"`;
+  }
+  return null;
+}
+
+function effectiveCode(row: Row, field: FieldKey): string | null {
+  if (row.editing) return row.editing[field];
+  if (row.saved) return row.saved[field];
+  return null;
+}
+
+function showError(row: Row, field: FieldKey): boolean {
+  return row.touched[field] && row.errors[field] !== null;
+}
+
+function isRowValid(row: Row): boolean {
+  if (!row.editing) return false;
+  return (
+    row.errors.directusCode === null &&
+    row.errors.localazyCode === null &&
+    row.editing.directusCode !== '' &&
+    row.editing.localazyCode !== ''
+  );
+}
+
+function isDirectusCodeStale(code: string): boolean {
+  return directusCodeOptions.value.length > 0 && !directusCodeSet.value.has(code);
+}
+
+function isLocalazyCodeStale(code: string): boolean {
+  return !localazyCodeSet.value.has(code);
+}
+
+function directusOptionsForRow(row: Row): SelectItem[] {
+  const opts = directusCodeOptions.value;
+  const current = row.editing?.directusCode;
+  if (current && !directusCodeSet.value.has(current)) {
+    return [{ text: `${current} (no longer exists)`, value: current }, ...opts];
+  }
+  return opts;
+}
+
+function localazyOptionsForRow(row: Row): SelectItem[] {
+  const opts = localazyCodeOptions.value;
+  const current = row.editing?.localazyCode;
+  if (current && !localazyCodeSet.value.has(current)) {
+    return [{ text: `${current} (unknown locale)`, value: current }, ...opts];
+  }
+  return opts;
+}
+
+function emitChange() {
+  const mappings: LanguageMappings = rows.value
+    .filter((r) => r.saved !== null)
+    .map((r) => ({ directusCode: r.saved!.directusCode, localazyCode: r.saved!.localazyCode }));
+  const json = JSON.stringify(mappings);
+  lastEmitted = json;
+  modelValue.value = json;
 }
 </script>
 
@@ -89,7 +333,15 @@ function removeMapping(index: number) {
 }
 
 .description {
-  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+  margin-bottom: 24px;
+}
+
+.description .note {
+  margin: 0;
 }
 
 .mappings-list {
@@ -103,11 +355,55 @@ function removeMapping(index: number) {
   display: grid;
   grid-template-columns: 1fr 1fr auto;
   gap: 12px;
-  align-items: center;
+  align-items: start;
 
   &.header {
     margin-bottom: 8px;
+    align-items: center;
   }
+
+  &:not(.is-editing):not(.header) {
+    align-items: center;
+  }
+}
+
+.actions-header {
+  text-align: right;
+}
+
+.field-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-error {
+  margin: 0;
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--danger);
+}
+
+.value-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+}
+
+.stale-icon {
+  color: var(--warning);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.has-error :deep(.v-input),
+.has-error :deep(.v-select) {
+  border-color: var(--danger);
 }
 
 .empty-state {
@@ -119,15 +415,6 @@ function removeMapping(index: number) {
 
 .add-button {
   margin-bottom: 20px;
-}
-
-.validation-errors {
-  margin-top: 12px;
-
-  ul {
-    margin: 0;
-    padding-left: 20px;
-  }
 }
 
 .note {

--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -64,6 +64,7 @@ import { SelectItem } from '../../models/directus/internals/select-item';
 import { Settings } from '../../../../common/models/collections-data/settings';
 import { getConfig } from '../../../../common/config/get-config';
 import { DirectusLocalazyAdapter } from '../../../../common/services/directus-localazy-adapter';
+import { formatLanguageOption, pickLanguageName } from '../../../../common/utilities/language-display';
 import LoginButton from './LoginButton.vue';
 import LogoutButton from './LogoutButton.vue';
 import { useDirectusCollectionsStoreRefs, useDirectusFieldsStore } from '../../composables/use-directus-stores';
@@ -143,9 +144,11 @@ const possibleLanguageCodeFields = computed((): SelectItem[] => {
 const languages: Ref<Item[]> = ref([]);
 const languageSelectOptions = computed(() =>
   languages.value.map((item) => {
+    const code = item[localEdits.value.language_code_field] as string;
+    const name = pickLanguageName(item as Record<string, unknown>);
     const option: SelectItem = {
-      text: item[localEdits.value.language_code_field],
-      value: item[localEdits.value.language_code_field],
+      text: formatLanguageOption(code, name),
+      value: code,
     };
     return option;
   }),

--- a/extensions/module/src/composables/use-directus-languages.ts
+++ b/extensions/module/src/composables/use-directus-languages.ts
@@ -4,7 +4,7 @@ import { useErrorsStore } from '../stores/errors-store';
 import { Settings } from '../../../common/models/collections-data/settings';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { DirectusLocalazyLanguage } from '../../../common/models/directus-localazy-language';
-import { SynchronizationLanguagesService } from '../../../common/services/synchronization-languages-service';
+import { DirectusLanguageRow, SynchronizationLanguagesService } from '../../../common/services/synchronization-languages-service';
 import { DirectusModuleApi } from '../services/directus-module-api';
 import { useDirectusCollectionsStore } from './use-directus-stores';
 
@@ -17,6 +17,15 @@ export function useDirectusLanguages() {
   async function fetchDirectusLanguages(languageCollection: string, languageCodeField: string): Promise<string[]> {
     try {
       return synchronizationLanguagesService.fetchDirectusLanguages(languageCollection, languageCodeField);
+    } catch (e: unknown) {
+      addDirectusError(e);
+      return [];
+    }
+  }
+
+  async function fetchDirectusLanguageRows(languageCollection: string, languageCodeField: string): Promise<DirectusLanguageRow[]> {
+    try {
+      return synchronizationLanguagesService.fetchDirectusLanguageRows(languageCollection, languageCodeField);
     } catch (e: unknown) {
       addDirectusError(e);
       return [];
@@ -49,5 +58,6 @@ export function useDirectusLanguages() {
     resolveExportLanguages,
     resolveImportLanguages,
     fetchDirectusLanguages,
+    fetchDirectusLanguageRows,
   };
 }


### PR DESCRIPTION
## Summary

Custom language mappings were edited as free-text `<v-input>` pairs, so typos silently produced mappings that never matched a real Directus language or Localazy locale. The Project Setup language dropdown showed raw codes (`en-US`, `cs`), making installs with several locale variants hard to tell apart.

- New `extensions/common/utilities/language-display.ts` (+ test) — shared `pickLanguageName()` (curated field-name search) and `formatLanguageOption()` (`"Name (code)"`).
- `SynchronizationLanguagesService.fetchDirectusLanguageRows()` — returns `{ code, name }` pairs.
- `useDirectusLanguages()` exposes a wrapper for the new fetcher.
- `ProjectSetupForm.vue` uses `formatLanguageOption` for the language dropdown; selection value unchanged.
- `LanguageMappingsEditor.vue` rewritten — two `<v-select>`s per row (Directus codes from the configured collection, Localazy locales from `@localazy/languages`); in-place edit / save / cancel flow; stale-row warning icons; `v-notice` linking to Project Setup when prerequisites aren't configured.
- `AdvancedSettingsForm.vue` passes `language-collection` / `language-code-field` props to the editor.

## Test plan

- [x] `vitest run language-display` — 8 tests pass.
- [ ] Manual: open Additional Settings → Custom mappings, add a row, confirm Directus list only contains codes from the configured collection and Localazy list comes from `@localazy/languages`.
- [ ] Manual: remove a language from Directus and reopen — saved row should display the warning icon for the stale code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)