### PR TITLE
PR 46/N (Stage 5): Activity page filters + initiator name resolution

### DIFF
--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -23,30 +23,45 @@
 
     <div class="panel">
       <div class="retention-note">
-        <v-icon name="info_outline" small />
+        <v-icon name="info" small />
         <span>Last 100 sync sessions are retained. Older sessions are automatically deleted.</span>
       </div>
 
       <v-notice v-if="clearedNotice" type="success" class="cleared-notice"> Activity logs cleared. </v-notice>
 
       <div class="filters">
-        <v-input v-model="searchValue" placeholder="Search by summary, initiator, status, or date" class="search-input" />
-        <interface-datetime type="date" :value="dateFromValue" :include-seconds="false" @input="onDateFromInput" />
-        <interface-datetime type="date" :value="dateToValue" :include-seconds="false" @input="onDateToInput" />
+        <div class="filter-field status-field">
+          <label class="filter-label">Status</label>
+          <v-select v-model="statusFilter" :items="STATUS_OPTIONS" multiple placeholder="All statuses" />
+        </div>
+        <div class="date-range">
+          <div class="filter-field">
+            <label class="filter-label">From</label>
+            <interface-datetime type="date" :value="dateFromValue" :include-seconds="false" @input="onDateFromInput" />
+          </div>
+          <div class="filter-field">
+            <label class="filter-label">To</label>
+            <interface-datetime type="date" :value="dateToValue" :include-seconds="false" @input="onDateToInput" />
+          </div>
+        </div>
       </div>
 
-      <v-tabs v-model="activeTabModel">
-        <v-tab value="upload">Upload</v-tab>
-        <v-tab value="download">Download</v-tab>
-        <v-tab value="webhook">Webhooks</v-tab>
-      </v-tabs>
+      <div class="sessions-tabs">
+        <v-tabs v-model="activeTabModel">
+          <v-tab value="upload">Upload</v-tab>
+          <v-tab value="download">Download</v-tab>
+          <v-tab value="webhook">Webhooks</v-tab>
+        </v-tabs>
+      </div>
 
-      <div class="tab-content">
+      <div class="sessions-card">
         <sessions-table
           :rows="paginatedSessions"
           :current-sort="currentSort"
           :page="page"
           :total-pages="totalPages"
+          :tab="activeTab"
+          :lookup-user-name="lookupUserName"
           @sort="setSort"
           @select="onSessionClick"
           @update:page="page = $event"
@@ -76,6 +91,7 @@ import SessionsTable from './components/Activity/SessionsTable.vue';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useLocalazySyncLogStore } from './stores/localazy-sync-log-store';
 import { useLocalazySettingsStore } from './stores/localazy-settings-store';
+import { useSyncLogUserNames } from './composables/use-sync-log-user-names';
 import {
   parseSortPreferences,
   serializeSortPreferences,
@@ -94,6 +110,11 @@ const { boot } = useLocalazyBoot();
 const syncLogStore = useLocalazySyncLogStore();
 const { sessions } = storeToRefs(syncLogStore);
 
+// Resolve Directus user names for each row's initiator id so the table shows
+// "Triggered by Jane Doe" instead of a raw UUID. Watches `sessions` and batches
+// one `/users?filter[id][_in]=...` fetch per fresh set of ids.
+const { lookupUserName } = useSyncLogUserNames(sessions);
+
 const settingsStore = useLocalazySettingsStore();
 const { data: settings } = storeToRefs(settingsStore);
 const initialSortPreferences = computed<SortPreferences>(() => parseSortPreferences(settings.value.activity_logs_sort));
@@ -108,37 +129,62 @@ function onSortPreferencesChange(next: SortPreferences) {
   }, 600);
 }
 
