### PR TITLE
PR 52/N: Automated export + deprecation pipeline foundation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,12 @@ A persisted row in `localazy_sync_log` capturing one Automated import or Automat
 The module that owns persistence of a Sync-log session — creation, milestone appends (serialised per session), finalisation, and retention trim. Lives in `extensions/common/` and is composed with a transport adapter: an axios adapter on the Module side, an `ItemsService` adapter on the Sync-hook bundle side.
 _Avoid_: "log service", "audit logger"
 
+**Automated export pipeline**:
+The closed orchestration in `extensions/common/services/orchestrator/automated-export-pipeline.ts` that drives one Automated export call end-to-end: load Localazy context → master-toggle gate → load project → payment-status gate → resolve export languages → fetch content → dispatch to Localazy. Returns a discriminated outcome; logging and error tracking happen at the bundle edge. The varying step (what content to fetch) is injected as a strategy. Composed by the Sync-hook bundle with `ItemsService`-backed adapters.
+
+**Automated deprecation pipeline**:
+Sibling module to the Automated export pipeline, in the same directory. Owns deprecation orchestration: load context → master + deprecation toggle gate → load project → payment-status gate → fetch source-language import content → project Localazy key IDs from deleted Directus item IDs → call deprecate. Returns a discriminated outcome.
+
 ## Relationships
 
 - **Automated export** is a property of the **Sync-hook bundle**; it cannot run when the bundle is not installed.

--- a/docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md
+++ b/docs/adr/0001-automation-page-as-single-home-for-sync-master-toggles.md
@@ -6,7 +6,7 @@ Outbound sync (Directus → Localazy) was historically governed by two independe
 
 ## Decision
 
-1. **Page purpose.** The **Automation** page is the single home for *automation master toggles* — the on/off switches that decide whether a sync direction runs at all. The **Additional Settings** page holds *behaviour-shaping knobs* — settings that decide *how* sync behaves once it runs (skip empty strings, source-language direction, language mappings, etc.). New automation-enable controls go on the Automation page; new behaviour controls go on Additional Settings.
+1. **Page purpose.** The **Automation** page is the single home for _automation master toggles_ — the on/off switches that decide whether a sync direction runs at all. The **Additional Settings** page holds _behaviour-shaping knobs_ — settings that decide _how_ sync behaves once it runs (skip empty strings, source-language direction, language mappings, etc.). New automation-enable controls go on the Automation page; new behaviour controls go on Additional Settings.
 
 2. **Master gates everything.** The "Automated export" master toggle is persisted as `Settings.automated_upload` and surfaces deprecation as a sub-setting. The runtime gating in `collection-content-synchronization-service.ts` and `translation-strings-synchronization-service.ts` was tightened so deprecation also requires `automated_upload === true` — meaning master OFF guarantees zero outbound activity, including for legacy installs that had the niche `upload=false, deprecate=true` combination.
 

