### PR TITLE
PR 44/N: Overview page UI redesign

### DIFF
--- a/extensions/module/src/Overview.vue
+++ b/extensions/module/src/Overview.vue
@@ -12,7 +12,7 @@
       <errors-notice class="notice" :localazy-data="localazyData" />
 
       <connection-overview class="overview-block" :localazy-data="localazyData" :settings="settings" />
-      <connection-languages class="overview-block mt-8" :settings="settings" />
+      <connection-languages class="mt-8" :settings="settings" />
     </div>
 
     <div v-else class="hydrating">
@@ -65,8 +65,10 @@ onBeforeMount(() => {
 }
 
 .overview-block {
-  background-color: var(--background-normal);
-  padding: 1rem;
+  background-color: var(--background-normal, var(--theme--background-normal, var(--theme--background)));
+  border: 1px solid var(--border-normal, var(--theme--border-color-accent));
+  border-radius: var(--border-radius, var(--theme--border-radius));
+  padding: 20px;
 }
 
 .notice {
@@ -75,7 +77,7 @@ onBeforeMount(() => {
 }
 
 .mt-8 {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
 }
 
 .hydrating {

--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -1,15 +1,26 @@
 <template>
   <div v-if="languageRows.length > 0" class="languages-table">
-    <div class="header">Language</div>
-    <div class="header">Present in Localazy</div>
-    <div class="header">Present in Directus</div>
+    <div class="row header-row">
+      <div class="cell header">Language</div>
+      <div class="cell header">Present in Localazy</div>
+      <div class="cell header">Present in Directus</div>
+    </div>
 
-    <template v-for="(data, index) in languageRows" :key="index">
-      <div class="font-normal">
-        {{ data.locale }}
-        <span v-if="data.englishName">({{ data.englishName }})</span>
+    <div v-for="(data, index) in languageRows" :key="index" class="row">
+      <div class="cell language-cell font-normal">
+        <span class="locale">{{ data.locale }}</span>
+        <span v-if="data.directusName" class="english-name">({{ data.directusName }})</span>
+        <span v-else-if="data.englishName" class="english-name">({{ data.englishName }})</span>
+        <span v-if="data.customMapping" class="mapping-chip" :title="mappingTooltip(data.customMapping)">
+          <v-icon small name="swap_horiz" />
+          <span class="mapping-codes">
+            <code>{{ data.customMapping.directusCode }}</code>
+            <span class="mapping-arrow">↔</span>
+            <code>{{ data.customMapping.localazyCode }}</code>
+          </span>
+        </span>
       </div>
-      <div class="ml-2">
+      <div class="cell">
         <v-icon
           v-if="!data.directus.recognizedInLocalazy"
           name="error"
@@ -32,7 +43,7 @@
           <v-icon small name="help_outline" title="This language is defined in a different form in Localazy" />
         </span>
       </div>
-      <div class="ml-2">
+      <div class="cell">
         <v-icon
           v-if="data.directus.present || data.directus.presentMapped"
           name="check"
@@ -46,7 +57,7 @@
           <v-icon small name="help_outline" title="This language is defined in a different form in Directus" />
         </span>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -59,11 +70,14 @@ import { useLocalazyStore } from '../../stores/localazy-store';
 import { useDirectusLanguages } from '../../composables/use-directus-languages';
 import { DirectusLocalazyAdapter } from '../../../../common/services/directus-localazy-adapter';
 import { Settings } from '../../../../common/models/collections-data/settings';
+import { LanguageMapping, LanguageMappings } from '../../../../common/models/language-mapping';
 
 type Row = {
   locale: string;
   englishName?: string;
+  directusName?: string;
   localazyId?: number;
+  customMapping: LanguageMapping | null;
   localazy: {
     present: boolean;
     presentMapped: boolean;
@@ -86,22 +100,56 @@ const props = defineProps({
 });
 
 const { localazyProject } = storeToRefs(useLocalazyStore());
-const { fetchDirectusLanguages } = useDirectusLanguages();
+const { fetchDirectusLanguageRows } = useDirectusLanguages();
 
-const directusLanguages = ref<string[]>([]);
+const directusLanguageRows = ref<{ code: string; name: string | null }[]>([]);
+const directusLanguages = computed(() => directusLanguageRows.value.map((r) => r.code));
+const directusNameByCode = computed(() => {
+  const map = new Map<string, string>();
+  directusLanguageRows.value.forEach((row) => {
+    if (row.name) map.set(row.code, row.name);
+  });
+  return map;
+});
 
 watch(
   () => props.settings,
   (s) => {
     if (s?.language_collection && s?.language_code_field) {
-      // Fire-and-forget: rejection logs through fetchDirectusLanguages' own try/catch.
-      void fetchDirectusLanguages(s.language_collection, s.language_code_field).then((languages) => {
-        directusLanguages.value = languages;
+      // Fire-and-forget: rejection logs through fetchDirectusLanguageRows' own try/catch.
+      void fetchDirectusLanguageRows(s.language_collection, s.language_code_field).then((rows) => {
+        directusLanguageRows.value = rows;
       });
     }
   },
   { immediate: true, deep: true },
 );
+
+const customMappings = computed((): LanguageMappings => {
+  try {
+    const parsed = JSON.parse(props.settings?.language_mappings || '[]') as unknown;
+    return Array.isArray(parsed) ? (parsed as LanguageMappings).filter((m) => m?.directusCode && m?.localazyCode) : [];
+  } catch {
+    return [];
+  }
+});
+
+function findCustomMapping(locale: string, directusFormLocale: string, localazyFormLocale: string): LanguageMapping | null {
+  return (
+    customMappings.value.find(
+      (m) =>
+        m.directusCode === locale ||
+        m.localazyCode === locale ||
+        m.directusCode === directusFormLocale ||
+        m.localazyCode === localazyFormLocale,
+    ) || null
+  );
+}
+
+function mappingTooltip(m: LanguageMapping): string {
+  const base = `Custom mapping: Directus "${m.directusCode}" ↔ Localazy "${m.localazyCode}"`;
+  return m.description ? `${base} — ${m.description}` : base;
+}
 
 const languageRows = computed((): Row[] => {
   const localazyLanguages = localazyProject.value?.languages || [];
@@ -117,6 +165,8 @@ const languageRows = computed((): Row[] => {
       locale,
       localazyId: localazyLanguage?.localazyId,
       englishName: localazyLanguage?.name,
+      directusName: directusNameByCode.value.get(locale) ?? directusNameByCode.value.get(directusFormLocale),
+      customMapping: findCustomMapping(locale, directusFormLocale, localazyFormLocale),
       localazy: {
         present: localazyLocales.includes(locale),
         presentMapped: localazyLocales.includes(localazyFormLocale),
@@ -157,10 +207,106 @@ const languageRows = computed((): Row[] => {
 <style lang="scss" scoped>
 @use '../../styles/mixins/common' as *;
 
+$divider-color: var(--border-normal, var(--theme--border-color-accent));
+$radius: var(--border-radius, var(--theme--border-radius));
+$bg-card: var(--background-normal, var(--theme--background-normal, var(--theme--background)));
+$bg-subdued: var(--background-subdued, var(--theme--background-subdued));
+$fg-normal: var(--foreground-normal, var(--theme--foreground));
+$fg-subdued: var(--foreground-subdued, var(--theme--foreground-subdued));
+$fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme--foreground)));
+$mono: var(--family-monospace, var(--theme--family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace));
+
 .languages-table {
   @include common;
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $divider-color;
+  border-radius: $radius;
+  overflow: hidden;
+}
+
+.row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr;
+  align-items: center;
+  position: relative;
+
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 0;
+    height: 1px;
+    background-color: $divider-color;
+  }
+
+  &.header-row::after {
+    left: 0;
+    right: 0;
+  }
+}
+
+.header-row {
+  background-color: $bg-subdued;
+}
+
+.cell {
+  padding: 7px 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+}
+
+.header {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $fg-accent;
+}
+
+.language-cell {
+  flex-wrap: wrap;
+}
+
+.locale {
+  font-weight: 500;
+}
+
+.english-name {
+  color: $fg-subdued;
+}
+
+.mapping-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding: 2px 8px;
+  background: $bg-subdued;
+  border: 1px solid $divider-color;
+  border-radius: $radius;
+  font-size: 12px;
+  color: $fg-normal;
+
+  code {
+    background: transparent;
+    font-family: $mono;
+    font-size: 12px;
+  }
+}
+
+.mapping-codes {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mapping-arrow {
+  color: var(--foreground-subdued);
 }
 
 .unknown-language {

--- a/extensions/module/src/components/Overview/ConnectionOverview.vue
+++ b/extensions/module/src/components/Overview/ConnectionOverview.vue
@@ -1,68 +1,63 @@
 <template>
   <div class="connection-overview">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex flex-col">
-        <span class="font-medium">Localazy connection</span>
-        <div v-if="isConnecting" class="flex items-center">
-          <div class="rounded-full bg-warning w-4 h-4 mr-2" />
-          <span class="font-medium">Connecting to Localazy</span>
-        </div>
-
-        <div v-else-if="isConnected" class="flex items-center">
-          <div class="rounded-full bg-success w-4 h-4 mr-2" />
-          <div class="text-foreground-normal font-normal">
-            {{ localazyProject?.name }}
-          </div>
-        </div>
-
-        <div v-else class="flex items-center">
-          <div class="rounded-full bg-danger w-4 h-4 mr-2" />
-          <span class="font-medium">Not connected to Localazy</span>
+    <div class="overview-header">
+      <div class="connection-info">
+        <span class="connection-label">Localazy connection</span>
+        <div class="connection-status">
+          <span class="status-pill" :class="statusPillClass">
+            <span class="status-dot" />
+            {{ statusLabel }}
+          </span>
+          <span v-if="isConnected" class="project-name">{{ localazyProject?.name }}</span>
         </div>
       </div>
 
-      <div class="flex">
-        <v-icon
-          name="sync"
-          class="mr-2"
-          :class="{
-            'disabled-link': !hasLocalazyToken,
-            'cursor-pointer': hasLocalazyToken,
-          }"
+      <div class="header-actions">
+        <button
+          type="button"
+          class="header-action"
+          :class="{ 'header-action--disabled': !hasLocalazyToken }"
+          :disabled="!hasLocalazyToken"
           title="Reconnect to Localazy"
           @click="onReconnect"
-        />
+        >
+          <v-icon name="sync" />
+        </button>
 
         <component
           :is="isConnected ? 'a' : 'span'"
           :href="localazyProject?.url || undefined"
           target="_blank"
-          class="open-link"
-          title="Open Localazy project in a new tab."
-          :class="{
-            'disabled-link': !isConnected,
-          }"
+          class="header-action"
+          :class="{ 'header-action--disabled': !isConnected }"
+          title="Open Localazy project in a new tab"
         >
           <v-icon name="open_in_new" />
         </component>
       </div>
     </div>
 
-    <div v-if="isConnected" class="flex organization-overview">
-      <div class="flex flex-col">
-        <span class="font-medium">Directus Source language</span>
-        <span class="font-normal">{{ settings?.source_language }} ({{ directusSourceLanguage?.name }})</span>
+    <div v-if="isConnected" class="overview-body">
+      <div class="metric">
+        <span class="metric-label">Directus source language</span>
+        <span class="metric-value">
+          {{ settings?.source_language }}
+          <span class="metric-meta">({{ directusSourceLanguage?.name }})</span>
+        </span>
       </div>
 
-      <div class="flex flex-col">
-        <span class="font-medium">Localazy Source language</span>
-        <span class="font-normal">{{ localazySourceLanguage?.locale }} ({{ localazySourceLanguage?.name }})</span>
+      <div class="metric">
+        <span class="metric-label">Localazy source language</span>
+        <span class="metric-value">
+          {{ localazySourceLanguage?.locale }}
+          <span class="metric-meta">({{ localazySourceLanguage?.name }})</span>
+        </span>
       </div>
 
-      <div class="flex flex-col">
-        <span class="font-medium">Organization keys</span>
-        <span class="font-normal" :class="{ 'over-key-limit': exceededKeyLimit }">
-          {{ localazyProject?.organization.usedKeys }} / {{ localazyProject?.organization.availableKeys }}
+      <div class="metric">
+        <span class="metric-label">Organization keys</span>
+        <span class="metric-value" :class="{ 'over-key-limit': exceededKeyLimit }">
+          {{ formattedUsedKeys }} <span class="metric-meta">/ {{ formattedAvailableKeys }}</span>
         </span>
       </div>
     </div>
@@ -104,6 +99,23 @@ const directusSourceLanguage = computed(() => {
   return findLocalazyLanguageByLocale(DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage(props.settings.source_language));
 });
 
+const statusLabel = computed(() => {
+  if (isConnecting.value) return 'Connecting';
+  if (isConnected.value) return 'Connected';
+  return 'Not connected';
+});
+
+const statusPillClass = computed(() => {
+  if (isConnecting.value) return 'status-pill--warning';
+  if (isConnected.value) return 'status-pill--success';
+  return 'status-pill--danger';
+});
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const formatNumber = (n: number | undefined | null): string => (typeof n === 'number' ? numberFormatter.format(n) : '—');
+const formattedUsedKeys = computed(() => formatNumber(localazyProject.value?.organization.usedKeys));
+const formattedAvailableKeys = computed(() => formatNumber(localazyProject.value?.organization.availableKeys));
+
 async function onReconnect() {
   if (hasLocalazyToken.value) {
     await hydrateLocalazyData({ force: true, localazyData: props.localazyData });
@@ -116,34 +128,180 @@ async function onReconnect() {
 
 .connection-overview {
   @include common;
-}
-
-.disabled-link {
-  opacity: 0.5;
-  color: var(--foreground-subdued);
-  fill: var(--foreground-subdued);
-}
-
-.source-language {
-  margin-bottom: 1rem;
-  @media (min-width: 960px) {
-    margin-right: 18rem;
-    margin-bottom: 0rem;
-  }
-}
-
-.organization-overview {
+  display: flex;
   flex-direction: column;
-  gap: 2rem;
+}
 
-  @media (min-width: 960px) {
-    flex-direction: row;
-    gap: 4rem;
+.overview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.connection-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+$divider-color: var(--border-normal, var(--theme--border-color-accent));
+$radius: var(--border-radius, var(--theme--border-radius));
+$fg-normal: var(--foreground-normal, var(--theme--foreground));
+$fg-subdued: var(--foreground-subdued, var(--theme--foreground-subdued));
+$fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme--foreground)));
+
+.connection-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $fg-accent;
+}
+
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+
+  .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: currentColor;
+  }
+}
+
+.status-pill--success {
+  background: var(--success-25, rgba(46, 184, 124, 0.12));
+  color: var(--success);
+}
+
+.status-pill--warning {
+  background: var(--warning-25, rgba(255, 167, 38, 0.15));
+  color: var(--warning);
+
+  .status-dot {
+    animation: pulse 1.6s ease-in-out infinite;
+  }
+}
+
+.status-pill--danger {
+  background: var(--danger-25, rgba(231, 76, 60, 0.12));
+  color: var(--danger);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.project-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: $fg-normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.header-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: $radius;
+  border: none;
+  background: transparent;
+  color: $fg-normal;
+  cursor: pointer;
+  transition: background-color var(--fast) var(--transition);
+  text-decoration: none;
+
+  &:hover {
+    background-color: var(--background-subdued);
   }
 
-  margin-top: 1rem;
-  border-top: 1px solid var(--border-normal);
-  padding-top: 1rem;
+  &--disabled,
+  &--disabled:hover {
+    opacity: 0.4;
+    cursor: not-allowed;
+    background: transparent;
+    pointer-events: none;
+  }
+}
+
+.overview-body {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid $divider-color;
+
+  @media (min-width: 720px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+  }
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  background: var(--background-subdued);
+  border-radius: $radius;
+  min-width: 0;
+}
+
+.metric-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $fg-accent;
+}
+
+.metric-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: $fg-normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-meta {
+  font-weight: 400;
+  color: $fg-subdued;
 }
 
 .over-key-limit {


### PR DESCRIPTION
## Summary

Tightens the Overview page so "is this set up correctly?" is answerable at a glance, and surfaces any custom language mappings that are silently in effect.

- `ConnectionOverview.vue` — inline colored-dot + label replaced with a Strapi-style status pill (Connected / Connecting / Not connected) tinted from the Directus theme. Reconnect + open-in-Localazy become icon buttons with hover/disabled state. Source-language + org-key stats render as labelled metric cards. Key counts pass through `Intl.NumberFormat('en-US')`.
- `ConnectionLanguages.vue` — restructures the languages grid into a proper card (sticky header, hairline dividers, consistent padding). Each row resolves the Directus-side language name via `fetchDirectusLanguageRows` (PR 43). New mapping chip surfaces any custom language mapping affecting the row, with tooltip carrying the optional description.
- `Overview.vue` — `.overview-block` switches to Directus 11 theme variables (with v10 fallbacks).

Depends on PR 43 (`fetchDirectusLanguageRows`, language-display helpers).

## Test plan

- [x] `vue-tsc --noEmit` — clean.
- [ ] Manual: load Overview connected; pill is green, status reads "Connected".
- [ ] Manual: load Overview without an access token; pill is red, "Not connected".
- [ ] Manual: with a custom mapping configured, confirm the chip renders next to the matching language row and the tooltip shows the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)