### PR TITLE
PR 45/N (Stage 5): upload-path sync-log writer + adapter setup-scope fix

### DIFF
--- a/extensions/module/src/composables/use-export-to-localazy.ts
+++ b/extensions/module/src/composables/use-export-to-localazy.ts
@@ -171,7 +171,7 @@ export const useExportToLocalazy = (token: Ref<string>) => {
 
       loading.value = false;
       // The orchestrator (`onExport`) owns the final summary message — including the
-      // empty-content short-circuit ("All items already uploaded — nothing to push") and
+      // empty-content short-circuit ("Already up to date — no items have changed…") and
       // the populated summary ("Uploaded N items in T.Ts."). Adding `EXPORT_FINISHED`
       // here too would render a duplicate row in the progress modal.
       // Analytics is fire-and-forget; export completion shouldn't block on telemetry.

--- a/extensions/module/src/composables/use-sync-container-actions.ts
+++ b/extensions/module/src/composables/use-sync-container-actions.ts
@@ -1,6 +1,7 @@
 import { isEqual, merge } from 'lodash';
 import { Ref, computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
+import { useApi } from '@directus/extensions-sdk';
 import { ProgressTrackerId } from '../enums/progress-tracker-id';
 import { EnabledFieldsService } from '../../../common/utilities/enabled-fields-service';
 import { useExportToLocalazy, UploadTrackedItem } from './use-export-to-localazy';
@@ -29,9 +30,24 @@ import {
 import { CURSOR_VERSION, UploadCursor } from '../../../common/models/collections-data/sync-state';
 import { TranslatableContent } from '../../../common/models/translatable-content';
 import { UploadedTriple } from '../models/upload-write-result';
-import { useDirectusNotificationsStore, useDirectusUserStore } from './use-directus-stores';
+import {
+  useDirectusCollectionsStore,
+  useDirectusNotificationsStore,
+  useDirectusRelationsStore,
+  useDirectusUserStore,
+} from './use-directus-stores';
 import { buildOrchestratorAdapters } from '../services/orchestrator-adapters';
+import { createSyncLogWriter, type SyncLogHttpClient } from '../services/sync-log-writer';
+import { LOCALAZY_COLLECTIONS } from '../stores/localazy-installer-store';
 import { runIncrementalImport } from '../../../common/services/orchestrator/incremental-import-orchestrator';
+
+/**
+ * Mirrors the orchestrator's terminal-status string for the sync-log row. Free-string
+ * column on disk; this union narrows the producer side so a typo in `onExport` can't
+ * write an unrecognised status that the Activity page's `<status-label>` doesn't know
+ * how to colour.
+ */
+type SyncLogStatus = 'completed' | 'failed' | 'skipped';
 
 type SyncMode = 'incremental' | 'full';
 
@@ -68,6 +84,26 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
 
   const accessToken = computed(() => localazyData.value.access_token);
   const exportService = useExportToLocalazy(accessToken);
+
+  // Resolve setup-only dependencies once here — calling `useApi()` /
+  // `useStores()` from the click handler (`onImport`) crashes with
+  // "The api could not be found" / "The stores could not be found" because
+  // Vue's `inject` requires an active component instance. Threading the
+  // pre-resolved values into `buildOrchestratorAdapters` keeps the orchestrator
+  // bundle (and its `syncLogWriter`) reachable from event handlers.
+  const api = useApi();
+  const collectionsStore = useDirectusCollectionsStore();
+  const relationsStore = useDirectusRelationsStore();
+
+  // The download path uses its own writer (built inside `buildOrchestratorAdapters`).
+  // The upload path doesn't go through the orchestrator, so we instantiate a separate
+  // writer here against the same axios client — both paths target the same
+  // `localazy_sync_log` collection and the writer is stateless beyond its per-session
+  // append-chain map.
+  const uploadSyncLogWriter = createSyncLogWriter({
+    api: api as unknown as SyncLogHttpClient,
+    collectionName: LOCALAZY_COLLECTIONS.syncLog,
+  });
 
   const loading = ref(false);
   const showProgress = ref(false);
@@ -141,6 +177,29 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     });
     // Save settings is fire-and-forget; errors surface via the errors store inside onSaveSettings.
     void onSaveSettings();
+
+    // Open a sync-log session up-front so the run shows on the Activity page even if
+    // the body throws halfway through. `startSession` is best-effort — a failure here
+    // falls back to no logging for this run, the upload itself still proceeds. The
+    // finalise step in `finally` is gated on `sessionId !== null`.
+    let sessionId: string | null = null;
+    try {
+      sessionId = await uploadSyncLogWriter.startSession({
+        eventType: mode === 'full' ? 'upload-full' : 'upload-incremental',
+        initiator: directusUserId.value,
+        initiatorUser: directusUserId.value || null,
+      });
+    } catch {
+      // Swallow — see comment above. The Activity page just won't show this run.
+    }
+
+    // Mutated by `onWritten` deep inside the export body and the various exit paths
+    // below; declared here so the `finally` block can read both. `runError` mirrors the
+    // orchestrator's pattern — capture, finalise the log, then re-throw.
+    let writtenSinceStart = 0;
+    let runError: unknown = null;
+    let logStatus: SyncLogStatus = 'completed';
+    let logSummary = '';
     try {
       const exportLanguages = await resolveExportLanguages(settings.value);
 
@@ -202,11 +261,13 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       if (totalTrackedItems === 0 && summary.sourceLangEntries === 0 && summary.translationEntries === 0) {
         addProgressMessage({
           id: ProgressTrackerId.UPLOAD_UP_TO_DATE,
-          message: 'All items already uploaded — nothing to push',
+          message: 'Already up to date — no items have changed since the last upload',
         });
         // Touch last_sync_at so the UX reflects the most recent successful run; merge
         // preserves the on-disk cursor verbatim.
         await persistUploadCursor(inMemoryUploadCursor);
+        logStatus = 'skipped';
+        logSummary = 'Already up to date — no items have changed since the last upload';
         return;
       }
 
@@ -219,7 +280,6 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       // total work, minimum 50). Final flush in `finally` is unconditional.
       const flushEvery = Math.max(50, Math.ceil(totalTrackedItems / 10));
       let sinceLastFlush = 0;
-      let writtenSinceStart = 0;
 
       const onWritten = (uploads: UploadedTriple[]) => {
         uploads.forEach((u) => {
@@ -264,8 +324,38 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
         id: ProgressTrackerId.UPLOAD_FINISHED,
         message: finalMessage,
       });
+      logSummary = finalMessage;
+    } catch (err) {
+      runError = err;
+      throw err;
     } finally {
       loading.value = false;
+
+      // Finalise the sync-log row even on throw. Status precedence: an explicit
+      // `skipped` set in the up-to-date short-circuit wins; otherwise an unhandled
+      // throw flips to `failed`; otherwise the default `completed` stands.
+      if (sessionId) {
+        try {
+          let status: SyncLogStatus = logStatus;
+          let summary = logSummary;
+          if (runError) {
+            status = 'failed';
+            summary = `Upload failed: ${runError instanceof Error ? runError.message : String(runError)}`;
+          }
+          await uploadSyncLogWriter.finish(sessionId, {
+            status,
+            summary,
+            itemsProcessed: writtenSinceStart,
+          });
+        } catch {
+          // Swallow — a left-in-progress row is fine for the Activity page; the next
+          // run's trim cycle cleans it up. The user-facing outcome (toast, banner) is
+          // already driven by the progress tracker, not the log row.
+        }
+      }
+      // Refresh so the "Last sync" banner + Activity page reflect this run without
+      // requiring a manual reload.
+      void syncLogStore.reload();
     }
   }
 
@@ -296,6 +386,9 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
       }
 
       const adapters = buildOrchestratorAdapters({
+        api,
+        collectionsStore,
+        relationsStore,
         getAnalyticsContext: () => ({
           userId: localazyUser.value.id,
           orgId: localazyProject.value?.orgId || '',

--- a/extensions/module/src/services/orchestrator-adapters.ts
+++ b/extensions/module/src/services/orchestrator-adapters.ts
@@ -1,4 +1,4 @@
-import { useApi } from '@directus/extensions-sdk';
+import type { AxiosInstance } from 'axios';
 import { storeToRefs } from 'pinia';
 import { CURSOR_VERSION, SyncCursor } from '../../../common/models/collections-data/sync-state';
 import { mergeCursor, parseCursor, serializeCursor } from '../../../common/utilities/sync-cursor';
@@ -19,7 +19,7 @@ import { ImportProgressIds } from '../../../common/services/orchestrator/increme
 import { UpsertProgressIds } from '../../../common/services/orchestrator/upsert-localazy-content';
 import { importFromLocalazyService } from './import-from-localazy-service';
 import { DirectusModuleApi } from './directus-module-api';
-import { useDirectusCollectionsStore, useDirectusRelationsStore } from '../composables/use-directus-stores';
+import type { useDirectusCollectionsStore, useDirectusRelationsStore } from '../composables/use-directus-stores';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { useLocalazySyncStateStore } from '../stores/localazy-sync-state-store';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
@@ -306,9 +306,12 @@ function buildProgressSink(): ProgressSink {
  * the FK column on each translation collection (Directus convention is
  * `languages_code`, but real installs often diverge — `lang_code`, `language`, etc.).
  * Falls back to `languages_code` when the relation can't be located.
+ *
+ * Takes the pre-resolved relations store rather than calling `useDirectusRelationsStore()`
+ * here — the latter wraps `useStores()` which fails outside Vue setup, and
+ * `buildOrchestratorAdapters` is invoked from a click handler.
  */
-function buildResolveLanguageFkField(): ResolveLanguageFkField {
-  const relationsStore = useDirectusRelationsStore();
+function buildResolveLanguageFkField(relationsStore: ReturnType<typeof useDirectusRelationsStore>): ResolveLanguageFkField {
   return (parentCollection, translationField, languagesCollection) => {
     const relations = relationsStore.getRelationsForField(parentCollection, translationField);
     const languageRelation = relations.find((r) => r.related_collection === languagesCollection);
@@ -318,22 +321,38 @@ function buildResolveLanguageFkField(): ResolveLanguageFkField {
 
 /**
  * Builds the module-side `SyncLogWriter` port. The writer talks to the
- * `localazy_sync_log` collection through `useApi()`; the adapter is constructed inside
- * the build function so it shares the same Directus session as the rest of the
- * orchestrator's wiring.
+ * `localazy_sync_log` collection through the supplied axios client (resolved by
+ * the caller from `useApi()` during Vue setup — `useApi()` itself cannot be
+ * called here because `buildOrchestratorAdapters` is invoked from a click
+ * handler, which is outside any setup scope).
  */
-function buildSyncLogWriter(): SyncLogWriter {
+function buildSyncLogWriter(api: AxiosInstance): SyncLogWriter {
   // Single targeted cast: `useApi()` returns axios' `AxiosInstance`, whose method
   // signatures (`post(url, data?, config?)` returning `Promise<AxiosResponse<any>>`)
   // can't structurally narrow into `SyncLogHttpClient`'s specific response shapes
   // through `any`. The cast is safe because the writer only calls the documented
   // axios surface and Directus' response envelope (`{ data: { data: ... } }`) matches
   // the interface's declared return shapes verbatim at runtime.
-  const api = useApi() as SyncLogHttpClient;
-  return createSyncLogWriter({ api, collectionName: LOCALAZY_COLLECTIONS.syncLog });
+  return createSyncLogWriter({ api: api as unknown as SyncLogHttpClient, collectionName: LOCALAZY_COLLECTIONS.syncLog });
 }
 
 type BuildAdaptersInput = {
+  /**
+   * Axios client resolved from `useApi()` by the caller during Vue setup. Must be
+   * supplied here because `buildOrchestratorAdapters` itself is invoked from a click
+   * handler — outside any setup scope, where `useApi()` would throw
+   * "[useApi]: The api could not be found." Pre-resolving it once during the
+   * composable's setup phase and threading it through is the supported pattern.
+   */
+  api: AxiosInstance;
+  /**
+   * Pre-resolved Directus stores. Same reason as `api` above — the wrappers in
+   * `use-directus-stores.ts` call `useStores()`, which (like `useApi()`) only works
+   * inside Vue setup. Capturing them in the calling composable and passing them in
+   * keeps the click-handler path crash-free.
+   */
+  collectionsStore: ReturnType<typeof useDirectusCollectionsStore>;
+  relationsStore: ReturnType<typeof useDirectusRelationsStore>;
   /**
    * Settings, languages, and project data are read at call time so analytics fires with
    * the same values the orchestrator ran with. The composable still owns "what to sync";
@@ -355,13 +374,14 @@ type BuildAdaptersInput = {
 };
 
 /**
- * Builds the full adapter bundle the orchestrator's `run` entry point needs. Must be
- * called inside a Vue setup scope (Pinia stores resolve through `useStores()` /
- * `defineStore` calls). The returned bundle has no Vue dependency past construction —
- * it can be passed across `await` boundaries freely.
+ * Builds the full adapter bundle the orchestrator's `run` entry point needs. Pinia
+ * stores accessed inside the build functions work outside Vue setup because Pinia
+ * resolves through the active app instance, but `useApi()` does not — the caller
+ * pre-resolves the axios client and passes it in via `input.api`. The returned bundle
+ * has no Vue dependency past construction and can be passed across `await` boundaries.
  */
 export function buildOrchestratorAdapters(input: BuildAdaptersInput): OrchestratorAdapters {
-  const directusApi = new DirectusModuleApi(useApi(), useDirectusCollectionsStore());
+  const directusApi = new DirectusModuleApi(input.api, input.collectionsStore);
   const { addDirectusError } = useErrorsStore();
   const onDirectusError: ErrorSink = (e) => addDirectusError(e);
 
@@ -371,7 +391,7 @@ export function buildOrchestratorAdapters(input: BuildAdaptersInput): Orchestrat
     localazyContentFetcher: buildLocalazyContentFetcher(),
     progress: buildProgressSink(),
     directusApi,
-    resolveLanguageFkField: buildResolveLanguageFkField(),
+    resolveLanguageFkField: buildResolveLanguageFkField(input.relationsStore),
     onDirectusError,
     reportDownloadAnalytics: () => {
       const ctx = input.getAnalyticsContext();
@@ -385,7 +405,7 @@ export function buildOrchestratorAdapters(input: BuildAdaptersInput): Orchestrat
         }),
       );
     },
-    syncLogWriter: buildSyncLogWriter(),
+    syncLogWriter: buildSyncLogWriter(input.api),
     syncLogInitiator: input.syncLogInitiator,
   };
 }


### PR DESCRIPTION
## Summary

Two related fixes.

**1. `useApi()` outside setup scope.** Automated Import on the orchestrator path was crashing with `"[useApi]: The api could not be found."` `buildOrchestratorAdapters` is invoked from the `onImport` click handler — outside any Vue setup scope. Pinia stores resolve fine through `useStores()` there, but `useApi()` does not. The composable now pre-resolves the axios client + the two stores at setup time and threads them in via `BuildAdaptersInput`.

**2. Uploads missing from the Activity page.** The upload path didn't go through the orchestrator and never wrote a `localazy_sync_log` row. Adds a stand-alone `SyncLogWriter` instance for the upload path. Each upload opens a session up-front and finalises it in a `finally`:

- `failed` if the body throws,
- `skipped` for the "Already up to date" short-circuit (also reworded from the confusing "All items already uploaded — nothing to push"),
- `completed` otherwise.

After finalisation the sync-log store reloads so the "Last sync" banner and Activity page pick up the new row without a refresh. Start/finish calls are best-effort — telemetry failures don't block the upload.

## Test plan

- [x] `vue-tsc --noEmit` clean; `vitest run composables/` — 62 tests pass.
- [ ] Manual: trigger automated Import (orchestrator path) — should complete without `useApi` crash.
- [ ] Manual: trigger an upload, navigate to Activity page — row should appear with the correct status (`completed`, `skipped`, or `failed`).
- [ ] Manual: trigger upload twice in a row; second run shows `skipped` with the new "Already up to date" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)