--- a/extensions/common/services/deprecate-localazy-keys.test.ts
+++ b/extensions/common/services/deprecate-localazy-keys.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const throttleMocks = vi.hoisted(() => ({
+  updateKey: vi.fn(),
+}));
+
+vi.mock('./localazy-api-throttle-service', () => ({
+  LocalazyApiThrottleService: {
+    updateKey: throttleMocks.updateKey,
+  },
+}));
+
+import { deprecateLocalazyKeys } from './deprecate-localazy-keys';
+
+describe('deprecateLocalazyKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    throttleMocks.updateKey.mockResolvedValue(undefined);
+  });
+
+  it('is a no-op when no key ids are supplied', async () => {
+    await deprecateLocalazyKeys('tok', 'p1', []);
+
+    expect(throttleMocks.updateKey).not.toHaveBeenCalled();
+  });
+
+  it('issues one updateKey call per id with deprecated=0 and the supplied project', async () => {
+    await deprecateLocalazyKeys('tok', 'p1', ['k1', 'k2']);
+
+    expect(throttleMocks.updateKey).toHaveBeenCalledTimes(2);
+    expect(throttleMocks.updateKey).toHaveBeenNthCalledWith(1, 'tok', { project: 'p1', key: 'k1', deprecated: 0 });
+    expect(throttleMocks.updateKey).toHaveBeenNthCalledWith(2, 'tok', { project: 'p1', key: 'k2', deprecated: 0 });
+  });
+
+  // The underlying createAsyncQueue swallows per-task rejections — by design, so one
+  // failing updateKey doesn't abort the remaining deprecations. The helper inherits that
+  // and therefore resolves cleanly even when individual API calls reject. The pipeline's
+  // outcome stays 'deprecated' in this case; preserving the legacy behaviour of
+  // BaseContentSynchronizationService.deprecateLocalazyKeys.
+  it('swallows per-task API rejections rather than aborting the rest', async () => {
+    throttleMocks.updateKey.mockRejectedValueOnce(new Error('boom on k1')).mockResolvedValueOnce(undefined);
+
+    await expect(deprecateLocalazyKeys('tok', 'p1', ['k1', 'k2'])).resolves.toBeUndefined();
+
+    expect(throttleMocks.updateKey).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/common/services/deprecate-localazy-keys.ts
+++ b/extensions/common/services/deprecate-localazy-keys.ts
@@ -1,0 +1,29 @@
+import { LocalazyApiThrottleService } from './localazy-api-throttle-service';
+import { createAsyncQueue } from '../utilities/async-queue';
+
+/**
+ * Pure helper that marks the given Localazy keys as deprecated. Used by the Automated
+ * deprecation pipeline; both Directus-collection and translation-string deletion paths
+ * project down to a flat list of Localazy key ids before calling this.
+ *
+ * Empty `keyIds` is a no-op — callers don't need to pre-check.
+ *
+ * The 100 ms inter-request delay preserves the throttling the original
+ * `BaseContentSynchronizationService.deprecateLocalazyKeys` applied.
+ */
+export async function deprecateLocalazyKeys(accessToken: string, projectId: string, keyIds: string[]): Promise<void> {
+  if (keyIds.length === 0) {
+    return;
+  }
+  const { add, execute } = createAsyncQueue();
+  keyIds.forEach((keyId) => {
+    add(async () => {
+      await LocalazyApiThrottleService.updateKey(accessToken, {
+        project: projectId,
+        key: keyId,
+        deprecated: 0,
+      });
+    });
+  });
+  await execute({ delayBetween: 100 });
+}

--- a/extensions/common/services/load-localazy-project.test.ts
+++ b/extensions/common/services/load-localazy-project.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Project } from '@localazy/api-client';
+
+const throttleMocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+}));
+
+vi.mock('./localazy-api-throttle-service', () => ({
+  LocalazyApiThrottleService: {
+    listProjects: throttleMocks.listProjects,
+  },
+}));
+
+import { loadLocalazyProject } from './load-localazy-project';
+
+describe('loadLocalazyProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null without calling the API when the token is empty', async () => {
+    const result = await loadLocalazyProject('');
+
+    expect(result).toBeNull();
+    expect(throttleMocks.listProjects).not.toHaveBeenCalled();
+  });
+
+  it('requests organisation + languages metadata and returns the first project', async () => {
+    const project = { id: 'p1' } as Project;
+    throttleMocks.listProjects.mockResolvedValue([project, { id: 'p2' } as Project]);
+
+    const result = await loadLocalazyProject('tok');
+
+    expect(throttleMocks.listProjects).toHaveBeenCalledWith('tok', { organization: true, languages: true });
+    expect(result).toBe(project);
+  });
+
+  it('returns null when the API yields no projects', async () => {
+    throttleMocks.listProjects.mockResolvedValue([]);
+
+    const result = await loadLocalazyProject('tok');
+
+    expect(result).toBeNull();
+  });
+
+  // Behaviour change versus the legacy BaseContentSynchronizationService.loadProject:
+  // the old helper swallowed API errors and returned null (the caller logged "could not
+  // load project"). The new helper lets API errors bubble so the pipeline can map them
+  // to a `failed` outcome with the original error attached.
+  it('propagates API errors instead of swallowing them', async () => {
+    const apiError = new Error('boom');
+    throttleMocks.listProjects.mockRejectedValue(apiError);
+
+    await expect(loadLocalazyProject('tok')).rejects.toBe(apiError);
+  });
+});

--- a/extensions/common/services/load-localazy-project.ts
+++ b/extensions/common/services/load-localazy-project.ts
@@ -1,0 +1,19 @@
+import { Project } from '@localazy/api-client';
+import { LocalazyApiThrottleService } from './localazy-api-throttle-service';
+
+/**
+ * Pure helper used by the Automated export and deprecation pipelines. Loads the first
+ * Localazy project visible to the supplied access token, with organisation and language
+ * metadata hydrated (both are required downstream for payment-status gating and language
+ * resolution).
+ *
+ * Returns `null` only when no token is supplied. API failures bubble — the caller's
+ * pipeline maps them to a `failed` outcome.
+ */
+export async function loadLocalazyProject(token: string): Promise<Project | null> {
+  if (!token) {
+    return null;
+  }
+  const projects = await LocalazyApiThrottleService.listProjects(token, { organization: true, languages: true });
+  return projects[0] || null;
+}

