### PR TITLE
PR 59/N: LanguageMappingsEditor — always-editable rows + valid model

### DIFF
--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -5,7 +5,12 @@
     </template>
 
     <template #actions>
-      <v-button class="panel-button" :disabled="!changesExist" :loading="hydrating || saving" @click="onSaveChanges"
+      <v-button
+        v-tooltip="!mappingsValid ? 'Fix invalid custom language mappings before saving' : null"
+        class="panel-button"
+        :disabled="!changesExist || !mappingsValid"
+        :loading="hydrating || saving"
+        @click="onSaveChanges"
         >Save changes
       </v-button>
     </template>
@@ -16,7 +21,7 @@
     <div v-if="hydrated && installed" class="panel page">
       <errors-notice class="errors-notice" :localazy-data="localazyData" />
 
-      <advanced-settings-form v-model:edits="settingsEdits" :collection="settingsCollectionName" />
+      <advanced-settings-form v-model:edits="settingsEdits" v-model:mappings-valid="mappingsValid" :collection="settingsCollectionName" />
 
       <div v-if="syncLookStuck" class="operator-tools">
         <h3 class="operator-tools-title">Operator tools</h3>
@@ -91,6 +96,7 @@ const { data: syncStateData } = storeToRefs(syncStateStore);
 
 const showClearConfirmDialog = ref(false);
 const clearing = ref(false);
+const mappingsValid = ref(true);
 
 // Reactive `Date.now()` tick — without this the staleness `computed` below stays stuck on
 // whatever value it captured the last time another tracked dep changed, so an observer

--- a/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
+++ b/extensions/module/src/components/AdvancedSettings/AdvancedSettingsForm.vue
@@ -48,6 +48,7 @@
 
       <LanguageMappingsEditor
         v-model="localEdits.language_mappings"
+        v-model:valid="mappingsValid"
         :language-collection="localEdits.language_collection"
         :language-code-field="localEdits.language_code_field"
       />
@@ -63,6 +64,7 @@ import { CreateMissingLanguagesInDirectus } from '../../../../common/enums/creat
 import LanguageMappingsEditor from './LanguageMappingsEditor.vue';
 
 const localEdits = defineModel<Settings>('edits', { required: true });
