### PR TITLE
PR 58/N: useUnsavedChangesGuard + wire into the three settings pages

### DIFF
--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -73,12 +73,15 @@ import { useSingletonForm } from './composables/use-singleton-form';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useDirectusNotificationsStore } from './composables/use-directus-stores';
 import { useNow } from './composables/use-now';
+import { useUnsavedChangesGuard } from './composables/use-unsaved-changes-guard';
 import { SYNC_LOCK_STUCK_HINT_MS } from '../../common/services/orchestrator/lock-constants';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
 const settingsStore = useLocalazySettingsStore();
 const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
+
+useUnsavedChangesGuard(changesExist);
 
 const notificationsStore = useDirectusNotificationsStore();
 const { installed, hydrating, hydrated, localazyData, boot } = useLocalazyBoot();
@@ -202,21 +205,21 @@ async function onSaveChanges() {
 .operator-tools {
   margin-top: 48px;
   padding: 16px;
-  border: 1px solid var(--border-subdued);
-  border-radius: var(--border-radius);
-  background: var(--background-subdued);
+  border: 1px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
+  background: var(--theme--background-subdued);
 }
 
 .operator-tools-title {
   font-size: 16px;
   font-weight: 600;
   margin: 0 0 8px 0;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 .operator-tools-note {
   font-size: 13px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   margin: 0 0 12px 0;
   max-width: 640px;
 }
@@ -227,9 +230,9 @@ async function onSaveChanges() {
   gap: 4px 16px;
   margin: 0 0 16px 0;
   padding: 8px 12px;
-  background: var(--background-normal);
-  border: 1px solid var(--border-subdued);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-normal);
+  border: 1px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
   font-size: 12px;
   max-width: 640px;
 }
@@ -238,14 +241,14 @@ async function onSaveChanges() {
   display: contents;
 
   dt {
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-weight: 600;
   }
 
   dd {
     margin: 0;
-    color: var(--foreground-normal);
-    font-family: var(--family-monospace);
+    color: var(--theme--foreground);
+    font-family: var(--theme--fonts--monospace--font-family);
   }
 }
 </style>

--- a/extensions/module/src/Automation.vue
+++ b/extensions/module/src/Automation.vue
@@ -70,10 +70,13 @@ import { useSingletonForm } from './composables/use-singleton-form';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useBundleStatus } from './composables/use-bundle-status';
 import { useDirectusNotificationsStore } from './composables/use-directus-stores';
+import { useUnsavedChangesGuard } from './composables/use-unsaved-changes-guard';
 import { BUNDLE_README_URL } from './data/constants';
 
 const settingsStore = useLocalazySettingsStore();
 const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
+
+useUnsavedChangesGuard(changesExist);
 
 const notificationsStore = useDirectusNotificationsStore();
 const { installed, hydrated, localazyData, boot } = useLocalazyBoot();