--- a/extensions/common/services/orchestrator/automated-deprecation-pipeline.test.ts
+++ b/extensions/common/services/orchestrator/automated-deprecation-pipeline.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Project } from '@localazy/api-client';
+import { Settings } from '../../models/collections-data/settings';
+import { ContentTransferSetupDatabase } from '../../models/collections-data/content-transfer-setup';
+import { LocalazyData } from '../../models/collections-data/localazy-data';
+import { LocalazyContent } from '../../models/localazy-content';
+
+const helperMocks = vi.hoisted(() => ({
+  loadLocalazyProject: vi.fn(),
+  deprecateLocalazyKeys: vi.fn(),
+}));
+
+vi.mock('../load-localazy-project', () => ({
+  loadLocalazyProject: helperMocks.loadLocalazyProject,
+}));
+
+vi.mock('../deprecate-localazy-keys', () => ({
+  deprecateLocalazyKeys: helperMocks.deprecateLocalazyKeys,
+}));
+
+import {
+  runAutomatedDeprecationPipeline,
+  DeprecationKeyProjector,
+  SourceLanguageImportContentFetcher,
+} from './automated-deprecation-pipeline';
+import { AutomatedExportLocalazyContext } from './automated-export-pipeline';
+
+const baseSettings = { automated_upload: true, automated_deprecation: true } as Settings;
+const baseTransferSetup = {} as ContentTransferSetupDatabase;
+const baseLocalazyData = { access_token: 'tok' } as LocalazyData;
+
+function makeContext(overrides: Partial<AutomatedExportLocalazyContext> = {}): AutomatedExportLocalazyContext {
+  return {
+    settings: baseSettings,
+    contentTransferSetup: baseTransferSetup,
+    localazyData: baseLocalazyData,
+    ...overrides,
+  };
+}
+
+const okProject = { id: 'p1' } as Project;
+const okImportContent: LocalazyContent = {
+  translationStrings: new Map(),
+  collections: new Map(),
+};
+
+function makeFetcher(result: Awaited<ReturnType<SourceLanguageImportContentFetcher>>): SourceLanguageImportContentFetcher {
+  return vi.fn().mockResolvedValue(result);
+}
+
+const noopProjector: DeprecationKeyProjector = () => [];
+
+describe('runAutomatedDeprecationPipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    helperMocks.deprecateLocalazyKeys.mockResolvedValue(undefined);
+  });
+
+  it("returns 'missing-context' when loadContext yields null", async () => {
+    const fetcher = makeFetcher({ success: true, content: okImportContent });
+    const projector = vi.fn();
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => null,
+      fetchSourceLanguageImportContent: fetcher,
+      projectDeprecationKeys: projector,
+    });
+
+    expect(outcome).toEqual({ kind: 'missing-context' });
+    expect(helperMocks.loadLocalazyProject).not.toHaveBeenCalled();
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  // ADR-0001: deprecation is gated by BOTH master toggle and the deprecation toggle.
+  it("returns 'deprecation-disabled' when automated_upload is off", async () => {
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext({ settings: { automated_upload: false, automated_deprecation: true } as Settings }),
+      fetchSourceLanguageImportContent: makeFetcher({ success: false }),
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'deprecation-disabled' });
+    expect(helperMocks.loadLocalazyProject).not.toHaveBeenCalled();
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  it("returns 'deprecation-disabled' when automated_deprecation is off", async () => {
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext({ settings: { automated_upload: true, automated_deprecation: false } as Settings }),
+      fetchSourceLanguageImportContent: makeFetcher({ success: false }),
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'deprecation-disabled' });
+    expect(helperMocks.loadLocalazyProject).not.toHaveBeenCalled();
+  });
+
+  it("returns 'no-project' when loadLocalazyProject resolves to null", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(null);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: true, content: okImportContent }),
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'no-project' });
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  it("returns 'payment-disabled' when the project lacks access to the plugin", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue({
+      id: 'p1',
+      organization: { usedKeys: 1, availableKeys: 1000, figma: false },
+    } as unknown as Project);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: true, content: okImportContent }),
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'payment-disabled' });
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  it("returns 'could-not-fetch-import-content' when the fetcher reports success: false", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: false }),
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'could-not-fetch-import-content' });
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  it('invokes the projector with importContent + itemIds and forwards key ids to deprecateLocalazyKeys', async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const projector: DeprecationKeyProjector = vi.fn().mockReturnValue(['lk-a', 'lk-b', 'lk-c']);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['d1', 'd2'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: true, content: okImportContent }),
+      projectDeprecationKeys: projector,
+    });
+
+    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 3 });
+    expect(projector).toHaveBeenCalledWith({ importContent: okImportContent, itemIds: ['d1', 'd2'] });
+    expect(helperMocks.deprecateLocalazyKeys).toHaveBeenCalledWith('tok', 'p1', ['lk-a', 'lk-b', 'lk-c']);
+  });
+
+  it("still reaches 'deprecated' (with keysCount 0) when the projector produces nothing", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['d1'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: true, content: okImportContent }),
+      projectDeprecationKeys: () => [],
+    });
+
+    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 0 });
+    // deprecateLocalazyKeys is called even with empty array; the helper itself short-circuits.
+    expect(helperMocks.deprecateLocalazyKeys).toHaveBeenCalledWith('tok', 'p1', []);
+  });
+
+  it("returns 'failed' with the original error when the fetcher throws", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const fetcherError = new Error('fetch boom');
+    const fetcher: SourceLanguageImportContentFetcher = vi.fn().mockRejectedValue(fetcherError);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: fetcher,
+      projectDeprecationKeys: noopProjector,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', error: fetcherError });
+    expect(helperMocks.deprecateLocalazyKeys).not.toHaveBeenCalled();
+  });
+
+  it("returns 'failed' when deprecateLocalazyKeys throws", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const apiError = new Error('localazy down');
+    helperMocks.deprecateLocalazyKeys.mockRejectedValue(apiError);
+
+    const outcome = await runAutomatedDeprecationPipeline({
+      itemIds: ['a'],
+      loadContext: async () => makeContext(),
+      fetchSourceLanguageImportContent: makeFetcher({ success: true, content: okImportContent }),
+      projectDeprecationKeys: () => ['lk-1'],
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', error: apiError });
+  });
+});

