### PR TITLE
PR 60/N: Overview language table — Directus column first + inline mapping

### DIFF
--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -2,8 +2,8 @@
   <div v-if="languageRows.length > 0" class="languages-table">
     <div class="row header-row">
       <div class="cell header">Language</div>
-      <div class="cell header">Present in Localazy</div>
       <div class="cell header">Present in Directus</div>
+      <div class="cell header">Present in Localazy</div>
     </div>
 
     <div v-for="(data, index) in languageRows" :key="index" class="row">
@@ -11,51 +11,53 @@
         <span class="locale">{{ data.locale }}</span>
         <span v-if="data.directusName" class="english-name">({{ data.directusName }})</span>
         <span v-else-if="data.englishName" class="english-name">({{ data.englishName }})</span>
-        <span v-if="data.customMapping" class="mapping-chip" :title="mappingTooltip(data.customMapping)">
-          <v-icon small name="swap_horiz" />
-          <span class="mapping-codes">
-            <code>{{ data.customMapping.directusCode }}</code>
-            <span class="mapping-arrow">↔</span>
-            <code>{{ data.customMapping.localazyCode }}</code>
-          </span>
+        <template v-if="data.customMapping">
+          <span v-tooltip="mappingArrowTooltip(data)" class="mapping-arrow-inline">→</span>
+          <code v-tooltip="mappingArrowTooltip(data)" class="mapping-counterpart">{{ mappingCounterpart(data) }}</code>
+          <span v-if="data.englishName" v-tooltip="mappingArrowTooltip(data)" class="english-name">({{ data.englishName }})</span>
+        </template>
+      </div>
+      <div class="cell">
+        <v-icon
+          v-if="data.directus.present || data.directus.presentMapped"
+          v-tooltip="'This language has been added in your Directus project'"
+          name="check"
+          color="var(--theme--success)"
+        />
+        <v-icon v-else v-tooltip="'This language has not been added in your Directus project'" name="clear" color="var(--theme--danger)" />
+
+        <span
+          v-if="data.directus.presentMapped && !data.directus.present"
+          v-tooltip="'This language is defined in a different form in Directus'"
+        >
+          Mapped to {{ data.directus.mappedTo }}
+          <v-icon small name="help_outline" />
         </span>
       </div>
       <div class="cell">
         <v-icon
           v-if="!data.directus.recognizedInLocalazy"
+          v-tooltip="'Localazy does not recognize this language'"
           name="error"
-          color="var(--danger)"
-          title="Localazy does not recognize this language"
+          color="var(--theme--danger)"
         />
-        <v-icon v-else-if="data.localazy.hidden" name="visibility_off" title="This language is disabled in your Localazy project" />
+        <v-icon v-else-if="data.localazy.hidden" v-tooltip="'This language is disabled in your Localazy project'" name="visibility_off" />
         <v-icon
           v-else-if="data.localazy.present || data.localazy.presentMapped"
+          v-tooltip="'This language has been added in your Localazy project'"
           name="check"
-          color="var(--success)"
-          title="This language has been added in your Localazy project"
+          color="var(--theme--success)"
         />
-        <v-icon v-else name="clear" color="var(--danger)" title="This language has not been added in your Localazy project" />
+        <v-icon v-else v-tooltip="'This language has not been added in your Localazy project'" name="clear" color="var(--theme--danger)" />
 
-        <span v-if="!data.directus.recognizedInLocalazy"> Unknown Localazy language </span>
-        <span v-else-if="data.localazy.hidden"> Disabled </span>
-        <span v-else-if="data.localazy.presentMapped && !data.localazy.present">
-          Mapped to {{ data.localazy.mappedTo }}
-          <v-icon small name="help_outline" title="This language is defined in a different form in Localazy" />
-        </span>
-      </div>
-      <div class="cell">
-        <v-icon
-          v-if="data.directus.present || data.directus.presentMapped"
-          name="check"
-          color="var(--success)"
-          title="This language has been added in your Directus project"
-        />
-        <v-icon v-else name="clear" color="var(--danger)" title="This language has not been added in your Directus project" />
-
-        <span v-if="data.directus.presentMapped && !data.directus.present">
-          Mapped to {{ data.directus.mappedTo }}
-          <v-icon small name="help_outline" title="This language is defined in a different form in Directus" />
-        </span>
+        <router-link
+          v-if="!data.directus.recognizedInLocalazy && !data.customMapping"
+          to="/localazy/additional-settings"
+          class="define-mapping-link"
+        >
+          Define mapping
+        </router-link>
+        <span v-else-if="data.localazy.hidden" class="hidden-language"> Disabled </span>
       </div>
     </div>
   </div>
