### PR TITLE
PR 62/N: burst-coalescing design docs + pipeline outcome counts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,12 +47,18 @@ The closed orchestration in `extensions/common/services/orchestrator/automated-e
 **Automated deprecation pipeline**:
 Sibling module to the Automated export pipeline, in the same directory. Owns deprecation orchestration: load context → master + deprecation toggle gate → load project → payment-status gate → fetch source-language import content → project Localazy key IDs from deleted Directus item IDs → call deprecate. Returns a discriminated outcome.
 
+**Automated export burst**:
+A coalesced Sync-log session covering a contiguous window of hook-triggered Automated export and Automated deprecation activity. Opens on the first actionable pipeline outcome, extends on each subsequent one within a 30 s idle window, closes after 30 s of inactivity. Persisted as `event_type='upload-automated'`, `initiator='hook'`, `initiator_user=null`. Per-entry user attribution lives inside each entry's `data.user`, not on the session row. Exists so the 100-row retention cap stays meaningful in the face of bulk Directus operations (which would otherwise flood the table with one row per item event).
+_Avoid_: "automated upload burst" (the user-facing term is "Automated export"; `upload-` survives only as the column prefix per the resolved upload/export ambiguity).
+
 ## Relationships
 
 - **Automated export** is a property of the **Sync-hook bundle**; it cannot run when the bundle is not installed.
 - **Automated import** also requires the **Sync-hook bundle** (to handle the inbound webhook) and additionally requires a configured **Webhook user**.
 - **Deprecation** is a sub-behavior of **Automated export** (today gated by an independent `automated_deprecation` flag; surfaced to users as a sub-setting under "Automated export").
+- An **Automated export burst** spans both Automated export and Automated deprecation events — they share one Sync-log session within a 30 s window. The split between the two appears only at per-entry granularity.
 
 ## Flagged ambiguities
 
 - "upload" vs "export" was used inconsistently across code and UI. **Resolved (2026-05-15)**: user-facing copy says "export"; code/field names keep "upload" for now to avoid a migration. Future contributors should not "fix" this inconsistency without a coordinated rename.
+  - **Activity-page application (2026-05-19)**: The Activity page completes the user-facing application of this resolution — the tab is "Export" (not "Upload"); `formatEventType` returns "Incremental export" / "Full export" / "Automated export"; persisted `event_type` values keep the `upload-*` prefix (`upload-incremental`, `upload-full`, `upload-automated`).

--- a/docs/adr/0002-automated-export-burst-coalescing.md
+++ b/docs/adr/0002-automated-export-burst-coalescing.md
@@ -1,0 +1,39 @@
+# Automated export hook activity is tracked as 30 s coalesced bursts, not per-event sessions
+
+## Context
+
+The Sync-log session model used by `runIncrementalImport` and `runIncrementalExport` opens one persisted row per orchestrator call. That maps cleanly when each call represents one user-driven operation: a click on "Download" or "Export," or one inbound Localazy `project_published` webhook. The Activity page's 100-row retention cap holds because user-driven runs are infrequent.
+
+The Sync-hook bundle's hook side has different cardinality. It calls `runAutomatedExportPipeline` once per Directus lifecycle event — `items.create`, `items.update`, `items.delete`, `translations.*`, `settings.*`. Realistic workloads produce many events per "operation":
+
+- A bulk import of 200 articles fires `items.create` 200 times (or one batched event with `keys.length = 200`, depending on how Directus delivers it).
+- A user clicking Save on a translation collection with 10 dirty rows fires 10 `translations.update` events.
+- A nightly content sync against an external CMS hammers `items.update` continuously.
+
+Applying the one-session-per-call model would mean 200 rows from a single bulk import — wiping out the 100-row retention window in one operation. The Activity page would lose the very signal it exists to surface.
+
+The hook side also has a different "what just happened" mental model. When a user reads the Activity page, they want to answer "did my recent edit ship to Localazy?" — not "did event #143 succeed?" Per-event rows force the reader to mentally re-coalesce. Per-burst rows do the work for them.
+
+## Decision
+
+1. **One Sync-log row per coalesced burst, not per pipeline call.** A burst opens on the first actionable pipeline outcome (`exported`, `deprecated` with non-zero keys, `failed`, `no-project`, `payment-disabled`, `could-not-fetch-import-content`) and closes after **30 s of idle** — i.e. when no further actionable outcome has extended the burst's timer. Outcomes that today's `outcome-reporters.ts` emits at `debug` level (`missing-context`, `export-disabled`, `nothing-to-export`, `deprecation-disabled`, `deprecated` with zero keys) are silenced from the Activity page entirely; they neither open nor extend a burst.
+
+2. **Process-wide coalesce key.** One burst at a time per bundle process. The burst spans both Automated export and Automated deprecation activity and is not partitioned by collection, user, or direction. ADR-0001 already binds export and deprecation under a single master toggle; treating them as one Activity-page stream is consistent with that.
+
+3. **Session-level attribution is `initiator='hook'`, `initiator_user=null`.** Per-entry user attribution lives in each entry's `data.user` (the `accountability.user` from the originating Directus event). User-name resolution is batched at read-time on the Activity page, reusing the existing `use-sync-log-user-names.ts` pattern.
+
+4. **`event_type='upload-automated'`.** Routes into the existing Upload tab (renamed to **Export** as part of this work, per CONTEXT.md's resolved upload/export ambiguity). The column-side `upload-` prefix matches the existing `upload-incremental` / `upload-full` convention; the user-facing label is "Automated export."
+
+5. **Coordinator lives at the bundle edge, not inside the pipelines.** A new `AutomatedExportBurstCoordinator` module wraps the existing `outcome-reporters.ts` call site in `hook/index.ts`. The export and deprecation pipelines themselves remain pure functions returning discriminated outcomes — no `SyncLogWriter` port is plumbed through them.
+
+6. **Bundle-restart resilience via lazy sweep.** On the first hook event after each bundle init, the coordinator sweeps any orphaned `event_type='upload-automated'` rows in `status='in_progress'` and finalises them as `status='aborted'` with summary `"Bundle restarted before burst completed"`, then proceeds with normal open/extend logic. Tracked via an in-memory flag so subsequent events skip the sweep.
+
+7. **Terminal status derived from per-entry levels.** `completed` when every appended entry was `info`-level; `partial` when there is a mix; `failed` when every entry was `error`-level. `aborted` and `skipped` do not apply at burst granularity (the no-action paths are filtered out before the burst opens).
+
+## Consequences
+
+- The hook-side pipelines need their outcome variants enriched with item-count fields (`{ kind: 'exported', itemsProcessed }`, `{ kind: 'deprecated', keysCount, itemsProcessed }`) so the burst row's `items_processed` column reflects what landed in Localazy, not the rough "1 per event" approximation. This is a small breaking change to the pipeline's return type — both production callers update in lockstep.
+- The bundle gains its first in-process mutable state outside of Directus' own infrastructure — the coordinator's `currentBurst` ref and its `setTimeout` handle. A promise-chain mutex on the open/extend/close transitions handles the (rare but real) case of two action callbacks firing concurrently.
+- Bundle restart mid-burst leaves a stale `in_progress` row on disk that won't reflect what actually happened during the truncated burst. The lazy sweep on the next hook event marks it `aborted`. Direct-mode operators who never trigger another hook event after a restart will see the stale row sit in the table until retention trims it (~100 sessions later) — acceptable for the same reasons the webhook handler accepts the same outcome class today.
+- Future change of the coalesce window from 30 s requires no schema change; it's a constant in the coordinator module. A future change of the coalesce **key** (e.g. partitioning by user for multi-admin installs) does require more work — the persisted rows under the old key shape would still be read by the Activity page, but the coordinator would need an explicit migration of in-flight bursts at deploy time. Not in scope here.
+- Future rename of `event_type` from `upload-automated` to `export-automated` is folded into the same coordinated migration as `upload-incremental` → `export-incremental` (out of scope for this work — `formatEventType` already absorbs the column→label mapping).

--- a/extensions/common/services/orchestrator/automated-deprecation-pipeline.test.ts
+++ b/extensions/common/services/orchestrator/automated-deprecation-pipeline.test.ts
@@ -155,12 +155,15 @@ describe('runAutomatedDeprecationPipeline', () => {
       projectDeprecationKeys: projector,
     });
 
-    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 3 });
+    // `itemsProcessed` mirrors `keysCount`; surfaced separately so the burst coordinator
+    // (PR 64+) can roll a single counter across both pipelines without case-splitting on
+    // `kind`.
+    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 3, itemsProcessed: 3 });
     expect(projector).toHaveBeenCalledWith({ importContent: okImportContent, itemIds: ['d1', 'd2'] });
     expect(helperMocks.deprecateLocalazyKeys).toHaveBeenCalledWith('tok', 'p1', ['lk-a', 'lk-b', 'lk-c']);
   });
 
-  it("still reaches 'deprecated' (with keysCount 0) when the projector produces nothing", async () => {
+  it("still reaches 'deprecated' (with keysCount + itemsProcessed 0) when the projector produces nothing", async () => {
     helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
 
     const outcome = await runAutomatedDeprecationPipeline({
@@ -170,7 +173,7 @@ describe('runAutomatedDeprecationPipeline', () => {
       projectDeprecationKeys: () => [],
     });
 
-    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 0 });
+    expect(outcome).toEqual({ kind: 'deprecated', keysCount: 0, itemsProcessed: 0 });
     // deprecateLocalazyKeys is called even with empty array; the helper itself short-circuits.
     expect(helperMocks.deprecateLocalazyKeys).toHaveBeenCalledWith('tok', 'p1', []);
   });

--- a/extensions/common/services/orchestrator/automated-deprecation-pipeline.ts
+++ b/extensions/common/services/orchestrator/automated-deprecation-pipeline.ts
@@ -53,11 +53,17 @@ export type DeprecationKeyProjector = (input: DeprecationKeyProjectorInput) => s
  *   - `could-not-fetch-import-content` → the import fetch returned `{ success: false }`
  *   - `deprecated`                  → deprecate-keys was invoked; `keysCount` carries
  *                                      the number of Localazy keys that were marked
- *                                      deprecated (may be 0 when nothing matched)
+ *                                      deprecated (may be 0 when nothing matched);
+ *                                      `itemsProcessed` mirrors `keysCount` (each
+ *                                      deprecated Localazy key is one logical item from
+ *                                      the burst coordinator's perspective) — surfaced
+ *                                      separately so the coordinator can roll a single
+ *                                      counter across both export and deprecation
+ *                                      pipelines without case-splitting on `kind`.
  *   - `failed`                      → any helper threw; original error preserved
  */
 export type AutomatedDeprecationOutcome =
-  | { kind: 'deprecated'; keysCount: number }
+  | { kind: 'deprecated'; keysCount: number; itemsProcessed: number }
   | { kind: 'missing-context' }
   | { kind: 'deprecation-disabled' }
   | { kind: 'no-project' }
@@ -106,7 +112,7 @@ export async function runAutomatedDeprecationPipeline(opts: AutomatedDeprecation
     const keyIds = opts.projectDeprecationKeys({ importContent: result.content, itemIds: opts.itemIds });
 
     await deprecateLocalazyKeys(context.localazyData.access_token, localazyProject.id, keyIds);
-    return { kind: 'deprecated', keysCount: keyIds.length };
+    return { kind: 'deprecated', keysCount: keyIds.length, itemsProcessed: keyIds.length };
   } catch (error) {
     return { kind: 'failed', error };
   }

--- a/extensions/common/services/orchestrator/automated-export-pipeline.test.ts
+++ b/extensions/common/services/orchestrator/automated-export-pipeline.test.ts
@@ -48,6 +48,10 @@ const nonEmptyContent: TranslatableContent = {
   sourceLanguage: { en: { hello: 'Hello' } },
   otherLanguages: {},
 };
+const threeKeyContent: TranslatableContent = {
+  sourceLanguage: { hello: 'Hello', goodbye: 'Bye', greeting: 'Hi' },
+  otherLanguages: {},
+};
 
 // The DirectusApi instance only matters as far as SynchronizationLanguagesService is
 // constructed with it — the constructor is mocked above, so any object works.
@@ -166,7 +170,10 @@ describe('runAutomatedExportPipeline', () => {
       dispatchContent,
     });
 
-    expect(outcome).toEqual({ kind: 'exported' });
+    // `itemsProcessed: 1` reflects the single source-language top-level key in
+    // `nonEmptyContent`. The burst coordinator (PR 64+) rolls this into the row's
+    // `items_processed` column.
+    expect(outcome).toEqual({ kind: 'exported', itemsProcessed: 1 });
     expect(fetchContent).toHaveBeenCalledOnce();
     expect(fetchContent).toHaveBeenCalledWith({
       context: makeContext(),
@@ -178,6 +185,20 @@ describe('runAutomatedExportPipeline', () => {
       context: makeContext(),
       localazyProject: okProject,
     });
+  });
+
+  it("reports 'exported' with itemsProcessed equal to the source-language key count", async () => {
+    helperMocks.loadLocalazyProject.mockResolvedValue(okProject);
+    helperMocks.resolveExportLanguages.mockResolvedValue(['en']);
+
+    const outcome = await runAutomatedExportPipeline({
+      loadContext: async () => makeContext(),
+      directusApi: fakeDirectusApi,
+      fetchContent: makeFetcher(threeKeyContent),
+      dispatchContent: makeDispatcher(),
+    });
+
+    expect(outcome).toEqual({ kind: 'exported', itemsProcessed: 3 });
   });
 
   it("returns 'failed' with the original error when loadLocalazyProject throws", async () => {

--- a/extensions/common/services/orchestrator/automated-export-pipeline.ts
+++ b/extensions/common/services/orchestrator/automated-export-pipeline.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, size } from 'lodash';
 import { Project } from '@localazy/api-client';
 import { Settings } from '../../models/collections-data/settings';
 import { ContentTransferSetupDatabase } from '../../models/collections-data/content-transfer-setup';
@@ -66,7 +66,8 @@ export type AutomatedExportContentDispatcher = (input: AutomatedExportContentDis
  *   - `no-project`        → loadProject returned null (token missing or no projects)
  *   - `payment-disabled`  → payment-status gate blocked the run
  *   - `nothing-to-export` → source language has no content (fetcher returned empty)
- *   - `exported`          → dispatch was invoked
+ *   - `exported`          → dispatch was invoked; `itemsProcessed` is the count of
+ *                            distinct source-language keys that flowed through dispatch
  *   - `failed`            → any helper threw; the original error is preserved
  *
  * Behaviour change from the legacy services: `automated_upload` is now gated at the
@@ -75,7 +76,7 @@ export type AutomatedExportContentDispatcher = (input: AutomatedExportContentDis
  * call and language resolution still ran on disabled installs.
  */
 export type AutomatedExportOutcome =
-  | { kind: 'exported' }
+  | { kind: 'exported'; itemsProcessed: number }
   | { kind: 'nothing-to-export' }
   | { kind: 'missing-context' }
   | { kind: 'export-disabled' }
@@ -125,7 +126,10 @@ export async function runAutomatedExportPipeline(opts: AutomatedExportPipelineOp
     }
 
     await opts.dispatchContent({ content, context, localazyProject });
-    return { kind: 'exported' };
+    // The count of distinct source-language keys is what landed in Localazy as keys;
+    // surfaced so the burst coordinator can roll it into the persisted Sync-log row's
+    // `items_processed` column. `isEmpty` above guarantees this is >= 1 on this branch.
+    return { kind: 'exported', itemsProcessed: size(content.sourceLanguage) };
   } catch (error) {
     return { kind: 'failed', error };
   }

--- a/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.test.ts
@@ -33,7 +33,7 @@ describe('reportAutomatedExportOutcome', () => {
     const logger = makeLogger();
 
     reportAutomatedExportOutcome({
-      outcome: { kind: 'exported' },
+      outcome: { kind: 'exported', itemsProcessed: 1 },
       logger,
       label: 'translation strings',
       trackingLabel: 'exportTranslationString',
@@ -138,7 +138,7 @@ describe('reportAutomatedDeprecationOutcome', () => {
     const logger = makeLogger();
 
     reportAutomatedDeprecationOutcome({
-      outcome: { kind: 'deprecated', keysCount: 3 },
+      outcome: { kind: 'deprecated', keysCount: 3, itemsProcessed: 3 },
       logger,
       label: 'collection articles',
       trackingLabel: 'deprecateDeletedCollectionItems',
@@ -153,7 +153,7 @@ describe('reportAutomatedDeprecationOutcome', () => {
     const logger = makeLogger();
 
     reportAutomatedDeprecationOutcome({
-      outcome: { kind: 'deprecated', keysCount: 0 },
+      outcome: { kind: 'deprecated', keysCount: 0, itemsProcessed: 0 },
       logger,
       label: 'collection articles',
       trackingLabel: 'deprecateDeletedCollectionItems',


### PR DESCRIPTION
## Summary

Lay the groundwork for hook-triggered Automated export tracking on the Activity page.

- **Design captured up front.** Add a new domain term to `CONTEXT.md` (**Automated export burst** — a coalesced Sync-log session covering a contiguous window of hook-triggered Automated export and Automated deprecation activity) and the rationale to `docs/adr/0002-automated-export-burst-coalescing.md`. The ADR explains why hook activity is coalesced into 30 s bursts instead of one row per pipeline call (retention cap + bulk operations would otherwise wipe the Activity history).
- **Pipeline outcome enrichment.** `runAutomatedExportPipeline`'s `exported` outcome and `runAutomatedDeprecationPipeline`'s `deprecated` outcome now carry an `itemsProcessed: number` field. For export, derived from the count of source-language keys flowing through dispatch; for deprecation, mirrors `keysCount`. Surfaced separately from `keysCount` so the burst coordinator (PR 64+) can roll a single counter across both pipelines without case-splitting on `kind`.

No runtime behaviour change yet — the field is added but no caller reads it. The existing `outcome-reporters.ts` call sites are untouched.

This is **Phase 1 of 5** for the Activity-page Automated-export tracking feature. Subsequent PRs:
- PR 63: extract the bundle's `SyncLogStorage` adapter so the hook context can reuse it.
- PR 64: burst coordinator module + integration into `hook/index.ts`, lazy sweep of orphaned `in_progress` rows on first event after bundle init.
- PR 65: module-side Activity-page UI — `tabForEventType('upload-automated')`, `formatEventType('upload-automated') === 'Automated export'`, Upload tab → Export rename per CONTEXT.md's resolved upload/export ambiguity, per-entry user-name resolution.
- PR 66: end-to-end manual smoke test against a local Directus instance + any follow-ups from the four PRs above.

## Test plan

- [x] `npm run check` — lint + format + typecheck + 540 unit tests all pass.
- [x] `npm run build` — production build of both extensions succeeds.
- [x] New test cases: `runAutomatedExportPipeline` reports `itemsProcessed` equal to the source-language top-level key count; `runAutomatedDeprecationPipeline` reports `itemsProcessed === keysCount` for both the non-zero and zero-keys paths.
- [x] Existing assertions on `outcome-reporters.test.ts` updated to include the new field; log copy unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)