--- a/extensions/common/services/orchestrator/automated-deprecation-pipeline.ts
+++ b/extensions/common/services/orchestrator/automated-deprecation-pipeline.ts
@@ -1,0 +1,113 @@
+import { Project } from '@localazy/api-client';
+import { LocalazyContent } from '../../models/localazy-content';
+import { LocalazyPaymentStatus } from '../../utilities/localazy-payment-status';
+import { loadLocalazyProject } from '../load-localazy-project';
+import { deprecateLocalazyKeys } from '../deprecate-localazy-keys';
+import { AutomatedExportLocalazyContext, AutomatedExportLocalazyContextLoader } from './automated-export-pipeline';
+
+/**
+ * Result returned by the `fetchSourceLanguageImportContent` port. Mirrors the shape of
+ * `importFromLocalazyService.importContentFromLocalazy` — the bundle adapter passes the
+ * call through verbatim.
+ */
+export type SourceLanguageImportContentResult = { success: true; content: LocalazyContent } | { success: false };
+
+export type SourceLanguageImportContentFetcherInput = {
+  context: AutomatedExportLocalazyContext;
+  localazyProject: Project;
+};
+
+/**
+ * Strategy: fetch source-language content from Localazy so the projector can locate the
+ * Localazy keys that correspond to the deleted Directus item ids. The bundle adapter
+ * wraps `importFromLocalazyService.importContentFromLocalazy` with a single-language
+ * (source-language only) request.
+ */
+export type SourceLanguageImportContentFetcher = (
+  input: SourceLanguageImportContentFetcherInput,
+) => Promise<SourceLanguageImportContentResult>;
+
+export type DeprecationKeyProjectorInput = {
+  importContent: LocalazyContent;
+  itemIds: string[];
+};
+
+/**
+ * Strategy: produce the Localazy key ids to deprecate from the fetched source-language
+ * import content and the deleted Directus item ids. Two production implementations:
+ * one walks `content.collections.get(collection)`; the other walks
+ * `content.translationStrings`.
+ */
+export type DeprecationKeyProjector = (input: DeprecationKeyProjectorInput) => string[];
+
+/**
+ * Discriminated outcome of one Automated deprecation pipeline run. The pipeline never
+ * logs or tracks errors directly — the caller maps each variant to the appropriate
+ * logger call and error-tracking invocation.
+ *
+ *   - `missing-context`             → settings / transfer setup / data row missing
+ *   - `deprecation-disabled`        → automated_upload OR automated_deprecation off
+ *                                      (ADR-0001: both must be on)
+ *   - `no-project`                  → loadProject returned null
+ *   - `payment-disabled`            → payment-status gate blocked the run
+ *   - `could-not-fetch-import-content` → the import fetch returned `{ success: false }`
+ *   - `deprecated`                  → deprecate-keys was invoked; `keysCount` carries
+ *                                      the number of Localazy keys that were marked
+ *                                      deprecated (may be 0 when nothing matched)
+ *   - `failed`                      → any helper threw; original error preserved
+ */
+export type AutomatedDeprecationOutcome =
+  | { kind: 'deprecated'; keysCount: number }
+  | { kind: 'missing-context' }
+  | { kind: 'deprecation-disabled' }
+  | { kind: 'no-project' }
+  | { kind: 'payment-disabled' }
+  | { kind: 'could-not-fetch-import-content' }
+  | { kind: 'failed'; error: unknown };
+
+export type AutomatedDeprecationPipelineOptions = {
+  itemIds: string[];
+  loadContext: AutomatedExportLocalazyContextLoader;
+  fetchSourceLanguageImportContent: SourceLanguageImportContentFetcher;
+  projectDeprecationKeys: DeprecationKeyProjector;
+};
+
+/**
+ * Runs one Automated deprecation end-to-end. Mirrors `runAutomatedExportPipeline` —
+ * pure orchestrator, returns a discriminated outcome, never logs.
+ */
+export async function runAutomatedDeprecationPipeline(opts: AutomatedDeprecationPipelineOptions): Promise<AutomatedDeprecationOutcome> {
+  try {
+    const context = await opts.loadContext();
+    if (!context) {
+      return { kind: 'missing-context' };
+    }
+
+    // ADR-0001: deprecation is a sub-behavior of the "automated export" master toggle.
+    // Both flags must be on; either off and no outbound activity happens.
+    if (!context.settings.automated_upload || !context.settings.automated_deprecation) {
+      return { kind: 'deprecation-disabled' };
+    }
+
+    const localazyProject = await loadLocalazyProject(context.localazyData.access_token);
+    if (!localazyProject) {
+      return { kind: 'no-project' };
+    }
+
+    if (LocalazyPaymentStatus.shouldDisableSyncOperations(localazyProject)) {
+      return { kind: 'payment-disabled' };
+    }
+
+    const result = await opts.fetchSourceLanguageImportContent({ context, localazyProject });
+    if (!result.success) {
+      return { kind: 'could-not-fetch-import-content' };
+    }
+
+    const keyIds = opts.projectDeprecationKeys({ importContent: result.content, itemIds: opts.itemIds });
+
+    await deprecateLocalazyKeys(context.localazyData.access_token, localazyProject.id, keyIds);
+    return { kind: 'deprecated', keysCount: keyIds.length };
+  } catch (error) {
+    return { kind: 'failed', error };
+  }
+}