-const { activeTab, searchInput, dateFrom, dateTo, page, totalPages, currentSort, setSort, filteredSessions, paginatedSessions, setSearch } =
-  useActivityLog({
-    sessions,
-    initialSortPreferences,
-    onSortPreferencesChange,
-  });
-
-const searchValue = computed({
-  get: () => searchInput.value,
-  set: (v: string) => setSearch(v),
+const { activeTab, statusFilter, dateFrom, dateTo, page, totalPages, currentSort, setSort, filteredSessions, paginatedSessions } = useActivityLog({
+  sessions,
+  initialSortPreferences,
+  onSortPreferencesChange,
 });
 
-// `<v-tabs>` model-value is a string; the composable uses a constrained `ActivityTab`
-// union. Bridge through a computed so the cast happens in one place.
-const activeTabModel = computed<string>({
+// `<v-select :items>` shape: `{ text, value }`. The statuses mirror StatusLabel.vue's
+// known set; an unknown status read from disk still passes through the filter (the
+// select just won't offer it as a checkbox option, which is fine — Strapi parity).
+const STATUS_OPTIONS = [
+  { text: 'Completed', value: 'completed' },
+  { text: 'Completed (errors)', value: 'partial' },
+  { text: 'Failed', value: 'failed' },
+  { text: 'Aborted', value: 'aborted' },
+  { text: 'Skipped', value: 'skipped' },
+  { text: 'In progress', value: 'in_progress' },
+];
+
+// Directus' `<v-tabs>` is declared as a single-select group (`multiple: false`) but
+// its emit on `update:modelValue` still produces a one-element ARRAY (`["download"]`)
+// rather than the unwrapped string. Without the `Array.isArray` unwrap, clicking a
+// tab sets `activeTab` to `["download"]`, the `tabForEventType(...) !== activeTab`
+// check fails for every row (string vs. array comparison), and the table empties.
+// Accepting both shapes here keeps the composable's `ActivityTab` union intact.
+const activeTabModel = computed<string | string[]>({
   get: () => activeTab.value,
-  set: (v: string) => {
-    activeTab.value = v as ActivityTab;
+  set: (v: string | string[]) => {
+    const next = Array.isArray(v) ? v[0] : v;
+    if (next) activeTab.value = next as ActivityTab;
   },
 });
 
-// `<interface-datetime>` returns ISO strings; the filter helpers consume `Date` objects
-// (or `undefined` for "no filter"). The bridges normalise both sides.
-const dateFromValue = computed(() => (dateFrom.value ? dateFrom.value.toISOString() : null));
-const dateToValue = computed(() => (dateTo.value ? dateTo.value.toISOString() : null));
+// `<interface-datetime type="date">` parses its value with date-fns `parse(value, 'yyyy-MM-dd', new Date)`.
+// Passing a full ISO string makes the value-display branch render `<!---->` (empty activator),
+// and triggers the "default" behaviour described as "calendar shows no value". The bridges
+// therefore round-trip `yyyy-MM-dd` strings — the filter helpers still consume `Date`
+// objects (UTC midnight matches `filterSessions`' UTC-based cutoffs).
+function toIsoDate(d: Date): string {
+  const yyyy = String(d.getUTCFullYear()).padStart(4, '0');
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+const dateFromValue = computed(() => (dateFrom.value ? toIsoDate(dateFrom.value) : null));
+const dateToValue = computed(() => (dateTo.value ? toIsoDate(dateTo.value) : null));
 
+function parseIsoDate(value: string): Date | undefined {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return undefined;
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+}
 function onDateFromInput(value: string | null) {
-  dateFrom.value = value ? new Date(value) : undefined;
+  dateFrom.value = value ? parseIsoDate(value) : undefined;
 }
 function onDateToInput(value: string | null) {
-  dateTo.value = value ? new Date(value) : undefined;
+  dateTo.value = value ? parseIsoDate(value) : undefined;
 }
 
 const showClearDialog = ref(false);
@@ -216,15 +262,51 @@ onBeforeMount(() => {
   flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 16px;
-  align-items: center;
-
-  .search-input {
-    flex: 1;
-    min-width: 240px;
-  }
+  align-items: flex-end;
 }
 
-.tab-content {
-  margin-top: 16px;
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 160px;
+}
+
+.status-field {
+  flex: 1;
+  min-width: 240px;
+  /* Match the date picker's 40px activator height — Directus form components
+     pick this variable up from the surrounding scope. */
+  --theme--form--field--input--height: 40px;
+}
+
+.filter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--foreground-subdued);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.date-range {
+  display: flex;
+  gap: 12px;
+}
+
+/* Tabs sit on the page background — only the active label gets recolored. The
+   default Directus active-tab color shift was too subtle, so we promote it to
+   `--primary` and bump weight; no card, no underline strip. */
+.sessions-tabs :deep(.v-tab.active) {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* Card wrapping just the session list (table or empty state) so the logs area
+   has its own surface separate from the tabs above. */
+.sessions-card {
+  background-color: var(--theme--background-normal);
+  border: 1px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
+  overflow: hidden;
 }
 </style>

--- a/extensions/module/src/ActivityDetail.vue
+++ b/extensions/module/src/ActivityDetail.vue
@@ -25,12 +25,10 @@
         </section>
 
         <section class="entries-section">
-          <v-input v-model="searchValue" class="entries-search" placeholder="Filter entries by message or timestamp" />
-
-          <div v-if="filteredEntries.length === 0" class="empty-state">No log entries to display.</div>
+          <div v-if="entries.length === 0" class="empty-state">No log entries to display.</div>
 
           <div v-else class="entries-list">
-            <div v-for="(entry, idx) in filteredEntries" :key="idx" class="entry-row" :class="`entry-${entry.level}`">
+            <div v-for="(entry, idx) in entries" :key="idx" class="entry-row" :class="`entry-${entry.level}`">
               <div class="entry-header">
                 <v-icon :name="iconForLevel(entry.level)" small class="entry-icon" />
                 <span class="entry-timestamp">{{ formatTime(entry.timestamp) }}</span>
@@ -76,29 +74,6 @@ const entries = computed<SyncLogEntry[]>(() => {
   } catch {
     return [];
   }
-});
-
-// Debounced entries search. Same 300 ms cadence as the list page.
-const searchInput = ref('');
-const searchQuery = ref('');
-let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-const searchValue = computed({
-  get: () => searchInput.value,
-  set: (v: string) => {
-    searchInput.value = v;
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      searchQuery.value = v;
-    }, 300);
-  },
-});
-
-const filteredEntries = computed(() => {
-  const lc = searchQuery.value.trim().toLowerCase();
-  if (!lc) return entries.value;
-  return entries.value.filter(
-    (entry) => entry.message.toLowerCase().includes(lc) || formatTime(entry.timestamp).toLowerCase().includes(lc),
-  );
 });
 
 function formatTime(ts: string): string {
@@ -173,10 +148,6 @@ onBeforeMount(async () => {
   background-color: var(--background-normal);
   padding: 24px;
   border-radius: var(--border-radius);
-}
-
-.entries-search {
-  margin-bottom: 16px;
 }
 
 .entries-list {

--- a/extensions/module/src/components/Activity/SessionsTable.vue
+++ b/extensions/module/src/components/Activity/SessionsTable.vue
@@ -24,13 +24,13 @@
           </td>
           <td>{{ formatStartedAt(session) }}</td>
           <td>{{ formatDuration(session) }}</td>
-          <td>{{ session.initiator }}</td>
+          <td>{{ formatInitiator(session.initiator, props.lookupUserName) }}</td>
           <td class="summary-cell">{{ session.summary || '-' }}</td>
         </tr>
       </tbody>
     </table>
 
-    <div v-else class="empty-state">No sync sessions to display.</div>
+    <div v-else class="empty-state">{{ emptyStateMessage }}</div>
 
     <v-pagination
       v-if="totalPages > 1"
@@ -43,16 +43,35 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue';
 import StatusLabel from './StatusLabel.vue';
-import { formatDuration, formatStartedAt, type SortKey, type SortPreference } from '../../composables/use-activity-log';
+import {
+  formatDuration,
+  formatInitiator,
+  formatStartedAt,
+  type ActivityTab,
+  type SortKey,
+  type SortPreference,
+} from '../../composables/use-activity-log';
 import type { SyncLogSession } from '../../../../common/models/collections-data/sync-log';
 
-defineProps<{
+const props = defineProps<{
   rows: SyncLogSession[];
   currentSort: SortPreference;
   page: number;
   totalPages: number;
+  tab: ActivityTab;
+  /**
+   * Resolves a Directus user id to a display name (full name, or email fallback).
+   * Returns `null` for unknown / deleted users — `formatInitiator` then falls back
+   * to the generic "Triggered by user" label. The function is read inside the
+   * template so Vue tracks its internal reactive deps and the cells re-render
+   * once the names arrive from the `/users` fetch.
+   */
+  lookupUserName: (userId: string) => string | null;
 }>();
+
+const emptyStateMessage = computed(() => `No ${props.tab} sessions to display.`);
 
 const emit = defineEmits<{
   (event: 'sort', key: SortKey): void;
@@ -122,8 +141,9 @@ const columns: Array<{ key: SortKey; label: string }> = [
 }
 
 .empty-state {
-  padding: 32px;
+  padding: 56px 32px;
   text-align: center;
   color: var(--foreground-subdued);
+  font-size: 14px;
 }
 </style>

--- a/extensions/module/src/composables/use-activity-log.test.ts
+++ b/extensions/module/src/composables/use-activity-log.test.ts
@@ -66,21 +66,28 @@ describe('formatDuration', () => {
 
 describe('filterSessions', () => {
   const sessions: SyncLogSession[] = [
-    make({ id: '1', event_type: 'upload-incremental', initiator: 'alice' }),
-    make({ id: '2', event_type: 'upload-full', initiator: 'bob' }),
-    make({ id: '3', event_type: 'download-incremental', initiator: 'alice' }),
-    make({ id: '4', event_type: 'webhook', initiator: 'webhook' }),
+    make({ id: '1', event_type: 'upload-incremental', initiator: 'alice', status: 'completed' }),
+    make({ id: '2', event_type: 'upload-full', initiator: 'bob', status: 'failed' }),
+    make({ id: '3', event_type: 'download-incremental', initiator: 'alice', status: 'skipped' }),
+    make({ id: '4', event_type: 'webhook', initiator: 'webhook', status: 'completed' }),
   ];
 
   it('filters by tab', () => {
-    expect(filterSessions(sessions, { tab: 'upload', searchQuery: '' }).map((s) => s.id)).toEqual(['1', '2']);
-    expect(filterSessions(sessions, { tab: 'download', searchQuery: '' }).map((s) => s.id)).toEqual(['3']);
-    expect(filterSessions(sessions, { tab: 'webhook', searchQuery: '' }).map((s) => s.id)).toEqual(['4']);
+    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2']);
+    expect(filterSessions(sessions, { tab: 'download' }).map((s) => s.id)).toEqual(['3']);
+    expect(filterSessions(sessions, { tab: 'webhook' }).map((s) => s.id)).toEqual(['4']);
   });
 
-  it('filters by search query against summary, initiator, status, and date', () => {
-    const result = filterSessions(sessions, { tab: 'upload', searchQuery: 'bob' });
-    expect(result.map((s) => s.id)).toEqual(['2']);
+  it('treats an empty / missing `statuses` set as "show all"', () => {
+    expect(filterSessions(sessions, { tab: 'upload', statuses: [] }).map((s) => s.id)).toEqual(['1', '2']);
+    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2']);
+  });
+
+  it('filters by `statuses` as an OR set', () => {
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed'] }).map((s) => s.id)).toEqual(['1']);
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed', 'failed'] }).map((s) => s.id)).toEqual(['1', '2']);
+    // A status that no upload row carries returns nothing within the tab.
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['skipped'] }).map((s) => s.id)).toEqual([]);
   });
 
   it('filters by dateFrom / dateTo', () => {
@@ -91,7 +98,6 @@ describe('filterSessions', () => {
     ];
     const result = filterSessions(mixed, {
       tab: 'upload',
-      searchQuery: '',
       dateFrom: new Date(Date.UTC(2026, 4, 1)),
       dateTo: new Date(Date.UTC(2026, 4, 31)),
     });

--- a/extensions/module/src/composables/use-activity-log.ts
+++ b/extensions/module/src/composables/use-activity-log.ts
@@ -106,21 +106,25 @@ export function formatStartedAt(session: SyncLogSession): string {
 }
 
 /**
- * Pure: filters a session list by the current tab, search query, and date range.
+ * Pure: filters a session list by the current tab, status set, and date range.
  * Extracted so the filter behaviour is testable without mounting the Vue component.
+ *
+ * `statuses` is an OR set — an empty (or omitted) array means "no status filter,
+ * show all". Mirrors the multi-select interface in the Activity page header.
  */
 export function filterSessions(
   sessions: SyncLogSession[],
   opts: {
     tab: ActivityTab;
-    searchQuery: string;
+    statuses?: string[];
     dateFrom?: Date;
     dateTo?: Date;
   },
 ): SyncLogSession[] {
-  const lcQuery = opts.searchQuery.trim().toLowerCase();
+  const statusSet = opts.statuses && opts.statuses.length > 0 ? new Set(opts.statuses) : null;
   return sessions.filter((session) => {
     if (tabForEventType(session.event_type) !== opts.tab) return false;
+    if (statusSet && !statusSet.has(session.status)) return false;
 
     const startedMs = Date.parse(session.started_at);
     // Cutoffs are interpreted as UTC midnight to match `session.started_at`'s UTC ISO
@@ -135,9 +139,7 @@ export function filterSessions(
       if (Number.isFinite(startedMs) && startedMs > toMs) return false;
     }
 
-    if (!lcQuery) return true;
-    const haystacks = [session.summary, session.initiator, session.status, formatStartedAt(session)];
-    return haystacks.some((h) => h.toLowerCase().includes(lcQuery));
+    return true;
   });
 }
 
@@ -211,10 +213,14 @@ export function useActivityLog(input: {
   onSortPreferencesChange: (prefs: SortPreferences) => void;
 }) {
   const activeTab = ref<ActivityTab>('upload');
-  const searchInput = ref('');
-  const searchQuery = ref('');
-  const dateFrom = ref<Date | undefined>(undefined);
-  const dateTo = ref<Date | undefined>(undefined);
+  const statusFilter = ref<string[]>([]);
+  // Default range mirrors Strapi: From = 30 days ago, To = today. UTC midnight on both
+  // ends so the cutoffs line up with `filterSessions`' UTC-based comparison.
+  const today = new Date();
+  const defaultDateTo = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  const defaultDateFrom = new Date(defaultDateTo.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const dateFrom = ref<Date | undefined>(defaultDateFrom);
+  const dateTo = ref<Date | undefined>(defaultDateTo);
   const page = ref(1);
   const sortPreferences = ref<SortPreferences>({ ...input.initialSortPreferences.value });
 
@@ -225,19 +231,9 @@ export function useActivityLog(input: {
     sortPreferences.value = { ...next };
   });
 
-  // Debounced search input → query. 300ms matches Strapi.
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  function setSearch(value: string) {
-    searchInput.value = value;
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      searchQuery.value = value;
-    }, 300);
-  }
-
   // Whenever the filter inputs change, reset to page 1 — otherwise a 5-page result
   // suddenly collapsing to 1 page would leave the user on a non-existent page 4.
-  watch([searchQuery, dateFrom, dateTo, activeTab], () => {
+  watch([statusFilter, dateFrom, dateTo, activeTab], () => {
     page.value = 1;
   });
 
@@ -255,7 +251,7 @@ export function useActivityLog(input: {
   const filteredSessions = computed(() =>
     filterSessions(input.sessions.value, {
       tab: activeTab.value,
-      searchQuery: searchQuery.value,
+      statuses: statusFilter.value,
       dateFrom: dateFrom.value,
       dateTo: dateTo.value,
     }),
@@ -268,9 +264,7 @@ export function useActivityLog(input: {
 
   return {
     activeTab,
-    searchInput,
-    searchQuery,
-    setSearch,
+    statusFilter,
     dateFrom,
     dateTo,
     page,

--- a/extensions/module/src/composables/use-sync-log-user-names.ts
+++ b/extensions/module/src/composables/use-sync-log-user-names.ts
@@ -1,0 +1,91 @@
+import { ref, watch, type Ref } from 'vue';
+import { useApi } from '@directus/extensions-sdk';
+import type { SyncLogSession } from '../../../common/models/collections-data/sync-log';
+
+/**
+ * Subset of Directus' `directus_users` row we read here. The columns are intentionally
+ * limited — we only need enough to render "first last" or fall back to email; pulling
+ * more would just enlarge the response with data the Activity page ignores.
+ */
+type UserRow = {
+  id: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+};
+
+function pickName(user: UserRow): string | null {
+  const name = [user.first_name, user.last_name].filter(Boolean).join(' ').trim();
+  if (name) return name;
+  return user.email || null;
+}
+
+/**
+ * Resolves the human name behind each `localazy_sync_log.initiator` id referenced in the
+ * supplied sessions. Watches the sessions ref, batches one `/users?filter[id][_in]=...`
+ * fetch per fresh set of unmapped ids, and caches the result so subsequent reloads
+ * don't re-fetch users already known.
+ *
+ * Failures are absorbed: any id that can't be resolved (request failed, user deleted,
+ * permissions blocked) is recorded as `null` in the cache so we don't loop and
+ * `formatInitiator` falls back to the generic "Triggered by user" label.
+ *
+ * The returned `lookupUserName` is a plain function but reads `namesById.value`
+ * inside, so when a template calls it during render Vue picks up the reactive
+ * dependency — re-rendering once the fetch resolves.
+ */
+export function useSyncLogUserNames(sessions: Ref<SyncLogSession[]>) {
+  const api = useApi();
+  const namesById = ref<Record<string, string | null>>({});
+
+  watch(
+    sessions,
+    async (rows) => {
+      const idsToFetch = new Set<string>();
+      for (const row of rows) {
+        // Prefer the m2o column. Fall back to the free `initiator` string when it
+        // doesn't carry the `'webhook'` marker — older rows may have been written
+        // before `initiator_user` was always populated alongside.
+        const candidate = row.initiator_user ?? (row.initiator !== 'webhook' ? row.initiator : null);
+        if (candidate && !(candidate in namesById.value)) {
+          idsToFetch.add(candidate);
+        }
+      }
+      if (idsToFetch.size === 0) return;
+      // Optimistically claim the ids so a second `watch` tick (e.g. concurrent reload)
+      // doesn't fire a duplicate fetch for the same set. They'll be overwritten with the
+      // real names below; if the fetch fails, the `null` placeholder stays and the
+      // formatter falls back to "Triggered by user".
+      const placeholderNext = { ...namesById.value };
+      idsToFetch.forEach((id) => {
+        placeholderNext[id] = null;
+      });
+      namesById.value = placeholderNext;
+
+      try {
+        const result = await api.get<{ data: UserRow[] }>('/users', {
+          params: {
+            filter: { id: { _in: Array.from(idsToFetch) } },
+            fields: ['id', 'first_name', 'last_name', 'email'],
+            limit: -1,
+          },
+        });
+        const next = { ...namesById.value };
+        for (const user of result.data.data ?? []) {
+          next[user.id] = pickName(user);
+        }
+        namesById.value = next;
+      } catch {
+        // Already filled with `null` placeholders above — nothing else to do. The user
+        // sees "Triggered by user" for these rows, which is the documented fallback.
+      }
+    },
+    { immediate: true },
+  );
+
+  function lookupUserName(userId: string): string | null {
+    return namesById.value[userId] ?? null;
+  }
+
+  return { lookupUserName };
+}


### PR DESCRIPTION
## Summary

The single free-text Activity filter was weak signal — typing "fail" matched any session whose summary or initiator string happened to contain those letters, with no way to isolate failed runs specifically. The initiator column rendered raw UUIDs, so identifying who triggered a run required cross-referencing Directus' user table.

- `use-activity-log.ts` — replaces `searchQuery` with `statuses: string[]` (OR set, empty = show-all). Default date range = last 30 days, UTC midnight (matches Strapi). Drops the debounced search plumbing. New `formatInitiator(initiator, lookupUserName?)`.
- `Activity.vue` — labelled status `<v-select multiple>` + labelled From/To pickers. Fixes two latent date/tab quirks: `<interface-datetime type="date">` round-trips `yyyy-MM-dd` (not ISO); `<v-tabs>` emits a one-element array even in single-select mode, unwrap defensively in the computed bridge. Wraps tabs + table in a card surface, bumps active tab color to `--primary`. Wires `useSyncLogUserNames(sessions)`.
- `ActivityDetail.vue` — drops the entries search; the detail view is a single run's log, free-text search there is friction not signal.
- `SessionsTable.vue` — takes `lookupUserName` + current `tab` props; renders the resolved initiator via `formatInitiator`; empty state now reads "No <tab> sessions to display."
- New `use-sync-log-user-names.ts` — watches sessions, batches one `/users?filter[id][_in]=...` fetch per fresh id set, caches resolved names (full name → email fallback → `null` for unresolvable).

## Test plan

- [x] `vitest run use-activity-log.test.ts` — 28 tests pass (including new status-filter cases).
- [x] `vue-tsc --noEmit` clean.
- [ ] Manual: load Activity page — default 30-day range, status select empty (show-all), tabs render with active-tab in primary color.
- [ ] Manual: pick "Failed" in status select — only failed sessions remain.
- [ ] Manual: initiator column shows full name (or email) instead of UUID for known users; falls back to "Triggered by user" for deleted ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)