@@ -139,7 +142,7 @@ onBeforeMount(() => {
   align-items: center;
   gap: 8px;
   margin-top: 24px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   font-size: 14px;
 }
 
@@ -149,19 +152,19 @@ onBeforeMount(() => {
 
 .bundle-version {
   font-size: 12px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   margin-top: 16px;
   margin-bottom: 16px;
 
   code {
-    background: var(--background-subdued);
+    background: var(--theme--background-subdued);
     padding: 1px 4px;
     border-radius: 4px;
   }
 }
 
 code {
-  background: var(--background-subdued);
+  background: var(--theme--background-subdued);
   padding: 1px 4px;
   border-radius: 4px;
   font-size: 12px;

--- a/extensions/module/src/ProjectSetup.vue
+++ b/extensions/module/src/ProjectSetup.vue
@@ -30,11 +30,14 @@ import { useLocalazySettingsStore } from './stores/localazy-settings-store';
 import { useSingletonForm } from './composables/use-singleton-form';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useDirectusNotificationsStore } from './composables/use-directus-stores';
+import { useUnsavedChangesGuard } from './composables/use-unsaved-changes-guard';
 
 const settingsCollectionName = LOCALAZY_COLLECTIONS.settings;
 
 const settingsStore = useLocalazySettingsStore();
 const { edits: settingsEdits, changesExist, save: saveSettings, loading: saving } = useSingletonForm(settingsStore);
+
+useUnsavedChangesGuard(changesExist);
 
 const notificationsStore = useDirectusNotificationsStore();
 const { installed, hydrating, hydrated, localazyData, boot } = useLocalazyBoot();

--- a/extensions/module/src/composables/use-unsaved-changes-guard.test.ts
+++ b/extensions/module/src/composables/use-unsaved-changes-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { createUnsavedChangesGuards } from './use-unsaved-changes-guard';
+
+describe('createUnsavedChangesGuards — leaveGuard', () => {
+  it('lets clean navigation through without prompting', () => {
+    const confirm = vi.fn(() => true);
+    const isDirty = ref(false);
+    const { leaveGuard } = createUnsavedChangesGuards(isDirty, 'msg', confirm);
+    expect(leaveGuard()).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('asks the user to confirm when the form is dirty', () => {
+    const confirm = vi.fn(() => true);
+    const isDirty = ref(true);
+    const { leaveGuard } = createUnsavedChangesGuards(isDirty, 'msg', confirm);
+    expect(leaveGuard()).toBe(true);
+    expect(confirm).toHaveBeenCalledWith('msg');
+  });
+
+  it('blocks navigation when the user cancels the confirm', () => {
+    const confirm = vi.fn(() => false);
+    const isDirty = ref(true);
+    const { leaveGuard } = createUnsavedChangesGuards(isDirty, 'msg', confirm);
+    expect(leaveGuard()).toBe(false);
+  });
+
+  it('reacts to dirty-state flips between calls', () => {
+    const confirm = vi.fn(() => true);
+    const isDirty = ref(false);
+    const { leaveGuard } = createUnsavedChangesGuards(isDirty, 'msg', confirm);
+    expect(leaveGuard()).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    isDirty.value = true;
+    expect(leaveGuard()).toBe(true);
+    expect(confirm).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createUnsavedChangesGuards — beforeUnloadHandler', () => {
+  function makeEvent() {
+    return {
+      preventDefault: vi.fn(),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+  }
+
+  it('is a no-op on a clean form (no native prompt)', () => {
+    const isDirty = ref(false);
+    const { beforeUnloadHandler } = createUnsavedChangesGuards(isDirty, 'msg', () => true);
+    const event = makeEvent();
+    beforeUnloadHandler(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  it('preventDefaults and sets returnValue when the form is dirty', () => {
+    const isDirty = ref(true);
+    const { beforeUnloadHandler } = createUnsavedChangesGuards(isDirty, 'msg', () => true);
+    const event = makeEvent();
+    beforeUnloadHandler(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe('msg');
+  });
+});

--- a/extensions/module/src/composables/use-unsaved-changes-guard.ts
+++ b/extensions/module/src/composables/use-unsaved-changes-guard.ts
@@ -1,0 +1,86 @@
+import { onBeforeUnmount, watch, type Ref } from 'vue';
+import { onBeforeRouteLeave } from 'vue-router';
+
+export const DEFAULT_UNSAVED_CHANGES_MESSAGE = 'You have unsaved changes. Leave anyway?';
+
+type ConfirmFn = (message: string) => boolean;
+
+export type GuardCallbacks = {
+  leaveGuard: () => boolean;
+  beforeUnloadHandler: (event: BeforeUnloadEvent) => void;
+};
+
+/**
+ * Pure factory for the two guard callbacks — kept separate from the Vue composable so
+ * unit tests can exercise the logic without spinning up a component instance. `confirm`
+ * is injected so the test env can hand in a deterministic stub instead of depending on
+ * `window.confirm`.
+ *
+ *  - `leaveGuard()` returns true when navigation should proceed, false to block.
+ *  - `beforeUnloadHandler(event)` sets `event.returnValue` when dirty, which is what
+ *    triggers the browser's native "Leave site?" prompt on hard refresh / tab close.
+ */
+export function createUnsavedChangesGuards(isDirty: Ref<boolean>, message: string, confirm: ConfirmFn): GuardCallbacks {
+  return {
+    leaveGuard: () => {
+      if (!isDirty.value) return true;
+      return confirm(message);
+    },
+    beforeUnloadHandler: (event: BeforeUnloadEvent) => {
+      if (!isDirty.value) return;
+      event.preventDefault();
+      // Setting returnValue is the cross-browser way to surface the native prompt; the
+      // string itself is ignored by modern browsers but the assignment is what triggers
+      // the dialog.
+      event.returnValue = message;
+    },
+  };
+}
+
+/**
+ * Block accidental navigation away from a page with unsaved form edits. Wires two guards:
+ *
+ *  - **In-app routes** — `onBeforeRouteLeave` shows a `confirm()` dialog before letting
+ *    the user click into a different Directus page.
+ *  - **Hard refresh / tab close** — a `beforeunload` listener triggers the browser's
+ *    native "Leave site?" prompt.
+ *
+ * The `beforeunload` listener is registered lazily on the first dirty transition and
+ * torn down whenever the page goes clean again or the host component unmounts, so clean
+ * pages don't leave dangling listeners pinned to `window`.
+ *
+ * Safe to call outside a router-aware component: `onBeforeRouteLeave` no-ops if there is
+ * no current route, and `beforeunload` no-ops if `window` is undefined (e.g. unit tests
+ * in the Node Vitest env).
+ */
+export function useUnsavedChangesGuard(isDirty: Ref<boolean>, message: string = DEFAULT_UNSAVED_CHANGES_MESSAGE): void {
+  const win = typeof window !== 'undefined' ? window : null;
+  const { leaveGuard, beforeUnloadHandler } = createUnsavedChangesGuards(isDirty, message, (m) => (win ? win.confirm(m) : true));
+
+  onBeforeRouteLeave(leaveGuard);
+
+  if (!win) return;
+
+  let listenerAttached = false;
+
+  watch(
+    isDirty,
+    (dirty) => {
+      if (dirty && !listenerAttached) {
+        win.addEventListener('beforeunload', beforeUnloadHandler);
+        listenerAttached = true;
+      } else if (!dirty && listenerAttached) {
+        win.removeEventListener('beforeunload', beforeUnloadHandler);
+        listenerAttached = false;
+      }
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    if (listenerAttached) {
+      win.removeEventListener('beforeunload', beforeUnloadHandler);
+      listenerAttached = false;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- New `composables/use-unsaved-changes-guard.ts` blocks accidental navigation away from a page with unsaved form edits.
- Two guards: `onBeforeRouteLeave` confirms in-app route changes, `beforeunload` triggers the browser's native prompt on hard refresh / tab close.
- Wired into `ProjectSetup.vue`, `AdvancedSettings.vue`, and `Automation.vue`.
- Pure `createUnsavedChangesGuards` factory split out so the leave / unload logic is unit-testable without a component mount (6 tests).
- `AdvancedSettings.vue` and `Automation.vue` also pick up the theme-token migration left behind by PR 56 (those files needed structural edits anyway).

## Test plan

- [x] `npm run check` green locally.
- [ ] Manual: edit a setting on any of the three pages, navigate to another module page → confirm dialog appears, Cancel keeps you on the page.
- [ ] Manual: edit a setting, then hard-refresh → browser's native "Leave site?" prompt appears.
- [ ] Manual: save the setting, then navigate / refresh → no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)