--- a/extensions/common/services/orchestrator/automated-export-pipeline.test.ts
+++ b/extensions/common/services/orchestrator/automated-export-pipeline.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Project } from '@localazy/api-client';
+import { Settings } from '../../models/collections-data/settings';
+import { ContentTransferSetupDatabase } from '../../models/collections-data/content-transfer-setup';
+import { LocalazyData } from '../../models/collections-data/localazy-data';
+import { TranslatableContent } from '../../models/translatable-content';
+import { DirectusApi } from '../../interfaces/directus-api';
+
+// Hoisted so the vi.mock factories below can reference them.
+const helperMocks = vi.hoisted(() => ({
+  loadLocalazyProject: vi.fn(),
+  resolveExportLanguages: vi.fn(),
+}));
+
+vi.mock('../load-localazy-project', () => ({
+  loadLocalazyProject: helperMocks.loadLocalazyProject,
+}));
+
+vi.mock('../synchronization-languages-service', () => ({
+  SynchronizationLanguagesService: class {
+    resolveExportLanguages = helperMocks.resolveExportLanguages;
+  },
+}));
+
+import {
+  runAutomatedExportPipeline,
+  AutomatedExportLocalazyContext,
+  AutomatedExportContentFetcher,
+  AutomatedExportContentDispatcher,
+} from './automated-export-pipeline';
+
+const baseSettings = { automated_upload: true } as Settings;
+const baseTransferSetup = {} as ContentTransferSetupDatabase;
+const baseLocalazyData = { access_token: 'tok' } as LocalazyData;
+
+function makeContext(overrides: Partial<AutomatedExportLocalazyContext> = {}): AutomatedExportLocalazyContext {
+  return {
+    settings: baseSettings,
+    contentTransferSetup: baseTransferSetup,
+    localazyData: baseLocalazyData,
+    ...overrides,
+  };
+}
+
+const okProject = { id: 'p1' } as Project;
+const emptyContent: TranslatableContent = { sourceLanguage: {}, otherLanguages: {} };
+const nonEmptyContent: TranslatableContent = {
+  sourceLanguage: { en: { hello: 'Hello' } },
+  otherLanguages: {},
+};
+
+// The DirectusApi instance only matters as far as SynchronizationLanguagesService is
+// constructed with it — the constructor is mocked above, so any object works.
+const fakeDirectusApi = {} as DirectusApi;
+
+function makeFetcher(content: TranslatableContent): AutomatedExportContentFetcher {
+  return vi.fn().mockResolvedValue(content);
+}
+
+function makeDispatcher(): AutomatedExportContentDispatcher {
+  return vi.fn().mockResolvedValue(undefined);
+}
+
+describe('runAutomatedExportPipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    helperMocks.resolveExportLanguages.mockResolvedValue([]);
+  });
+
+  it("returns 'missing-context' when loadContext yields null", async () => {
+    const fetchContent = makeFetcher(nonEmptyContent);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => null,
+      directusApi: fakeDirectusApi,
+      fetchContent,
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'missing-context' });
+    expect(helperMocks.loadLocalazyProject).not.toHaveBeenCalled();
+    expect(fetchContent).not.toHaveBeenCalled();
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  // Behaviour change vs. legacy services: the toggle gate was buried inside
+  // `ExportToLocalazyService.exportContentToLocalazy`; lifting it here means no Localazy
+  // API call fires when the master export toggle is off.
+  it("returns 'export-disabled' before any Localazy API call when settings.automated_upload is off", async () => {
+    const fetchContent = makeFetcher(nonEmptyContent);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext({ settings: { automated_upload: false } as Settings }),
+      directusApi: fakeDirectusApi,
+      fetchContent,
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'export-disabled' });
+    expect(helperMocks.loadLocalazyProject).not.toHaveBeenCalled();
+    expect(fetchContent).not.toHaveBeenCalled();
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'no-project' when loadLocalazyProject resolves to null", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(null);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(nonEmptyContent),
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'no-project' });
+    expect(helperMocks.loadLocalazyProject).toHaveBeenCalledWith('tok');
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'payment-disabled' when the project's organisation is over its keys limit", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue({
+      id: 'p1',
+      organization: { usedKeys: 1000, availableKeys: 100, figma: true },
+    } as unknown as Project);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(nonEmptyContent),
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'payment-disabled' });
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'nothing-to-export' and skips dispatch when the fetcher yields an empty source language", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(emptyContent),
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'nothing-to-export' });
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'exported' and dispatches content + context + project on the happy path", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    helperMocks.resolveExportLanguages.mockResolvedValue(['en']);
+    const dispatchContent = makeDispatcher();
+    const fetchContent = makeFetcher(nonEmptyContent);
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent,
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'exported' });
+    expect(fetchContent).toHaveBeenCalledOnce();
+    expect(fetchContent).toHaveBeenCalledWith({
+      context: makeContext(),
+      localazyProject: okProject,
+      exportLanguages: ['en'],
+    });
+    expect(dispatchContent).toHaveBeenCalledWith({
+      content: nonEmptyContent,
+      context: makeContext(),
+      localazyProject: okProject,
+    });
+  });
+
+  it("returns 'failed' with the original error when loadLocalazyProject throws", async () => {
+    const apiError = new Error('localazy down');
+    helperMocks.loadLocalazyProject.mockRejectedValue(apiError);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(nonEmptyContent),
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', error: apiError });
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'failed' when the fetcher throws", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const fetcherError = new Error('fetcher boom');
+    const fetchContent: AutomatedExportContentFetcher = vi.fn().mockRejectedValue(fetcherError);
+    const dispatchContent = makeDispatcher();
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent,
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', error: fetcherError });
+    expect(dispatchContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 'failed' when the dispatcher throws (content was already produced)", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    const dispatchError = new Error('dispatch boom');
+    const dispatchContent: AutomatedExportContentDispatcher = vi.fn().mockRejectedValue(dispatchError);
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(nonEmptyContent),
+      dispatchContent,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', error: dispatchError });
+  });
+});

