### PR TITLE
PR 56/N: migrate styles to Directus 11 theme-token namespace

### DIFF
--- a/extensions/module/src/About.vue
+++ b/extensions/module/src/About.vue
@@ -141,7 +141,10 @@ h2 {
   padding-bottom: 4px;
   font-size: 24px;
   line-height: 34px;
-  border-bottom: 2px solid var(--border-subdued);
+  /* Directus 11 renamed theme tokens to the `--theme--*` namespace. The old
+     `--border-subdued` is undefined → the whole shorthand becomes invalid CSS
+     and the section divider disappears. */
+  border-bottom: 2px solid var(--theme--border-color-subdued);
   font-weight: 600;
 }
 
@@ -155,10 +158,10 @@ h3 {
   padding-bottom: 4px;
   font-size: 20px;
   line-height: 22px;
-  border-bottom: 1px solid var(--border-subdued);
+  border-bottom: 1px solid var(--theme--border-color-subdued);
 
   .v-icon {
-    color: var(--primary);
+    color: var(--theme--primary);
   }
 }
 

--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -249,7 +249,7 @@ onBeforeMount(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   font-size: 13px;
   margin-bottom: 16px;
 }
@@ -284,7 +284,7 @@ onBeforeMount(() => {
 .filter-label {
   font-size: 12px;
   font-weight: 600;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -298,7 +298,7 @@ onBeforeMount(() => {
    default Directus active-tab color shift was too subtle, so we promote it to
    `--primary` and bump weight; no card, no underline strip. */
 .sessions-tabs :deep(.v-tab.active) {
-  color: var(--primary);
+  color: var(--theme--primary);
   font-weight: 600;
 }
 

--- a/extensions/module/src/ActivityDetail.vue
+++ b/extensions/module/src/ActivityDetail.vue
@@ -91,19 +91,19 @@ onBeforeMount(async () => {
 .empty-state {
   padding: 48px;
   text-align: center;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 }
 
 .metadata-section {
-  background-color: var(--background-normal);
+  background-color: var(--theme--background-normal);
   padding: 24px;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   margin-bottom: 16px;
 }
 
 .summary-row {
   margin-top: 24px;
-  border-top: 1px solid var(--border-subdued);
+  border-top: 1px solid var(--theme--border-color-subdued);
   padding-top: 16px;
 }
 
@@ -111,20 +111,20 @@ onBeforeMount(async () => {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   letter-spacing: 0.5px;
   margin-bottom: 4px;
 }
 
 .summary-value {
   font-size: 14px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 .entries-section {
-  background-color: var(--background-normal);
+  background-color: var(--theme--background-normal);
   padding: 24px;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
 }
 
 .entries-list {
@@ -134,8 +134,8 @@ onBeforeMount(async () => {
 
 .entry-row {
   padding: 12px 0;
-  border-bottom: 1px solid var(--border-subdued);
-  font-family: var(--family-monospace);
+  border-bottom: 1px solid var(--theme--border-color-subdued);
+  font-family: var(--theme--fonts--monospace--font-family);
 
   &:last-child {
     border-bottom: none;
@@ -153,7 +153,7 @@ onBeforeMount(async () => {
 }
 
 .entry-timestamp {
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   font-size: 12px;
   white-space: nowrap;
   min-width: 80px;
@@ -161,26 +161,26 @@ onBeforeMount(async () => {
 
 .entry-message {
   font-size: 13px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 .entry-info .entry-icon {
-  color: var(--primary);
+  color: var(--theme--primary);
 }
 .entry-warn .entry-icon {
-  color: var(--warning);
+  color: var(--theme--warning);
 }
 .entry-error .entry-icon {
-  color: var(--danger);
+  color: var(--theme--danger);
 }
 
 .entry-data {
   margin: 8px 0 0 32px;
   padding: 8px 12px;
-  background-color: var(--background-subdued);
-  border-radius: var(--border-radius);
+  background-color: var(--theme--background-subdued);
+  border-radius: var(--theme--border-radius);
   font-size: 12px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -249,7 +249,7 @@ function deselectAll() {
 .translation-strings-separator {
   padding-top: 8px;
   margin-top: 8px;
-  border-top: 1px solid var(--border-normal);
+  border-top: 1px solid var(--theme--border-color);
 }
 
 .last-sync-banner {
@@ -259,18 +259,18 @@ function deselectAll() {
   padding: 10px 14px;
   margin-top: 12px;
   margin-bottom: 12px;
-  background-color: var(--background-subdued);
-  border: 1px solid var(--border-subdued);
-  border-radius: var(--border-radius);
+  background-color: var(--theme--background-subdued);
+  border: 1px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
   cursor: pointer;
   font-size: 13px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   transition: background-color var(--fast) var(--transition);
 
   &:hover,
   &:focus {
-    background-color: var(--background-normal);
-    color: var(--foreground-normal);
+    background-color: var(--theme--background-normal);
+    color: var(--theme--foreground);
     outline: none;
   }
 

--- a/extensions/module/src/components/Activity/SessionMetadata.vue
+++ b/extensions/module/src/components/Activity/SessionMetadata.vue
@@ -60,12 +60,12 @@ defineProps<{
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   letter-spacing: 0.5px;
 }
 
 .metadata-value {
   font-size: 14px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 </style>

--- a/extensions/module/src/components/Activity/SessionsTable.vue
+++ b/extensions/module/src/components/Activity/SessionsTable.vue
@@ -98,17 +98,17 @@ const columns: Array<{ key: SortKey; label: string }> = [
 .sortable-header {
   text-align: left;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-subdued);
+  border-bottom: 1px solid var(--theme--border-color-subdued);
   cursor: pointer;
   user-select: none;
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   letter-spacing: 0.5px;
 
   &.active {
-    color: var(--primary);
+    color: var(--theme--primary);
   }
 }
 
@@ -123,12 +123,12 @@ const columns: Array<{ key: SortKey; label: string }> = [
   transition: background-color var(--fast) var(--transition);
 
   &:hover {
-    background-color: var(--background-subdued);
+    background-color: var(--theme--background-subdued);
   }
 
   td {
     padding: 12px 16px;
-    border-bottom: 1px solid var(--border-subdued);
+    border-bottom: 1px solid var(--theme--border-color-subdued);
     font-size: 14px;
   }
 }
@@ -143,7 +143,7 @@ const columns: Array<{ key: SortKey; label: string }> = [
 .empty-state {
   padding: 56px 32px;
   text-align: center;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   font-size: 14px;
 }
 </style>

--- a/extensions/module/src/components/Activity/StatusLabel.vue
+++ b/extensions/module/src/components/Activity/StatusLabel.vue
@@ -60,7 +60,7 @@ const statusClass = computed(() => {
 .status-label {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   font-size: 12px;
   font-weight: 600;
   line-height: 1.4;
@@ -68,21 +68,21 @@ const statusClass = computed(() => {
 
 .status-success {
   background: var(--success-25, rgba(46, 184, 124, 0.12));
-  color: var(--success);
+  color: var(--theme--success);
 }
 
 .status-warning {
   background: var(--warning-25, rgba(255, 167, 38, 0.15));
-  color: var(--warning);
+  color: var(--theme--warning);
 }
 
 .status-danger {
   background: var(--danger-25, rgba(231, 76, 60, 0.12));
-  color: var(--danger);
+  color: var(--theme--danger);
 }
 
 .status-neutral {
-  background: var(--background-subdued);
-  color: var(--foreground-subdued);
+  background: var(--theme--background-subdued);
+  color: var(--theme--foreground-subdued);
 }
 </style>

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -246,14 +246,14 @@ onMounted(() => {
 .section-header-divider {
   margin-top: 16px;
   padding-top: 32px;
-  border-top: 1px solid var(--border-subdued);
+  border-top: 1px solid var(--theme--border-color-subdued);
 }
 
 .section-title {
   font-size: 20px;
   font-weight: 700;
   margin: 0 0 4px 0;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 .section-description {
@@ -269,7 +269,7 @@ onMounted(() => {
   font-size: 16px;
   font-weight: 600;
   margin: 0 0 8px 0;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 .webhook-description {
@@ -288,14 +288,14 @@ onMounted(() => {
   font-style: italic;
   font-size: 13px;
   line-height: 18px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 
   & a {
     text-decoration: underline;
   }
 
   code {
-    background: var(--background-subdued);
+    background: var(--theme--background-subdued);
     padding: 1px 4px;
     border-radius: 4px;
     font-style: normal;
@@ -304,6 +304,6 @@ onMounted(() => {
 
 .hint {
   margin-top: 6px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 }
 </style>

--- a/extensions/module/src/components/Automation/WebhookSetup.vue
+++ b/extensions/module/src/components/Automation/WebhookSetup.vue
@@ -198,7 +198,7 @@ watch(
   display: flex;
   gap: 8px;
   align-items: center;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   font-size: 14px;
 }
 
@@ -212,9 +212,9 @@ watch(
 }
 
 .notice-url {
-  font-family: var(--family-monospace);
+  font-family: var(--theme--fonts--monospace--font-family);
   font-size: 13px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
   word-break: break-all;
 }
 
@@ -246,10 +246,10 @@ watch(
 .step-description {
   margin: 6px 0 0 0;
   font-size: 13px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 
   code {
-    background: var(--background-subdued);
+    background: var(--theme--background-subdued);
     padding: 1px 6px;
     border-radius: 4px;
     font-size: 12px;
@@ -262,10 +262,10 @@ watch(
   align-items: flex-start;
   margin-top: 8px;
   padding: 8px 12px;
-  background: var(--warning-25, var(--background-subdued));
-  border: 1px solid var(--warning-50, var(--border-subdued));
-  border-radius: var(--border-radius);
-  color: var(--warning, var(--foreground-normal));
+  background: var(--warning-25, var(--theme--background-subdued));
+  border: 1px solid var(--warning-50, var(--theme--border-color-subdued));
+  border-radius: var(--theme--border-radius);
+  color: var(--warning, var(--theme--foreground));
   font-size: 13px;
   line-height: 1.4;
 }

--- a/extensions/module/src/components/Modals/ProgressTrackerModal.vue
+++ b/extensions/module/src/components/Modals/ProgressTrackerModal.vue
@@ -4,9 +4,9 @@
       <v-card-title>Progress Status</v-card-title>
       <v-card-text>
         <div v-for="(progress, idx) in progressTracker" :key="idx">
-          <v-icon v-if="progress.type === 'error'" name="clear" color="var(--danger)" />
-          <v-icon v-else-if="idx + 1 < progressTracker.length || !loading" name="check" color="var(--success)" />
-          <v-icon v-else name="arrow_right_alt" color="var(--foreground-subdued)" />
+          <v-icon v-if="progress.type === 'error'" name="clear" color="var(--theme--danger)" />
+          <v-icon v-else-if="idx + 1 < progressTracker.length || !loading" name="check" color="var(--theme--success)" />
+          <v-icon v-else name="arrow_right_alt" color="var(--theme--foreground-subdued)" />
           <span>
             {{ progress.message }}
           </span>

--- a/extensions/module/src/components/Navigation.vue
+++ b/extensions/module/src/components/Navigation.vue
@@ -59,11 +59,11 @@ const versionLabel = `Version ${packageJson.version}`;
 
 <style lang="scss" scoped>
 .version {
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   transition: color var(--fast) var(--transition);
 
   &::v-deep(.v-icon) {
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     transition: color var(--fast) var(--transition);
   }
 }

--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -229,14 +229,14 @@ watch(
 }
 
 .input-note-error {
-  color: var(--danger) !important;
+  color: var(--theme--danger) !important;
 }
 
 .note {
   font-style: italic;
   font-size: 13px;
   line-height: 18px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 
   & a {
     text-decoration: underline;
@@ -245,7 +245,7 @@ watch(
 
 .input-error {
   & ::v-deep(.input) {
-    border-color: var(--danger);
+    border-color: var(--theme--danger);
   }
 }
 </style>

--- a/extensions/module/src/components/Sync/CollectionItem.vue
+++ b/extensions/module/src/components/Sync/CollectionItem.vue
@@ -21,14 +21,14 @@
         @update:model-value="onUpdateCollectionSelection"
       >
         <span>
-          <v-icon :color="collection.color || 'var(--primary)'" class="collection-icon" :name="collection.icon" />
+          <v-icon :color="collection.color || 'var(--theme--primary)'" class="collection-icon" :name="collection.icon" />
           <span class="collection-name">{{ collection.name }}</span>
         </span>
       </v-checkbox>
 
       <v-list-item v-else class="collection-item collection-item-unclickable v-list-item">
         <span>
-          <v-icon :color="collection.color || 'var(--primary)'" class="collection-icon" :name="collection.icon" />
+          <v-icon :color="collection.color || 'var(--theme--primary)'" class="collection-icon" :name="collection.icon" />
           <span class="collection-name">{{ collection.name }}</span>
         </span>
       </v-list-item>
@@ -214,12 +214,12 @@ function onGroupClick() {
 
 .collection-group-chevron {
   margin-right: 0 !important;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   transform: rotate(0deg);
   transition: transform var(--medium) var(--transition);
 
   &:hover {
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 
   &.active {

--- a/extensions/module/src/components/Sync/SyncOptionButtons.vue
+++ b/extensions/module/src/components/Sync/SyncOptionButtons.vue
@@ -69,23 +69,23 @@ function onUpdateCollectionSelection() {
   width: 100%;
 
   & .v-icon {
-    --v-icon-color: var(--foreground-subdued);
+    --v-icon-color: var(--theme--foreground-subdued);
   }
 
   .checkbox-button {
     &::v-deep(.v-icon) {
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
     }
 
     &:hover {
       ::v-deep(.checkbox) {
-        color: var(--foreground-subdued);
+        color: var(--theme--foreground-subdued);
       }
     }
   }
 
   & .button-label {
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-weight: 500;
   }
 

--- a/extensions/module/src/components/Sync/TranslationStringsContent.vue
+++ b/extensions/module/src/components/Sync/TranslationStringsContent.vue
@@ -2,7 +2,7 @@
   <div>
     <v-checkbox v-model="shouldSynchronize" class="collection-item collection-item-clickable">
       <span>
-        <v-icon color="var(--primary)" class="collection-icon" name="translate" />
+        <v-icon color="var(--theme--primary)" class="collection-icon" name="translate" />
         <span class="collection-name"
           >Translation Strings
           <a

--- a/extensions/module/src/styles/mixins/common.scss
+++ b/extensions/module/src/styles/mixins/common.scss
@@ -32,20 +32,20 @@
 
   // Background
   .bg-success {
-    background-color: var(--success);
+    background-color: var(--theme--success);
   }
 
   .bg-danger {
-    background-color: var(--danger);
+    background-color: var(--theme--danger);
   }
 
   .bg-warning {
-    background-color: var(--warning);
+    background-color: var(--theme--warning);
   }
 
   // Colors
   .text-foreground-normal {
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 
   // Width


### PR DESCRIPTION
## Summary

- Pure cosmetic. Replaces legacy theme variables (`--foreground-subdued`, `--border-subdued`, `--danger`, `--primary`, `--success`, `--warning`, `--background-subdued`, `--border-radius`, `--family-monospace`) with their Directus 11 `--theme--*` equivalents.
- The legacy names are undefined in the host now, which makes the whole shorthand declaration invalid CSS (e.g. the About-page section divider disappears, status pills lose hue).
- Files in this PR are those where the token swap is the only change. The Connection* rewrite, LanguageMappingsEditor rewrite, and the AdvancedSettings / Automation guard wire-up carry their own token migrations as part of their feature PRs.

## Test plan

- [x] `npm run check` green locally (lint, prettier, typecheck, 539 tests).
- [ ] Visual check: About-page section divider visible, status pills have hue, Activity sortable-header active state in `--theme--primary`.
- [ ] Spot-check at least one screen per touched component still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)