### PR TITLE
PR 55/N: useSyncLogEntries composable for Activity detail page

### DIFF
--- a/extensions/module/src/ActivityDetail.vue
+++ b/extensions/module/src/ActivityDetail.vue
@@ -50,7 +50,8 @@ import Navigation from './components/Navigation.vue';
 import SessionMetadata from './components/Activity/SessionMetadata.vue';
 import { useLocalazySyncLogStore } from './stores/localazy-sync-log-store';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
-import type { SyncLogEntry, SyncLogLevel, SyncLogSession } from '../../common/models/collections-data/sync-log';
+import { useSyncLogEntries } from './composables/use-sync-log-entries';
+import type { SyncLogSession } from '../../common/models/collections-data/sync-log';
 
 const route = useRoute();
 const sessionId = computed(() => String(route.params.sessionId || ''));
@@ -66,31 +67,7 @@ const breadcrumb = computed(() => [
   { name: 'Activity', to: '/localazy/activity' },
 ]);
 
-const entries = computed<SyncLogEntry[]>(() => {
-  if (!session.value) return [];
-  try {
-    const parsed: unknown = JSON.parse(session.value.entries || '[]');
-    return Array.isArray(parsed) ? (parsed as SyncLogEntry[]) : [];
-  } catch {
-    return [];
-  }
-});
-
-function formatTime(ts: string): string {
-  const ms = Date.parse(ts);
-  if (!Number.isFinite(ms)) return ts;
-  return new Date(ms).toLocaleTimeString(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
-
-function iconForLevel(level: SyncLogLevel): string {
-  if (level === 'error') return 'error_outline';
-  if (level === 'warn') return 'warning_amber';
-  return 'info';
-}
+const { entries, formatTime, iconForLevel } = useSyncLogEntries(session);
 
 onBeforeMount(async () => {
   await boot();

--- a/extensions/module/src/composables/use-sync-log-entries.test.ts
+++ b/extensions/module/src/composables/use-sync-log-entries.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import type { SyncLogSession } from '../../../common/models/collections-data/sync-log';
+import { formatSyncLogEntryTime, iconForSyncLogLevel, parseSyncLogEntries, useSyncLogEntries } from './use-sync-log-entries';
+
+describe('parseSyncLogEntries', () => {
+  it('returns [] for null, undefined, and empty string', () => {
+    expect(parseSyncLogEntries(null)).toEqual([]);
+    expect(parseSyncLogEntries(undefined)).toEqual([]);
+    expect(parseSyncLogEntries('')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    expect(parseSyncLogEntries('not json')).toEqual([]);
+    expect(parseSyncLogEntries('{')).toEqual([]);
+  });
+
+  it('returns [] when the parsed JSON is not an array', () => {
+    expect(parseSyncLogEntries('{}')).toEqual([]);
+    expect(parseSyncLogEntries('"a string"')).toEqual([]);
+    expect(parseSyncLogEntries('42')).toEqual([]);
+  });
+
+  it('returns the parsed array when the JSON encodes a SyncLogEntry[]', () => {
+    const json = JSON.stringify([
+      { timestamp: '2026-05-17T10:00:00Z', level: 'info', message: 'first' },
+      { timestamp: '2026-05-17T10:00:01Z', level: 'error', message: 'oops', data: { foo: 1 } },
+    ]);
+
+    expect(parseSyncLogEntries(json)).toEqual([
+      { timestamp: '2026-05-17T10:00:00Z', level: 'info', message: 'first' },
+      { timestamp: '2026-05-17T10:00:01Z', level: 'error', message: 'oops', data: { foo: 1 } },
+    ]);
+  });
+});
+
+describe('formatSyncLogEntryTime', () => {
+  it('returns the input verbatim when it cannot be parsed as a date', () => {
+    expect(formatSyncLogEntryTime('not a date')).toBe('not a date');
+    expect(formatSyncLogEntryTime('')).toBe('');
+  });
+
+  it('formats a parseable ISO timestamp as a time-of-day string', () => {
+    // Locale + timezone are environment-dependent, so we don't pin the exact output
+    // string. Just assert: not the raw input, no "Invalid Date", and contains digits.
+    const formatted = formatSyncLogEntryTime('2026-05-17T14:23:07Z');
+
+    expect(formatted).not.toBe('2026-05-17T14:23:07Z');
+    expect(formatted).not.toContain('Invalid');
+    expect(formatted).toMatch(/\d/);
+  });
+});
+
+describe('iconForSyncLogLevel', () => {
+  it('maps each known level to the Directus icon name used in the detail page', () => {
+    expect(iconForSyncLogLevel('error')).toBe('error_outline');
+    expect(iconForSyncLogLevel('warn')).toBe('warning_amber');
+    expect(iconForSyncLogLevel('info')).toBe('info');
+  });
+});
+
+describe('useSyncLogEntries', () => {
+  function makeSession(entriesJson: string | null): SyncLogSession {
+    return { entries: entriesJson } as unknown as SyncLogSession;
+  }
+
+  it('reactively reflects the current session row entries', () => {
+    const session = ref<SyncLogSession | null>(null);
+    const { entries } = useSyncLogEntries(session);
+
+    expect(entries.value).toEqual([]);
+
+    session.value = makeSession(JSON.stringify([{ timestamp: 't1', level: 'info', message: 'hello' }]));
+    expect(entries.value).toEqual([{ timestamp: 't1', level: 'info', message: 'hello' }]);
+  });
+
+  it('returns the same formatTime + iconForLevel references as the named module exports', () => {
+    const session = ref<SyncLogSession | null>(null);
+    const view = useSyncLogEntries(session);
+
+    expect(view.formatTime).toBe(formatSyncLogEntryTime);
+    expect(view.iconForLevel).toBe(iconForSyncLogLevel);
+  });
+});

--- a/extensions/module/src/composables/use-sync-log-entries.ts
+++ b/extensions/module/src/composables/use-sync-log-entries.ts
@@ -1,0 +1,59 @@
+import { computed, type Ref } from 'vue';
+import type { SyncLogEntry, SyncLogLevel, SyncLogSession } from '../../../common/models/collections-data/sync-log';
+
+/**
+ * Parses the JSON `entries` column of a sync-log session row. Tolerant — `null`,
+ * `undefined`, empty strings, malformed JSON, and non-array payloads all return an
+ * empty array so the detail page renders an "No log entries to display" empty state
+ * rather than crashing on a bad row.
+ */
+export function parseSyncLogEntries(entriesJson: string | null | undefined): SyncLogEntry[] {
+  if (!entriesJson) return [];
+  try {
+    const parsed: unknown = JSON.parse(entriesJson);
+    return Array.isArray(parsed) ? (parsed as SyncLogEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Locale-aware time-of-day formatter for sync-log entry timestamps. Returns the input
+ * string unchanged when it isn't parseable so the detail page shows the raw value
+ * rather than a misleading "Invalid Date".
+ */
+export function formatSyncLogEntryTime(ts: string): string {
+  const ms = Date.parse(ts);
+  if (!Number.isFinite(ms)) return ts;
+  return new Date(ms).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+/**
+ * Directus icon name for a sync-log entry level. Unknown levels fall through to the
+ * `info` icon — defensive, since a future level shouldn't disappear from the UI before
+ * the mapping is taught.
+ */
+export function iconForSyncLogLevel(level: SyncLogLevel): string {
+  if (level === 'error') return 'error_outline';
+  if (level === 'warn') return 'warning_amber';
+  return 'info';
+}
+
+/**
+ * View-model for the Activity detail page's entries list. Bundles the reactive parse
+ * of the session-row's `entries` column with the two pure formatters used in the
+ * template, so the page binds a single composable rather than three named imports
+ * plus an inline `computed`.
+ */
+export function useSyncLogEntries(session: Ref<SyncLogSession | null>) {
+  const entries = computed(() => parseSyncLogEntries(session.value?.entries));
+  return {
+    entries,
+    formatTime: formatSyncLogEntryTime,
+    iconForLevel: iconForSyncLogLevel,
+  };
+}


### PR DESCRIPTION
## Summary

Mild deepening of the Activity detail page. Pulls three concerns out of `ActivityDetail.vue` (~30 LOC removed) into a dedicated composable + module-level pure helpers:

- `parseSyncLogEntries(json)` — tolerant JSON parse of the session's `entries` column. Empty string / malformed JSON / non-array payloads all collapse to `[]` so the page renders the empty state rather than crashing on a bad row.
- `formatSyncLogEntryTime(ts)` — locale-aware time-of-day formatter (`HH:MM:SS`) for log-entry timestamps. Invalid input passes through verbatim.
- `iconForSyncLogLevel(level)` — `error`/`warn`/`info` → Directus icon name.
- `useSyncLogEntries(session)` — view-model that bundles `entries` (reactive parse of the supplied session ref) + the two formatters, so the template binds one composable instead of three named imports plus an inline `computed`.

## Context

This is the one architectural item left in the Activity surface — most of the original "session-view module" deepening shipped across PRs 35–47 (`use-activity-log.ts`, `use-sync-log-user-names.ts`, the `SessionsTable` + `SessionMetadata` + `StatusLabel` components). Surveying today, the only remaining inline ad-hoc parsers were in `ActivityDetail.vue`. This PR closes that gap.

`ActivityDetail.vue` drops from 210 → 184 LOC.

## Test plan

- [x] `npm run check` clean: lint, format, typecheck, **491/491** tests pass.
- [x] `npm run build` clean for both extensions.
- [x] New `use-sync-log-entries.test.ts` covers all three helpers + the composable's reactivity:
  - `parseSyncLogEntries`: null/undefined/empty, malformed JSON, non-array JSON, valid `SyncLogEntry[]` payload
  - `formatSyncLogEntryTime`: invalid input pass-through + parseable ISO produces a non-raw, non-"Invalid Date" string
  - `iconForSyncLogLevel`: all three levels mapped
  - `useSyncLogEntries`: reactive `entries` ref-bound to the session, formatters are stable references

🤖 Generated with [Claude Code](https://claude.com/claude-code)