--- a/extensions/common/services/orchestrator/automated-export-pipeline.ts
+++ b/extensions/common/services/orchestrator/automated-export-pipeline.ts
@@ -1,0 +1,132 @@
+import { isEmpty } from 'lodash';
+import { Project } from '@localazy/api-client';
+import { Settings } from '../../models/collections-data/settings';
+import { ContentTransferSetupDatabase } from '../../models/collections-data/content-transfer-setup';
+import { LocalazyData } from '../../models/collections-data/localazy-data';
+import { TranslatableContent } from '../../models/translatable-content';
+import { DirectusApi } from '../../interfaces/directus-api';
+import { SynchronizationLanguagesService } from '../synchronization-languages-service';
+import { LocalazyPaymentStatus } from '../../utilities/localazy-payment-status';
+import { loadLocalazyProject } from '../load-localazy-project';
+
+/**
+ * The three rows of Localazy configuration the Automated export pipeline reads before
+ * each run. Loaded together by the `loadContext` port so the pipeline never holds a
+ * half-resolved state (e.g. settings without data or transfer setup).
+ */
+export type AutomatedExportLocalazyContext = {
+  settings: Settings;
+  contentTransferSetup: ContentTransferSetupDatabase;
+  localazyData: LocalazyData;
+};
+
+/**
+ * Loads the Localazy context. Returns `null` when any of the three rows is missing —
+ * the pipeline treats that uniformly as a `missing-context` outcome.
+ */
+export type AutomatedExportLocalazyContextLoader = () => Promise<AutomatedExportLocalazyContext | null>;
+
+export type AutomatedExportContentFetcherInput = {
+  context: AutomatedExportLocalazyContext;
+  localazyProject: Project;
+  // SynchronizationLanguagesService.resolveExportLanguages returns a `string[]` — Directus
+  // language codes, not the richer DirectusLocalazyLanguage triple. Downstream services
+  // (ApiTranslatableCollectionsService, TranslationStringsService) consume them as codes.
+  exportLanguages: string[];
+};
+
+/**
+ * Strategy plugged in by the caller: produce the translatable content to export. Two
+ * production implementations on the bundle side: one for collection-item exports, one
+ * for translation-string exports.
+ */
+export type AutomatedExportContentFetcher = (input: AutomatedExportContentFetcherInput) => Promise<TranslatableContent>;
+
+export type AutomatedExportContentDispatcherInput = {
+  content: TranslatableContent;
+  context: AutomatedExportLocalazyContext;
+  localazyProject: Project;
+};
+
+/**
+ * Strategy plugged in by the caller: send the resolved content to Localazy. The bundle
+ * adapter wraps `ExportToLocalazyService.exportContentToLocalazy`.
+ */
+export type AutomatedExportContentDispatcher = (input: AutomatedExportContentDispatcherInput) => Promise<void>;
+
+/**
+ * Discriminated outcome of one Automated export pipeline run. The pipeline never logs
+ * or tracks errors directly — the caller (today: the Sync-hook bundle's hook/index.ts)
+ * maps each variant to the appropriate logger call and `trackDirectusError` invocation.
+ *
+ * Variants map roughly onto the bail points the original
+ * `BaseContentSynchronizationService`-derived services had:
+ *   - `missing-context`   → "Missing settings or content transfer setup"
+ *   - `export-disabled`   → automated_upload toggle is off (new explicit gate, see below)
+ *   - `no-project`        → loadProject returned null (token missing or no projects)
+ *   - `payment-disabled`  → payment-status gate blocked the run
+ *   - `nothing-to-export` → source language has no content (fetcher returned empty)
+ *   - `exported`          → dispatch was invoked
+ *   - `failed`            → any helper threw; the original error is preserved
+ *
+ * Behaviour change from the legacy services: `automated_upload` is now gated at the
+ * top of the pipeline. Previously the check lived deep inside
+ * `ExportToLocalazyService.exportContentToLocalazy`, which meant a `loadProject` API
+ * call and language resolution still ran on disabled installs.
+ */
+export type AutomatedExportOutcome =
+  | { kind: 'exported' }
+  | { kind: 'nothing-to-export' }
+  | { kind: 'missing-context' }
+  | { kind: 'export-disabled' }
+  | { kind: 'no-project' }
+  | { kind: 'payment-disabled' }
+  | { kind: 'failed'; error: unknown };
+
+export type AutomatedExportPipelineOptions = {
+  loadContext: AutomatedExportLocalazyContextLoader;
+  directusApi: DirectusApi;
+  fetchContent: AutomatedExportContentFetcher;
+  dispatchContent: AutomatedExportContentDispatcher;
+};
+
+/**
+ * Runs one Automated export end-to-end. Pure orchestrator — all side effects flow
+ * through the four injected ports plus the `loadLocalazyProject` helper. The pipeline
+ * does no logging and never throws; instead it returns a discriminated outcome the
+ * caller maps to logger + error-tracking calls.
+ */
+export async function runAutomatedExportPipeline(opts: AutomatedExportPipelineOptions): Promise<AutomatedExportOutcome> {
+  try {
+    const context = await opts.loadContext();
+    if (!context) {
+      return { kind: 'missing-context' };
+    }
+
+    if (!context.settings.automated_upload) {
+      return { kind: 'export-disabled' };
+    }
+
+    const localazyProject = await loadLocalazyProject(context.localazyData.access_token);
+    if (!localazyProject) {
+      return { kind: 'no-project' };
+    }
+
+    if (LocalazyPaymentStatus.shouldDisableSyncOperations(localazyProject)) {
+      return { kind: 'payment-disabled' };
+    }
+
+    const exportLanguages = await new SynchronizationLanguagesService(opts.directusApi).resolveExportLanguages(context.settings);
+
+    const content = await opts.fetchContent({ context, localazyProject, exportLanguages });
+
+    if (isEmpty(content.sourceLanguage)) {
+      return { kind: 'nothing-to-export' };
+    }
+
+    await opts.dispatchContent({ content, context, localazyProject });
+    return { kind: 'exported' };
+  } catch (error) {
+    return { kind: 'failed', error };
+  }
+}