@@ -68,7 +70,6 @@ import { findLocalazyLanguageByLocale } from '@localazy/languages';
 import { uniqWith } from 'lodash';
 import { useLocalazyStore } from '../../stores/localazy-store';
 import { useDirectusLanguages } from '../../composables/use-directus-languages';
-import { DirectusLocalazyAdapter } from '../../../../common/services/directus-localazy-adapter';
 import { Settings } from '../../../../common/models/collections-data/settings';
 import { LanguageMapping, LanguageMappings } from '../../../../common/models/language-mapping';
 
@@ -146,18 +147,38 @@ function findCustomMapping(locale: string, directusFormLocale: string, localazyF
   );
 }
 
-function mappingTooltip(m: LanguageMapping): string {
-  const base = `Custom mapping: Directus "${m.directusCode}" ↔ Localazy "${m.localazyCode}"`;
-  return m.description ? `${base} — ${m.description}` : base;
+function mappingCounterpart(data: Row): string | null {
+  if (!data.customMapping) return null;
+  return data.customMapping.directusCode === data.locale ? data.customMapping.localazyCode : data.customMapping.directusCode;
+}
+
+function mappingArrowTooltip(data: Row): string {
+  if (!data.customMapping) return '';
+  const fromDirectus = data.customMapping.directusCode === data.locale;
+  const base = fromDirectus
+    ? `Custom mapping: this Directus language maps to "${data.customMapping.localazyCode}" in Localazy`
+    : `Custom mapping: this Localazy language maps to "${data.customMapping.directusCode}" in Directus`;
+  return data.customMapping.description ? `${base} — ${data.customMapping.description}` : base;
 }
 
 const languageRows = computed((): Row[] => {
+  const mappings = customMappings.value;
+  const directusToLocalazyMap = new Map<string, string>();
+  const localazyToDirectusMap = new Map<string, string>();
+  mappings.forEach((m) => {
+    directusToLocalazyMap.set(m.directusCode, m.localazyCode);
+    localazyToDirectusMap.set(m.localazyCode, m.directusCode);
+  });
+
+  const toLocalazyForm = (code: string) => directusToLocalazyMap.get(code) ?? code.replace('-', '_');
+  const toDirectusForm = (code: string) => localazyToDirectusMap.get(code) ?? code.replace('_', '-');
+
   const localazyLanguages = localazyProject.value?.languages || [];
   const localazyLocales = localazyLanguages.map((l) => l.code);
 
   const allLanguages = [...directusLanguages.value, ...localazyLocales].map((locale) => {
-    const directusFormLocale = DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(locale);
-    const localazyFormLocale = DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage(locale);
+    const directusFormLocale = toDirectusForm(locale);
+    const localazyFormLocale = toLocalazyForm(locale);
     const localazyLanguage = findLocalazyLanguageByLocale(localazyFormLocale);
     const projectLanguage = localazyLanguages.find((l) => l.code === localazyFormLocale);
 
@@ -184,15 +205,13 @@ const languageRows = computed((): Row[] => {
 
   return uniqWith(allLanguages, (arrVal, othVal) => {
     if (arrVal.directus.present !== othVal.directus.present) {
-      return (
-        DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(arrVal.locale) ===
-        DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(othVal.locale)
-      );
+      return toDirectusForm(arrVal.locale) === toDirectusForm(othVal.locale);
     }
     return arrVal.locale === othVal.locale;
   }).sort((a, b) => {
-    const isASourceLanguage = a.localazyId === localazyProject.value?.sourceLanguage;
-    const isBSourceLanguage = b.localazyId === localazyProject.value?.sourceLanguage;
+    const directusSourceLanguage = props.settings?.source_language;
+    const isASourceLanguage = !!directusSourceLanguage && a.locale === directusSourceLanguage;
+    const isBSourceLanguage = !!directusSourceLanguage && b.locale === directusSourceLanguage;
     if (isASourceLanguage && !isBSourceLanguage) {
       return -1;
     }
@@ -280,40 +299,32 @@ $mono: var(--family-monospace, var(--theme--family-monospace, ui-monospace, SFMo
   color: $fg-subdued;
 }
 
-.mapping-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin-left: auto;
-  padding: 2px 8px;
-  background: $bg-subdued;
-  border: 1px solid $divider-color;
-  border-radius: $radius;
-  font-size: 12px;
-  color: $fg-normal;
+.mapping-arrow-inline {
+  color: $fg-subdued;
+}
 
-  code {
-    background: transparent;
-    font-family: $mono;
-    font-size: 12px;
+.mapping-counterpart {
+  background: transparent;
+  font-family: $mono;
+  font-size: 13px;
+  color: $fg-normal;
+}
+
+.define-mapping-link {
+  margin-left: 4px;
+  color: var(--theme--primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
   }
 }
 
-.mapping-codes {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.mapping-arrow {
-  color: var(--foreground-subdued);
-}
-
 .unknown-language {
-  color: var(--danger);
+  color: var(--theme--danger);
 }
 
 .hidden-language {
-  color: var(--info);
+  color: var(--theme--foreground-subdued);
 }
 </style>

--- a/extensions/module/src/components/Overview/ConnectionOverview.vue
+++ b/extensions/module/src/components/Overview/ConnectionOverview.vue
@@ -8,7 +8,17 @@
             <span class="status-dot" />
             {{ statusLabel }}
           </span>
-          <span v-if="isConnected" class="project-name">{{ localazyProject?.name }}</span>
+          <a
+            v-if="isConnected && localazyProject?.url"
+            :href="localazyProject.url"
+            target="_blank"
+            rel="noopener"
+            class="project-name project-name--link"
+            title="Open Localazy project in a new tab"
+          >
+            {{ localazyProject?.name }}
+          </a>
+          <span v-else-if="isConnected" class="project-name">{{ localazyProject?.name }}</span>
         </div>
       </div>
 
@@ -23,17 +33,6 @@
         >
           <v-icon name="sync" />
         </button>
-
-        <component
-          :is="isConnected ? 'a' : 'span'"
-          :href="localazyProject?.url || undefined"
-          target="_blank"
-          class="header-action"
-          :class="{ 'header-action--disabled': !isConnected }"
-          title="Open Localazy project in a new tab"
-        >
-          <v-icon name="open_in_new" />
-        </component>
       </div>
     </div>
 
@@ -187,12 +186,12 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
 
 .status-pill--success {
   background: var(--success-25, rgba(46, 184, 124, 0.12));
-  color: var(--success);
+  color: var(--theme--success);
 }
 
 .status-pill--warning {
   background: var(--warning-25, rgba(255, 167, 38, 0.15));
-  color: var(--warning);
+  color: var(--theme--warning);
 
   .status-dot {
     animation: pulse 1.6s ease-in-out infinite;
@@ -201,7 +200,7 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
 
 .status-pill--danger {
   background: var(--danger-25, rgba(231, 76, 60, 0.12));
-  color: var(--danger);
+  color: var(--theme--danger);
 }
 
 @keyframes pulse {
@@ -221,6 +220,15 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.project-name--link {
+  text-decoration: none;
+
+  &:hover {
+    color: var(--theme--primary);
+    text-decoration: underline;
+  }
 }
 
 .header-actions {
@@ -245,7 +253,7 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
   text-decoration: none;
 
   &:hover {
-    background-color: var(--background-subdued);
+    background-color: var(--theme--background-subdued);
   }
 
   &--disabled,
@@ -276,7 +284,7 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
   flex-direction: column;
   gap: 4px;
   padding: 12px 14px;
-  background: var(--background-subdued);
+  background: var(--theme--background-subdued);
   border-radius: $radius;
   min-width: 0;
 }
@@ -305,6 +313,6 @@ $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme
 }
 
 .over-key-limit {
-  color: var(--danger);
+  color: var(--theme--danger);
 }
 </style>


### PR DESCRIPTION
## Summary

- `ConnectionLanguages` restructure: column order flips to **Directus first, Localazy second** to match the user's setup-flow mental model.
- Custom mappings move out of a separate "chip" column into the language cell itself as `→ <counterpart-code>` with directional tooltips; reduces row weight when many mappings exist.
- Languages without a Localazy match and no custom mapping get an inline "Define mapping" link straight to AdvancedSettings — shortens the diagnostic path for the most common confusion.
- Replaces `DirectusLocalazyAdapter` static calls with two local `Map`s built from `customMappings` plus a `-`/`_` swap fallback. The adapter service was overkill for two lookups + a swap.
- `ConnectionOverview`: the "Open in Localazy" affordance moves from a separate icon button into the project name itself (anchor with hover underline) — the dedicated icon was redundant.

## Test plan

- [x] `npm run check` green locally.
- [ ] Connect a project, check Overview: Directus column is the second cell, Localazy column the third; language cell shows `→ <code>` chip for any custom-mapped row.
- [ ] Add a language to Directus that Localazy doesn't recognize → "Define mapping" link appears, clicking it opens AdvancedSettings.
- [ ] Click the project name in the Overview header → opens the Localazy project in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)