### PR TITLE
PR 57/N: heal-fields utility + meta.special drift PATCH

### DIFF
--- a/extensions/module/src/stores/localazy-installer-store.ts
+++ b/extensions/module/src/stores/localazy-installer-store.ts
@@ -12,6 +12,7 @@ import { createContentTransferSetupsFields } from '../data/fields/content-transf
 import { createLocalazyDataFields } from '../data/fields/localazy-data/create';
 import { createSyncStateFields } from '../data/fields/sync-state/create';
 import { createSyncLogFields } from '../data/fields/sync-log/create';
+import { computeFieldHealActions } from './utilities/heal-fields';
 
 /**
  * Collection names owned by this extension. Used by the installer and the per-singleton
@@ -118,15 +119,27 @@ export const useLocalazyInstallerStore = defineStore('localazyInstaller', () => 
       return;
     }
 
-    // Heal: declarative field check. Diff what we declare against what Directus reports
-    // and POST any missing fields. The correct route is `/fields/{collection}` —
-    // the old `/collections/{collection}/fields` was a 404 (latent bug pre-dating PR 21).
+    // Heal: declarative field check. Diff what we declare against what Directus reports.
+    // The route `/fields/{collection}` accepts POSTs for missing fields and
+    // `/fields/{collection}/{field}` accepts PATCHes for metadata reconciliation.
+    // (The old `/collections/{collection}/fields` route was a 404 — latent bug pre-dating PR 21.)
+    //
+    // Metadata reconciliation specifically fixes `meta.special` drift: older Localazy
+    // installations have boolean field rows in `directus_fields` without `cast-boolean`
+    // (the flag was added to the field declarations later). On MySQL the driver returns
+    // `tinyint(1)` as raw `1`/`0` without the cast, which breaks `<v-select>` strict
+    // equality against item values like `{ value: true }`. SQLite happens to coerce
+    // `tinyint(1)` → boolean and masks the bug locally.
     const existingFields = fieldsStore.getFieldsForCollection(plan.name) as Field[];
-    const missing = plan.fields().filter((f) => !existingFields.find((ef) => ef.field === f.field));
-    if (missing.length === 0) return;
+    const { missing, metaUpdates } = computeFieldHealActions(plan.fields(), existingFields);
+    if (missing.length === 0 && metaUpdates.length === 0) return;
 
     for (const field of missing) {
       await api.post(`/fields/${plan.name}`, field);
+      await sleep(100);
+    }
+    for (const update of metaUpdates) {
+      await api.patch(`/fields/${plan.name}/${update.field}`, { meta: { special: update.special } });
       await sleep(100);
     }
     await fieldsStore.hydrate();

--- a/extensions/module/src/stores/utilities/heal-fields.test.ts
+++ b/extensions/module/src/stores/utilities/heal-fields.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import type { DeepPartial, Field } from '@directus/types';
+import { computeFieldHealActions, specialEqual } from './heal-fields';
+
+// Tests live alongside the helper to exercise the regression case that surfaced on
+// MySQL-backed installs: a boolean field row in `directus_fields` without
+// `cast-boolean` in `meta.special` shows raw `1`/`0` in `<v-select>` instead of the
+// item labels. The healer's metadata-reconciliation path patches those rows on boot.
+
+// Convenience constructors keep the cases readable.
+function field(name: string, special: string[] = []): DeepPartial<Field> {
+  return { field: name, meta: { special } };
+}
+function existingField(name: string, special: string[] = []): Field {
+  return { field: name, meta: { special } } as Field;
+}
+
+describe('computeFieldHealActions', () => {
+  it('returns empty action lists when declared and existing match exactly', () => {
+    const declared = [field('automated_import', ['cast-boolean']), field('language_collection')];
+    const existing = [existingField('automated_import', ['cast-boolean']), existingField('language_collection')];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.missing).toEqual([]);
+    expect(result.metaUpdates).toEqual([]);
+  });
+
+  it('flags a declared field as missing when Directus has no row for it', () => {
+    const declared = [field('automated_import', ['cast-boolean']), field('newly_added_field')];
+    const existing = [existingField('automated_import', ['cast-boolean'])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.missing).toEqual([field('newly_added_field')]);
+    expect(result.metaUpdates).toEqual([]);
+  });
+
+  // The original regression: MySQL installs predating PR 21 stored boolean fields
+  // without `cast-boolean`. SQLite happens to coerce `tinyint(1)` → boolean so the
+  // bug only surfaces on MySQL — meaning this test is the only line of defence
+  // against silently reintroducing the broken state.
+  it('patches `meta.special` when the existing row is missing `cast-boolean` on a declared boolean', () => {
+    const declared = [field('automated_import', ['cast-boolean'])];
+    const existing = [existingField('automated_import', [])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.missing).toEqual([]);
+    expect(result.metaUpdates).toEqual([{ field: 'automated_import', special: ['cast-boolean'] }]);
+  });
+
+  it('treats `undefined` meta.special on the declared side as an empty array (no false-positive update)', () => {
+    const declared: DeepPartial<Field>[] = [{ field: 'plain_string', meta: {} }];
+    const existing = [existingField('plain_string', [])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.metaUpdates).toEqual([]);
+  });
+
+  it('treats `undefined` meta on the existing side as an empty array (no false-positive update)', () => {
+    const declared: DeepPartial<Field>[] = [{ field: 'plain_string', meta: { special: [] } }];
+    const existing = [{ field: 'plain_string' } as Field];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.metaUpdates).toEqual([]);
+  });
+
+  it('ignores ordering when comparing `meta.special` arrays', () => {
+    const declared = [field('multi_special', ['cast-boolean', 'no-data'])];
+    const existing = [existingField('multi_special', ['no-data', 'cast-boolean'])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.metaUpdates).toEqual([]);
+  });
+
+  it('detects when `meta.special` has the right count but different members', () => {
+    const declared = [field('drifted', ['cast-boolean'])];
+    const existing = [existingField('drifted', ['cast-json'])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.metaUpdates).toEqual([{ field: 'drifted', special: ['cast-boolean'] }]);
+  });
+
+  it('handles missing fields and meta updates in a single plan', () => {
+    const declared = [field('automated_import', ['cast-boolean']), field('automated_upload', ['cast-boolean']), field('newly_added_field')];
+    const existing = [existingField('automated_import', []), existingField('automated_upload', ['cast-boolean'])];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.missing).toEqual([field('newly_added_field')]);
+    expect(result.metaUpdates).toEqual([{ field: 'automated_import', special: ['cast-boolean'] }]);
+  });
+
+  it('skips declared entries that are missing the `field` key (defensive)', () => {
+    const declared: DeepPartial<Field>[] = [{ meta: { special: ['cast-boolean'] } }, field('valid_field')];
+    const existing: Field[] = [];
+
+    const result = computeFieldHealActions(declared, existing);
+
+    expect(result.missing).toEqual([field('valid_field')]);
+    expect(result.metaUpdates).toEqual([]);
+  });
+});
+
+describe('specialEqual', () => {
+  it('returns true for identical arrays', () => {
+    expect(specialEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+
+  it('returns true regardless of ordering', () => {
+    expect(specialEqual(['a', 'b'], ['b', 'a'])).toBe(true);
+  });
+
+  it('returns false when lengths differ', () => {
+    expect(specialEqual(['a'], ['a', 'b'])).toBe(false);
+  });
+
+  it('returns false when members differ', () => {
+    expect(specialEqual(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+
+  it('returns true for two empty arrays', () => {
+    expect(specialEqual([], [])).toBe(true);
+  });
+});

--- a/extensions/module/src/stores/utilities/heal-fields.ts
+++ b/extensions/module/src/stores/utilities/heal-fields.ts
@@ -1,0 +1,44 @@
+import type { DeepPartial, Field } from '@directus/types';
+
+export type MetaUpdate = { field: string; special: string[] };
+export type HealActions = { missing: DeepPartial<Field>[]; metaUpdates: MetaUpdate[] };
+
+/**
+ * Diff field declarations against what Directus' fields store reports and return the
+ * write actions the healer should perform. Pure — no I/O, no store reads — so it can
+ * be unit-tested without mounting Pinia or the Directus SDK.
+ *
+ * The two action lists reflect the two routes the installer uses:
+ *   - `missing` → POST `/fields/{collection}` (create the missing field)
+ *   - `metaUpdates` → PATCH `/fields/{collection}/{field}` (reconcile drifted `meta.special`)
+ *
+ * `meta.special` reconciliation is the regression-prone path: older Localazy installs
+ * have boolean rows in `directus_fields` without `cast-boolean`, which on MySQL surfaces
+ * as raw `1`/`0` in `<v-select>` (SQLite happens to coerce and hides the bug locally).
+ * The healer is what brings those installs up to spec on next boot.
+ */
+export function computeFieldHealActions(declared: DeepPartial<Field>[], existing: Field[]): HealActions {
+  const missing: DeepPartial<Field>[] = [];
+  const metaUpdates: MetaUpdate[] = [];
+  for (const field of declared) {
+    if (!field.field) continue;
+    const match = existing.find((ef) => ef.field === field.field);
+    if (!match) {
+      missing.push(field);
+      continue;
+    }
+    const declaredSpecial = field.meta?.special ?? [];
+    const existingSpecial = match.meta?.special ?? [];
+    if (!specialEqual(declaredSpecial, existingSpecial)) {
+      metaUpdates.push({ field: field.field, special: declaredSpecial });
+    }
+  }
+  return { missing, metaUpdates };
+}
+
+export function specialEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}


### PR DESCRIPTION
## Summary

- Splits the installer's "diff declared fields vs Directus" logic into a pure utility at `stores/utilities/heal-fields.ts` and adds a metadata-reconciliation path that patches drifted `meta.special` arrays via `PATCH /fields/{collection}/{field}`.
- Fixes a regression on MySQL-backed installs: older Localazy installs have boolean rows in `directus_fields` without `cast-boolean` in `meta.special`. MySQL returns `tinyint(1)` as raw `1`/`0`, which breaks `<v-select>` strict equality against `{ value: true }` items. SQLite coerces locally, so the bug only ever surfaces in production — the new healer path is the only thing keeping it fixed automatically on boot.
- 9 test cases covering missing-fields, exact-match, drifted special, ordering insensitivity, defensive undefined handling, and the regression itself.

## Test plan

- [x] `npm run check` green locally.
- [ ] Spin up a MySQL-backed dev install with the legacy boolean-no-cast-boolean rows, boot the module, confirm `<v-select>` renders the labelled options instead of raw `1`/`0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)