--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -129,11 +129,12 @@ function onSortPreferencesChange(next: SortPreferences) {
   }, 600);
 }
 
-const { activeTab, statusFilter, dateFrom, dateTo, page, totalPages, currentSort, setSort, filteredSessions, paginatedSessions } = useActivityLog({
-  sessions,
-  initialSortPreferences,
-  onSortPreferencesChange,
-});
+const { activeTab, statusFilter, dateFrom, dateTo, page, totalPages, currentSort, setSort, filteredSessions, paginatedSessions } =
+  useActivityLog({
+    sessions,
+    initialSortPreferences,
+    onSortPreferencesChange,
+  });
 
 // `<v-select :items>` shape: `{ text, value }`. The statuses mirror StatusLabel.vue's
 // known set; an unknown status read from disk still passes through the filter (the

--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -118,7 +118,6 @@ const directusMissingLanguagesOptions = ref<Item[]>([
     value: CreateMissingLanguagesInDirectus.NO,
   },
 ]);
-
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -3,7 +3,9 @@
     <div class="form grid">
       <header class="section-header">
         <h2 class="section-title">Export</h2>
-        <p class="note section-description">From Directus to Localazy &mdash; triggered by changes to translatable content inside Directus.</p>
+        <p class="note section-description">
+          From Directus to Localazy &mdash; triggered by changes to translatable content inside Directus.
+        </p>
       </header>
 
       <div class="half">