+const mappingsValid = defineModel<boolean>('mappingsValid', { default: true });
 
 defineProps({
   collection: {
@@ -154,7 +156,7 @@ const directusMissingLanguagesOptions = ref<Item[]>([
   font-style: italic;
   font-size: 13px;
   line-height: 18px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 
   & a {
     text-decoration: underline;

--- a/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
+++ b/extensions/module/src/components/AdvancedSettings/LanguageMappingsEditor.vue
@@ -23,71 +23,33 @@
         <div class="mapping-row header">
           <span class="type-label">Directus code</span>
           <span class="type-label">Localazy code</span>
-          <span class="type-label actions-header">Actions</span>
+          <span class="type-label actions-header" aria-hidden="true"></span>
         </div>
 
-        <div v-for="row in rows" :key="row.id" class="mapping-row" :class="{ 'is-editing': row.editing !== null }">
-          <template v-if="row.editing !== null">
-            <div class="field-cell">
-              <v-select
-                v-model="row.editing.directusCode"
-                :items="directusOptionsForRow(row)"
-                placeholder="Select Directus language"
-                :class="{ 'has-error': showError(row, 'directusCode') }"
-                @update:model-value="onFieldChange(row, 'directusCode')"
-              />
-              <p v-if="showError(row, 'directusCode')" class="field-error">{{ row.errors.directusCode }}</p>
-            </div>
-            <div class="field-cell">
-              <v-select
-                v-model="row.editing.localazyCode"
-                :items="localazyOptionsForRow(row)"
-                placeholder="Select Localazy locale"
-                :class="{ 'has-error': showError(row, 'localazyCode') }"
-                @update:model-value="onFieldChange(row, 'localazyCode')"
-              />
-              <p v-if="showError(row, 'localazyCode')" class="field-error">{{ row.errors.localazyCode }}</p>
-            </div>
-            <div class="actions">
-              <v-button v-tooltip="'Cancel'" icon rounded secondary @click="cancelEdit(row)">
-                <v-icon name="close" />
-              </v-button>
-              <v-button v-tooltip="'Save'" icon rounded :disabled="!isRowValid(row)" @click="saveEdit(row)">
-                <v-icon name="check" />
-              </v-button>
-            </div>
-          </template>
-
-          <template v-else>
-            <div class="value-cell">
-              <code>{{ row.saved!.directusCode }}</code>
-              <v-icon
-                v-if="isDirectusCodeStale(row.saved!.directusCode)"
-                v-tooltip="'No longer present in the Directus languages collection'"
-                name="warning"
-                small
-                class="stale-icon"
-              />
-            </div>
-            <div class="value-cell">
-              <code>{{ row.saved!.localazyCode }}</code>
-              <v-icon
-                v-if="isLocalazyCodeStale(row.saved!.localazyCode)"
-                v-tooltip="'Not a known Localazy locale'"
-                name="warning"
-                small
-                class="stale-icon"
-              />
-            </div>
-            <div class="actions">
-              <v-button v-tooltip="'Edit'" icon rounded secondary :disabled="isAnyEditing" @click="startEdit(row)">
-                <v-icon name="edit" />
-              </v-button>
-              <v-button v-tooltip="'Delete'" icon rounded secondary :disabled="isAnyEditing" @click="removeRow(row)">
-                <v-icon name="delete" />
-              </v-button>
-            </div>
-          </template>
+        <div v-for="(row, index) in rows" :key="row.id" class="mapping-row">
+          <div class="field-cell">
+            <v-select
+              v-model="row.directusCode"
+              :items="directusOptionsForRow(row)"
+              placeholder="Select Directus language"
+              :class="{ 'has-error': fieldErrors(row, index).directusCode !== null }"
+            />
+            <p v-if="fieldErrors(row, index).directusCode" class="field-error">{{ fieldErrors(row, index).directusCode }}</p>
+          </div>
+          <div class="field-cell">
+            <v-select
+              v-model="row.localazyCode"
+              :items="localazyOptionsForRow(row)"
+              placeholder="Select Localazy locale"
+              :class="{ 'has-error': fieldErrors(row, index).localazyCode !== null }"
+            />
+            <p v-if="fieldErrors(row, index).localazyCode" class="field-error">{{ fieldErrors(row, index).localazyCode }}</p>
+          </div>
+          <div class="actions">
+            <v-button v-tooltip="'Remove mapping'" icon rounded secondary @click="removeRow(row.id)">
+              <v-icon name="delete" />
+            </v-button>
+          </div>
         </div>
       </div>
 
@@ -95,7 +57,7 @@
         <p class="note">No custom mappings configured. Default behaviour swaps <code>-</code> and <code>_</code> in both directions.</p>
       </div>
 
-      <v-button class="add-button" secondary :disabled="isAnyEditing" @click="addMapping">
+      <v-button class="add-button" secondary @click="addMapping">
         <v-icon name="add" left />
         Add mapping
       </v-button>
@@ -108,21 +70,17 @@ import { computed, ref, toRef, watch } from 'vue';
 import { useItems } from '@directus/extensions-sdk';
 import { Item } from '@directus/types';
 import { getLocalazyLanguages } from '@localazy/languages';
-import { LanguageMappings } from '../../../../common/models/language-mapping';
 import { SelectItem } from '../../models/directus/internals/select-item';
 import { formatLanguageOption, pickLanguageName } from '../../../../common/utilities/language-display';
+import {
+  parseLanguageMappings,
+  serializeLanguageMappings,
+  validateMappingRow,
+  hasMappingErrors,
+  type MappingCodes,
+} from './language-mappings-form';
 
-type FieldKey = 'directusCode' | 'localazyCode';
-
-type Codes = { directusCode: string; localazyCode: string };
-
-type Row = {
-  id: number;
-  saved: Codes | null;
-  editing: Codes | null;
-  touched: Record<FieldKey, boolean>;
-  errors: Record<FieldKey, string | null>;
-};
+type Row = MappingCodes & { id: number };
 
 const props = defineProps<{
   languageCollection: string;
@@ -130,6 +88,7 @@ const props = defineProps<{
 }>();
 
 const modelValue = defineModel<string>({ default: '[]' });
+const valid = defineModel<boolean>('valid', { default: true });
 
 const isConfigured = computed(() => !!props.languageCollection && !!props.languageCodeField);
 
@@ -170,137 +129,39 @@ let nextId = 1;
 let lastEmitted: string | null = null;
 const rows = ref<Row[]>([]);
 
-const isAnyEditing = computed(() => rows.value.some((r) => r.editing !== null));
-
 watch(
   modelValue,
   (value) => {
     if (value === lastEmitted) return;
-    try {
-      const parsed = JSON.parse(value || '[]') as LanguageMappings;
-      rows.value = parsed.map((m) => createRow({ directusCode: m.directusCode, localazyCode: m.localazyCode }));
-    } catch {
-      rows.value = [];
-    }
+    rows.value = parseLanguageMappings(value).map((m) => ({ id: nextId++, ...m }));
   },
   { immediate: true },
 );
 
-watch([directusCodeOptions, localazyCodeOptions], () => {
-  rows.value.forEach((row) => {
-    if (row.editing) validateRow(row);
-  });
-});
+watch(
+  rows,
+  () => {
+    emitChange();
+  },
+  { deep: true },
+);
 
-function createRow(saved: Codes | null): Row {
-  return {
-    id: nextId++,
-    saved,
-    editing: null,
-    touched: { directusCode: false, localazyCode: false },
-    errors: { directusCode: null, localazyCode: null },
-  };
-}
-
-function startEdit(row: Row) {
-  if (!row.saved || isAnyEditing.value) return;
-  row.editing = { ...row.saved };
-  row.touched = { directusCode: false, localazyCode: false };
-  validateRow(row);
-}
-
-function cancelEdit(row: Row) {
-  if (row.saved === null) {
-    rows.value = rows.value.filter((r) => r.id !== row.id);
-    return;
-  }
-  row.editing = null;
-  row.touched = { directusCode: false, localazyCode: false };
-  row.errors = { directusCode: null, localazyCode: null };
-}
-
-function saveEdit(row: Row) {
-  if (!row.editing || !isRowValid(row)) return;
-  row.saved = { ...row.editing };
-  row.editing = null;
-  row.touched = { directusCode: false, localazyCode: false };
-  row.errors = { directusCode: null, localazyCode: null };
-  emitChange();
-}
-
-function removeRow(row: Row) {
-  rows.value = rows.value.filter((r) => r.id !== row.id);
-  emitChange();
+function fieldErrors(row: Row, index: number) {
+  return validateMappingRow(row, rows.value, index);
 }
 
 function addMapping() {
-  if (isAnyEditing.value) return;
-  const newRow = createRow(null);
-  newRow.editing = { directusCode: '', localazyCode: '' };
-  rows.value.push(newRow);
+  rows.value.push({ id: nextId++, directusCode: '', localazyCode: '' });
 }
 
-function onFieldChange(row: Row, field: FieldKey) {
-  row.touched[field] = true;
-  validateRow(row);
-}
-
-function validateRow(row: Row) {
-  if (!row.editing) {
-    row.errors = { directusCode: null, localazyCode: null };
-    return;
-  }
-  row.errors = {
-    directusCode: fieldError(row, 'directusCode'),
-    localazyCode: fieldError(row, 'localazyCode'),
-  };
-}
-
-function fieldError(row: Row, field: FieldKey): string | null {
-  const value = row.editing![field];
-  if (value === '' || value === null) {
-    return field === 'directusCode' ? 'Select a Directus language' : 'Select a Localazy locale';
-  }
-  const duplicate = rows.value.some((other) => other.id !== row.id && effectiveCode(other, field) === value);
-  if (duplicate) {
-    const label = field === 'directusCode' ? 'Directus' : 'Localazy';
-    return `Duplicate ${label} code "${value}"`;
-  }
-  return null;
-}
-
-function effectiveCode(row: Row, field: FieldKey): string | null {
-  if (row.editing) return row.editing[field];
-  if (row.saved) return row.saved[field];
-  return null;
-}
-
-function showError(row: Row, field: FieldKey): boolean {
-  return row.touched[field] && row.errors[field] !== null;
-}
-
-function isRowValid(row: Row): boolean {
-  if (!row.editing) return false;
-  return (
-    row.errors.directusCode === null &&
-    row.errors.localazyCode === null &&
-    row.editing.directusCode !== '' &&
-    row.editing.localazyCode !== ''
-  );
-}
-
-function isDirectusCodeStale(code: string): boolean {
-  return directusCodeOptions.value.length > 0 && !directusCodeSet.value.has(code);
-}
-
-function isLocalazyCodeStale(code: string): boolean {
-  return !localazyCodeSet.value.has(code);
+function removeRow(id: number) {
+  rows.value = rows.value.filter((r) => r.id !== id);
 }
 
 function directusOptionsForRow(row: Row): SelectItem[] {
   const opts = directusCodeOptions.value;
-  const current = row.editing?.directusCode;
-  if (current && !directusCodeSet.value.has(current)) {
+  const current = row.directusCode;
+  if (current && !directusCodeSet.value.has(current) && directusCodeOptions.value.length > 0) {
     return [{ text: `${current} (no longer exists)`, value: current }, ...opts];
   }
   return opts;
@@ -308,7 +169,7 @@ function directusOptionsForRow(row: Row): SelectItem[] {
 
 function localazyOptionsForRow(row: Row): SelectItem[] {
   const opts = localazyCodeOptions.value;
-  const current = row.editing?.localazyCode;
+  const current = row.localazyCode;
   if (current && !localazyCodeSet.value.has(current)) {
     return [{ text: `${current} (unknown locale)`, value: current }, ...opts];
   }
@@ -316,10 +177,9 @@ function localazyOptionsForRow(row: Row): SelectItem[] {
 }
 
 function emitChange() {
-  const mappings: LanguageMappings = rows.value
-    .filter((r) => r.saved !== null)
-    .map((r) => ({ directusCode: r.saved!.directusCode, localazyCode: r.saved!.localazyCode }));
-  const json = JSON.stringify(mappings);
+  const json = serializeLanguageMappings(rows.value);
+  valid.value = !hasMappingErrors(rows.value);
+  if (json === modelValue.value) return;
   lastEmitted = json;
   modelValue.value = json;
 }
@@ -361,10 +221,6 @@ function emitChange() {
     margin-bottom: 8px;
     align-items: center;
   }
-
-  &:not(.is-editing):not(.header) {
-    align-items: center;
-  }
 }
 
 .actions-header {
@@ -381,36 +237,26 @@ function emitChange() {
   margin: 0;
   font-size: 13px;
   line-height: 18px;
-  color: var(--danger);
-}
-
-.value-cell {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 0;
-}
-
-.stale-icon {
-  color: var(--warning);
+  color: var(--theme--danger);
 }
 
 .actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  padding-top: 4px;
 }
 
 .has-error :deep(.v-input),
 .has-error :deep(.v-select) {
-  border-color: var(--danger);
+  border-color: var(--theme--danger);
 }
 
 .empty-state {
   margin-bottom: 20px;
   padding: 20px;
-  background: var(--background-subdued);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-subdued);
+  border-radius: var(--theme--border-radius);
 }
 
 .add-button {
@@ -421,13 +267,13 @@ function emitChange() {
   font-style: italic;
   font-size: 13px;
   line-height: 18px;
-  color: var(--foreground-normal);
+  color: var(--theme--foreground);
 }
 
 code {
-  background: var(--background-subdued);
+  background: var(--theme--background-subdued);
   padding: 2px 6px;
-  border-radius: var(--border-radius);
-  font-family: var(--family-monospace);
+  border-radius: var(--theme--border-radius);
+  font-family: var(--theme--fonts--monospace--font-family);
 }
 </style>

--- a/extensions/module/src/components/AdvancedSettings/language-mappings-form.test.ts
+++ b/extensions/module/src/components/AdvancedSettings/language-mappings-form.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseLanguageMappings,
+  serializeLanguageMappings,
+  validateMappingRow,
+  hasMappingErrors,
+  type MappingCodes,
+} from './language-mappings-form';
+
+describe('parseLanguageMappings', () => {
+  it('returns an empty array for null / undefined / empty input', () => {
+    expect(parseLanguageMappings(null)).toEqual([]);
+    expect(parseLanguageMappings(undefined)).toEqual([]);
+    expect(parseLanguageMappings('')).toEqual([]);
+  });
+
+  it('parses a well-formed payload', () => {
+    const json = JSON.stringify([
+      { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+    ]);
+    expect(parseLanguageMappings(json)).toEqual([
+      { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+    ]);
+  });
+
+  it('returns [] on malformed JSON instead of throwing', () => {
+    expect(parseLanguageMappings('{not json')).toEqual([]);
+  });
+
+  it('returns [] when the payload is not an array', () => {
+    expect(parseLanguageMappings('{"directusCode":"x"}')).toEqual([]);
+  });
+
+  it('drops entries that do not look like mappings', () => {
+    const json = JSON.stringify([
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+      { directusCode: 42, localazyCode: 'pt_BR' },
+      null,
+      { localazyCode: 'pt_BR' },
+    ]);
+    expect(parseLanguageMappings(json)).toEqual([{ directusCode: 'pt-BR', localazyCode: 'pt_BR' }]);
+  });
+
+  it('keeps only the two known fields and ignores extras (e.g. legacy description)', () => {
+    const json = JSON.stringify([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans', description: 'legacy' }]);
+    expect(parseLanguageMappings(json)).toEqual([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]);
+  });
+});
+
+describe('serializeLanguageMappings', () => {
+  it('round-trips a clean list', () => {
+    const rows: MappingCodes[] = [
+      { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+    ];
+    expect(serializeLanguageMappings(rows)).toBe(JSON.stringify(rows));
+  });
+
+  it('drops draft rows where either code is blank', () => {
+    const rows: MappingCodes[] = [
+      { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+      { directusCode: '', localazyCode: 'pt_BR' },
+      { directusCode: 'fr-CA', localazyCode: '' },
+      { directusCode: '', localazyCode: '' },
+    ];
+    expect(serializeLanguageMappings(rows)).toBe(JSON.stringify([{ directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' }]));
+  });
+
+  it('emits an empty array when every row is a draft', () => {
+    expect(serializeLanguageMappings([{ directusCode: '', localazyCode: '' }])).toBe('[]');
+  });
+});
+
+describe('validateMappingRow', () => {
+  it('reports missing values with field-specific copy', () => {
+    const row: MappingCodes = { directusCode: '', localazyCode: '' };
+    const errors = validateMappingRow(row, [row], 0);
+    expect(errors.directusCode).toBe('Select a Directus language');
+    expect(errors.localazyCode).toBe('Select a Localazy locale');
+  });
+
+  it('flags duplicate Directus codes on the row that collides', () => {
+    const rows: MappingCodes[] = [
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+      { directusCode: 'pt-BR', localazyCode: 'pt_PT' },
+    ];
+    const errors = validateMappingRow(rows[1]!, rows, 1);
+    expect(errors.directusCode).toBe('Duplicate Directus code "pt-BR"');
+    expect(errors.localazyCode).toBeNull();
+  });
+
+  it('flags duplicate Localazy codes', () => {
+    const rows: MappingCodes[] = [
+      { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+      { directusCode: 'pt-PT', localazyCode: 'pt_BR' },
+    ];
+    const errors = validateMappingRow(rows[1]!, rows, 1);
+    expect(errors.localazyCode).toBe('Duplicate Localazy code "pt_BR"');
+  });
+
+  it('does not consider a row to duplicate itself', () => {
+    const rows: MappingCodes[] = [{ directusCode: 'pt-BR', localazyCode: 'pt_BR' }];
+    const errors = validateMappingRow(rows[0]!, rows, 0);
+    expect(errors.directusCode).toBeNull();
+    expect(errors.localazyCode).toBeNull();
+  });
+});
+
+describe('hasMappingErrors', () => {
+  it('returns false for an empty list', () => {
+    expect(hasMappingErrors([])).toBe(false);
+  });
+
+  it('returns false for a fully valid list', () => {
+    expect(
+      hasMappingErrors([
+        { directusCode: 'zh-Hans', localazyCode: 'zh-CN#Hans' },
+        { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns true when any row has a blank code (drafts gate save)', () => {
+    expect(hasMappingErrors([{ directusCode: 'zh-Hans', localazyCode: '' }])).toBe(true);
+  });
+
+  it('returns true on duplicates', () => {
+    expect(
+      hasMappingErrors([
+        { directusCode: 'pt-BR', localazyCode: 'pt_BR' },
+        { directusCode: 'pt-BR', localazyCode: 'pt_PT' },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/extensions/module/src/components/AdvancedSettings/language-mappings-form.ts
+++ b/extensions/module/src/components/AdvancedSettings/language-mappings-form.ts
@@ -1,0 +1,75 @@
+import { LanguageMappings } from '../../../../common/models/language-mapping';
+
+export type MappingCodes = { directusCode: string; localazyCode: string };
+
+export type MappingFieldKey = 'directusCode' | 'localazyCode';
+
+export type MappingErrors = Record<MappingFieldKey, string | null>;
+
+/**
+ * Parse the persisted JSON payload into the row codes used by the editor. Tolerates
+ * malformed input — an empty list keeps the UI usable rather than throwing on a one-off
+ * bad value (the user can still add or replace rows and re-save).
+ */
+export function parseLanguageMappings(json: string | null | undefined): MappingCodes[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json) as LanguageMappings;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((m): m is { directusCode: string; localazyCode: string } => {
+        return !!m && typeof m.directusCode === 'string' && typeof m.localazyCode === 'string';
+      })
+      .map((m) => ({ directusCode: m.directusCode, localazyCode: m.localazyCode }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Serialize rows to the JSON payload stored on `Settings.language_mappings`. Rows with
+ * either code blank are treated as drafts and excluded — the always-editable UI emits
+ * directly from the row state, so half-finished rows must not bleed into the saved value.
+ */
+export function serializeLanguageMappings(rows: MappingCodes[]): string {
+  const filtered = rows.filter((r) => r.directusCode !== '' && r.localazyCode !== '');
+  return JSON.stringify(filtered);
+}
+
+/**
+ * Validate a single row against the rest of the rows. Returns null when the field is OK,
+ * an error message otherwise. Empty values are allowed at the row level (they mark the
+ * row as a draft) but reported as missing so the row can flag the field visually; the
+ * top-level "Save changes" gate is what stops empty rows from being persisted.
+ */
+export function validateMappingRow(row: MappingCodes, allRows: MappingCodes[], rowIndex: number): MappingErrors {
+  return {
+    directusCode: fieldError(row, 'directusCode', allRows, rowIndex),
+    localazyCode: fieldError(row, 'localazyCode', allRows, rowIndex),
+  };
+}
+
+function fieldError(row: MappingCodes, field: MappingFieldKey, allRows: MappingCodes[], rowIndex: number): string | null {
+  const value = row[field];
+  if (value === '' || value === null) {
+    return field === 'directusCode' ? 'Select a Directus language' : 'Select a Localazy locale';
+  }
+  const duplicate = allRows.some((other, idx) => idx !== rowIndex && other[field] === value);
+  if (duplicate) {
+    const label = field === 'directusCode' ? 'Directus' : 'Localazy';
+    return `Duplicate ${label} code "${value}"`;
+  }
+  return null;
+}
+
+/**
+ * True when at least one row has any field error. The top-level "Save changes" button
+ * uses this to gate persistence — drafts (blank codes) are also reported as errors so
+ * the dirty-but-incomplete state can't accidentally save.
+ */
+export function hasMappingErrors(rows: MappingCodes[]): boolean {
+  return rows.some((row, idx) => {
+    const errors = validateMappingRow(row, rows, idx);
+    return errors.directusCode !== null || errors.localazyCode !== null;
+  });
+}


### PR DESCRIPTION
## Summary

- Replaces the per-row "Edit → Cancel → Save" flow in the language-mappings editor with always-editable `v-select` rows. The page-level Save changes button now gates persistence; drafts (blank codes) and duplicates are reported inline but don't lock individual rows.
- Pure validation lives in `language-mappings-form.ts` (parse / serialize / `validateMappingRow` / `hasMappingErrors`) with 17 unit tests — parse tolerance, draft filtering on serialize, duplicate detection, save-gate predicate.
- `AdvancedSettingsForm.vue` and `AdvancedSettings.vue` plumb a `valid` v-model from editor → form → page so the Save button can disable + tooltip ("Fix invalid custom language mappings before saving") when any row has errors.

## Test plan

- [x] `npm run check` green locally.
- [ ] Add a mapping, leave one field blank → save button disabled, tooltip says "Fix invalid custom language mappings before saving."
- [ ] Add two mappings with the same Directus code → save button disabled, duplicate-warning copy under the row.
- [ ] Delete a mapping → save button enabled, save persists the reduced list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)