@@ -41,7 +43,9 @@
 
       <header class="section-header section-header-divider">
         <h2 class="section-title">Import</h2>
-        <p class="note section-description">From Localazy to Directus &mdash; triggered by Localazy's <code>project_published</code> webhook.</p>
+        <p class="note section-description">
+          From Localazy to Directus &mdash; triggered by Localazy's <code>project_published</code> webhook.
+        </p>
       </header>
 
       <div class="half">


### PR DESCRIPTION
## Summary

Architecture-deepening PR #3 from the backlog — foundation half. Pure addition: two new closed orchestrators in `common/services/orchestrator/` plus two pure helpers in `common/services/`. Nothing is wired yet; the bundle still goes through `BaseContentSynchronizationService` and its two subclasses. **PR 53/N** will cut the hook over and delete the legacy hierarchy.

**Why this refactor.** The bundle-side `BaseContentSynchronizationService` + `CollectionContentSynchronizationService` + `TranslationStringsSynchronizationService` formed a template-method hierarchy. Re-reading showed the base owned IO helpers but the orchestration loop itself was duplicated across the two subclasses, and the tests reached into `BaseContentSynchronizationService.prototype as unknown as Record<string, AnyFn>` to mock protected methods — classic shallow-module test-surface evidence. The variation across the two services was really just two pure functions (a content fetcher and, for deprecation, a key-id projector). Inheritance was heavier than the variation warranted.

**New shape:**

- `common/services/orchestrator/automated-export-pipeline.ts` — `runAutomatedExportPipeline(opts)` returns a discriminated `AutomatedExportOutcome`. Ports: `loadContext`, `directusApi`, `fetchContent`, `dispatchContent`. No logger inside; caller maps the outcome at the bundle edge.
- `common/services/orchestrator/automated-deprecation-pipeline.ts` — `runAutomatedDeprecationPipeline(opts)` returns `AutomatedDeprecationOutcome`. Ports: `loadContext`, `fetchSourceLanguageImportContent`, `projectDeprecationKeys`.
- `common/services/load-localazy-project.ts` — pure helper, replaces the protected `loadProject`. API errors propagate (legacy behaviour: `console.log` + return null).
- `common/services/deprecate-localazy-keys.ts` — pure helper, replaces protected `deprecateLocalazyKeys`. Inherits the async-queue's per-task error swallowing.
- `CONTEXT.md` gains two new terms: **Automated export pipeline** and **Automated deprecation pipeline**.

**Behaviour change to flag.** The export pipeline gates on `settings.automated_upload` at the top of the run. Previously the gate was buried inside `ExportToLocalazyService.exportContentToLocalazy`, so disabled installs still made the Localazy `loadProject` call and resolved export languages before bailing. Lifting the gate removes that wasted work and the previously hidden contract. Caller maps `{ kind: 'export-disabled' }` → a debug log.

**Behaviour change in the helpers.** `loadLocalazyProject` lets API errors bubble (legacy code did `console.log` + return null). The pipeline catches and returns `{ kind: 'failed', error }`. Net effect: failures are louder (caller can `trackDirectusError` with the original error) instead of being silently classified as "no project."

**Incidental.** Includes prettier-format fixes for four files that drifted on `next` (PR 48–51 went directly without CI). The four touched files: `Activity.vue`, `AdvancedSettingsForm.vue`, `AutomationForm.vue`, ADR-0001. Mechanical line-wrap only.

## Test plan

- [x] `npm run check` clean: lint (0 errors, 1 pre-existing warning), format, typecheck (`vue-tsc --noEmit`), 460/460 tests pass.
- [x] `npm run build` clean for both extensions.
- [ ] No runtime test possible in this PR — nothing is wired yet. PR 53/N's cutover will exercise the new pipelines through the hook on a real Directus instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)