### PR TITLE
PR 64/N: burst coordinator + hook handler integration

### DIFF
--- a/extensions/sync-hook/src/hook/index.ts
+++ b/extensions/sync-hook/src/hook/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { defineHook } from '@directus/extensions-sdk';
 import { runAutomatedExportPipeline } from '../../../common/services/orchestrator/automated-export-pipeline';
 import { runAutomatedDeprecationPipeline } from '../../../common/services/orchestrator/automated-deprecation-pipeline';
@@ -13,6 +14,7 @@ import {
   projectTranslationStringsDeprecationKeys,
 } from './services/content-synchronization/deprecation-key-projectors';
 import { reportAutomatedDeprecationOutcome, reportAutomatedExportOutcome } from './services/content-synchronization/outcome-reporters';
+import { createAutomatedExportBurstCoordinator } from './services/automated-export-burst-coordinator';
 import { DirectusApiService } from './services/directus-service';
 
 const EXPORT_TRANSLATION_STRINGS_EVENTS = ['settings.create', 'settings.update', 'translations.create', 'translations.update'] as const;
@@ -24,9 +26,19 @@ const EXPORT_COLLECTION_CONTENT_EVENTS = ['items.create', 'items.update'] as con
 export default defineHook(({ action }, { services, logger }) => {
   const { ItemsService, FieldsService } = services;
 
+  // Process-singleton burst coordinator. Captures the bundle's `ItemsService` ref + a
+  // node:crypto UUID factory; per-event schemas thread through each `record…Outcome`
+  // call. The coordinator is purely additive — the existing `reportAutomated…Outcome`
+  // calls still route to Directus' logger + analytics; the coordinator adds the
+  // persistent Activity-page surface on top. ADR-0002 explains the burst lifecycle.
+  const burstCoordinator = createAutomatedExportBurstCoordinator({
+    ItemsService,
+    generateId: randomUUID,
+  });
+
   // Settings + translation-string create/update: export translatable strings to Localazy.
   for (const event of EXPORT_TRANSLATION_STRINGS_EVENTS) {
-    action(event, async (_, { schema }) => {
+    action(event, async (_, { schema, accountability }) => {
       if (!schema) return;
       const outcome = await runAutomatedExportPipeline({
         loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema }),
@@ -35,12 +47,20 @@ export default defineHook(({ action }, { services, logger }) => {
         dispatchContent: dispatchToLocalazy,
       });
       reportAutomatedExportOutcome({ outcome, logger, label: 'translation strings', trackingLabel: 'exportTranslationString' });
+      await burstCoordinator.recordExportOutcome({
+        outcome,
+        schema,
+        event,
+        collection: event.startsWith('settings.') ? 'directus_settings' : 'directus_translations',
+        keys: [],
+        userId: accountability?.user ?? null,
+      });
     });
   }
 
   // Settings + translation-string delete: deprecate matching Localazy keys.
   for (const event of DEPRECATE_TRANSLATION_STRINGS_EVENTS) {
-    action(event, async ({ keys }, { schema }) => {
+    action(event, async ({ keys }, { schema, accountability }) => {
       if (!schema) return;
       const outcome = await runAutomatedDeprecationPipeline({
         itemIds: keys,
@@ -54,13 +74,21 @@ export default defineHook(({ action }, { services, logger }) => {
         label: 'translation strings',
         trackingLabel: 'deprecateDeletedTranslationStrings',
       });
+      await burstCoordinator.recordDeprecationOutcome({
+        outcome,
+        schema,
+        event,
+        collection: event.startsWith('settings.') ? 'directus_settings' : 'directus_translations',
+        keys,
+        userId: accountability?.user ?? null,
+      });
     });
   }
 
   // Items create/update: export collection content. The create event delivers
   // a single `key`; update delivers a `keys` array. Normalise to keys[].
   for (const event of EXPORT_COLLECTION_CONTENT_EVENTS) {
-    action(event, async (payload, { schema }) => {
+    action(event, async (payload, { schema, accountability }) => {
       if (!schema) return;
       const keys: string[] = 'keys' in payload ? payload.keys : [payload.key];
       const outcome = await runAutomatedExportPipeline({
@@ -75,11 +103,19 @@ export default defineHook(({ action }, { services, logger }) => {
         label: `${payload.collection} content for keys ${keys.join(', ')}`,
         trackingLabel: 'exportCollectionContent',
       });
+      await burstCoordinator.recordExportOutcome({
+        outcome,
+        schema,
+        event,
+        collection: payload.collection,
+        keys,
+        userId: accountability?.user ?? null,
+      });
     });
   }
 
   // Items delete: deprecate the matching Localazy keys.
-  action('items.delete', async ({ keys, collection }, { schema }) => {
+  action('items.delete', async ({ keys, collection }, { schema, accountability }) => {
     if (!schema) return;
     const outcome = await runAutomatedDeprecationPipeline({
       itemIds: keys,
@@ -92,6 +128,14 @@ export default defineHook(({ action }, { services, logger }) => {
       logger,
       label: `collection ${collection}`,
       trackingLabel: 'deprecateDeletedCollectionItems',
+    });
+    await burstCoordinator.recordDeprecationOutcome({
+      outcome,
+      schema,
+      event: 'items.delete',
+      collection,
+      keys,
+      userId: accountability?.user ?? null,
     });
   });
 });

--- a/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.test.ts
+++ b/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AbstractServiceOptions, Item, SchemaOverview } from '@directus/types';
+import type { ItemsServiceCtor } from '../types/directus-services';
+import { createAutomatedExportBurstCoordinator } from './automated-export-burst-coordinator';
+import type { AutomatedExportOutcome } from '../../../../common/services/orchestrator/automated-export-pipeline';
+import type { AutomatedDeprecationOutcome } from '../../../../common/services/orchestrator/automated-deprecation-pipeline';
+
+type FakeRow = Record<string, unknown>;
+
+const unused = (): never => {
+  throw new Error('FakeService stub method called — not implemented in test fake');
+};
+
+function matchesFilter(row: Record<string, unknown>, filter: Record<string, unknown>): boolean {
+  for (const [field, predicate] of Object.entries(filter)) {
+    const value = row[field];
+    const pred = predicate as Record<string, unknown>;
+    if ('_eq' in pred && value !== pred._eq) return false;
+  }
+  return true;
+}
+
+/**
+ * In-memory `ItemsService` fake. Same shape as `shared/sync-log-storage.test.ts` and
+ * `endpoint/orchestrator-adapters.test.ts`, but with read/filter support the coordinator
+ * needs for its lazy sweep.
+ */
+function makeFakeItemsService(initial: Record<string, FakeRow[]>) {
+  const tables = new Map<string, FakeRow[]>();
+  for (const [k, v] of Object.entries(initial)) tables.set(k, [...v]);
+
+  class FakeService<T extends Item = Item> {
+    private collection: string;
+    readonly knex = unused as never;
+    readonly accountability = null;
+    readonly nested: string[] = [];
+    getKeysByQuery = unused;
+    createMany = unused;
+    readMany = unused;
+    updateByQuery = unused;
+    updateBatch = unused;
+    updateMany = unused;
+    upsertMany = unused;
+    upsertOne = unused;
+    upsertSingleton = unused;
+    deleteByQuery = unused;
+    deleteOne = unused;
+    readSingleton = unused;
+    deleteMany = unused;
+    constructor(collection: string, _options: AbstractServiceOptions) {
+      this.collection = collection;
+    }
+    async readByQuery(q: { filter?: Record<string, unknown>; sort?: string[]; limit?: number; fields?: string[] } = {}): Promise<T[]> {
+      let list = ((tables.get(this.collection) ?? []) as T[]).slice();
+      if (q.filter) {
+        list = list.filter((row) => matchesFilter(row as Record<string, unknown>, q.filter ?? {}));
+      }
+      return list;
+    }
+    async readOne(id: string | number): Promise<T | null> {
+      const row = (tables.get(this.collection) ?? []).find((r) => r.id === id);
+      return (row as T | undefined) ?? null;
+    }
+    async createOne(data: Partial<T>) {
+      const list = tables.get(this.collection) ?? [];
+      list.push(data as FakeRow);
+      tables.set(this.collection, list);
+      return data.id as string;
+    }
+    async updateOne(id: string | number, data: Partial<T>) {
+      const list = tables.get(this.collection) ?? [];
+      const idx = list.findIndex((r) => r.id === id);
+      if (idx >= 0) list[idx] = { ...list[idx], ...data };
+      return id;
+    }
+  }
+  return { FakeService, tables };
+}
+
+/**
+ * Test harness for the idle timer. Captures every scheduled callback; tests fire them
+ * manually by calling `runPending`. Mirrors the real `setTimeout` API surface enough that
+ * the coordinator's `clearTimeoutFn` path works.
+ */
+function makeFakeTimer() {
+  let nextId = 1;
+  const pending = new Map<number, () => void>();
+  function setTimeoutFn(cb: () => void, _ms: number): ReturnType<typeof setTimeout> {
+    const id = nextId++;
+    pending.set(id, cb);
+    // The coordinator types this as `ReturnType<typeof setTimeout>`. Node's `setTimeout`
+    // returns a `Timeout` object; cast through unknown so the structural shape matches.
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+  function clearTimeoutFn(handle: ReturnType<typeof setTimeout>) {
+    const id = handle as unknown as number;
+    pending.delete(id);
+  }
+  /** Fire whichever scheduled callback is still pending — the coordinator only ever has one active timer. */
+  async function runPending() {
+    const entries = Array.from(pending.entries());
+    for (const [id, cb] of entries) {
+      pending.delete(id);
+      cb();
+      // Yield so the coordinator's withLock+finish chain runs to completion before the
+      // test inspects state.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+  return { setTimeoutFn, clearTimeoutFn, runPending, pendingCount: () => pending.size };
+}
+
+const schema: SchemaOverview = { collections: {}, relations: [] };
+
+let idCounter = 0;
+function generateId() {
+  idCounter += 1;
+  return `sess-${idCounter}`;
+}
+
+beforeEach(() => {
+  idCounter = 0;
+});
+
+/**
+ * Convenience: build a coordinator + its test scaffolding, returning everything tests
+ * need to inspect (rows table, timer fakes, the coordinator surface).
+ */
+function setup(initialRows: FakeRow[] = []) {
+  const fake = makeFakeItemsService({ localazy_sync_log: initialRows });
+  const timer = makeFakeTimer();
+  const coordinator = createAutomatedExportBurstCoordinator({
+    ItemsService: fake.FakeService as ItemsServiceCtor,
+    generateId,
+    idleWindowMs: 30_000,
+    now: () => Date.parse('2026-05-19T10:00:00.000Z'),
+    setTimeoutFn: timer.setTimeoutFn,
+    clearTimeoutFn: timer.clearTimeoutFn,
+  });
+  return { fake, timer, coordinator };
+}
+
+describe('createAutomatedExportBurstCoordinator', () => {
+  describe('Q3 outcome filter', () => {
+    it('opens a burst on an exported outcome', async () => {
+      const { fake, coordinator } = setup();
+      const outcome: AutomatedExportOutcome = { kind: 'exported', itemsProcessed: 3 };
+
+      await coordinator.recordExportOutcome({
+        outcome,
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1', 'a2', 'a3'],
+        userId: 'user-1',
+      });
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.event_type).toBe('upload-automated');
+      expect(rows[0]?.initiator).toBe('hook');
+      expect(rows[0]?.initiator_user).toBeNull();
+      expect(rows[0]?.status).toBe('in_progress');
+    });
+
+    it.each(['nothing-to-export', 'missing-context', 'export-disabled'] as const)(
+      'silently drops the %s export outcome (no burst opens)',
+      async (kind) => {
+        const { fake, coordinator } = setup();
+
+        await coordinator.recordExportOutcome({
+          outcome: { kind } as AutomatedExportOutcome,
+          schema,
+          event: 'items.update',
+          collection: 'articles',
+          keys: ['a1'],
+          userId: null,
+        });
+
+        expect(fake.tables.get('localazy_sync_log') ?? []).toHaveLength(0);
+      },
+    );
+
+    it.each(['failed', 'no-project', 'payment-disabled'] as const)('opens a burst on the %s export outcome', async (kind) => {
+      const { fake, coordinator } = setup();
+      const outcome = kind === 'failed' ? { kind, error: new Error('boom') } : ({ kind } as AutomatedExportOutcome);
+
+      await coordinator.recordExportOutcome({
+        outcome: outcome as AutomatedExportOutcome,
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+
+      expect(fake.tables.get('localazy_sync_log') ?? []).toHaveLength(1);
+    });
+
+    it('silently drops a deprecated outcome when keysCount/itemsProcessed are zero', async () => {
+      const { fake, coordinator } = setup();
+
+      await coordinator.recordDeprecationOutcome({
+        outcome: { kind: 'deprecated', keysCount: 0, itemsProcessed: 0 },
+        schema,
+        event: 'items.delete',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+
+      expect(fake.tables.get('localazy_sync_log') ?? []).toHaveLength(0);
+    });
+
+    it.each(['missing-context', 'deprecation-disabled'] as const)('silently drops the %s deprecation outcome', async (kind) => {
+      const { fake, coordinator } = setup();
+
+      await coordinator.recordDeprecationOutcome({
+        outcome: { kind } as AutomatedDeprecationOutcome,
+        schema,
+        event: 'items.delete',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+
+      expect(fake.tables.get('localazy_sync_log') ?? []).toHaveLength(0);
+    });
+  });
+
+  describe('coalescing within the idle window', () => {
+    it('extends the same burst across multiple events without firing the timer', async () => {
+      const { fake, timer, coordinator } = setup();
+      const outcome: AutomatedExportOutcome = { kind: 'exported', itemsProcessed: 2 };
+
+      await coordinator.recordExportOutcome({
+        outcome,
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1', 'a2'],
+        userId: 'user-1',
+      });
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a3'],
+        userId: 'user-2',
+      });
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows).toHaveLength(1);
+      // The timer was extended exactly once (the second event clears + reschedules); the
+      // pending count stays at 1 throughout.
+      expect(timer.pendingCount()).toBe(1);
+
+      // Two append cycles landed two entries on the row.
+      const entries = JSON.parse((rows[0]?.entries ?? '[]') as string);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].data.user).toBe('user-1');
+      expect(entries[1].data.user).toBe('user-2');
+    });
+
+    it('opens a new burst when the timer fires before the next event', async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+      await timer.runPending(); // burst 1 closes
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a2'],
+        userId: null,
+      });
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.id).toBe('sess-1');
+      expect(rows[1]?.id).toBe('sess-2');
+    });
+  });
+
+  describe('terminal status derivation on timer fire', () => {
+    it("finalises a single-exported burst as 'completed'", async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 5 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1', 'a2', 'a3', 'a4', 'a5'],
+        userId: null,
+      });
+      await timer.runPending();
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows[0]?.status).toBe('completed');
+      expect(rows[0]?.items_processed).toBe(5);
+      expect(rows[0]?.summary).toBe('Exported 5 items across 1 event');
+    });
+
+    it("finalises a mixed export+deprecation burst as 'completed' with both counters in the summary", async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 2 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1', 'a2'],
+        userId: null,
+      });
+      await coordinator.recordDeprecationOutcome({
+        outcome: { kind: 'deprecated', keysCount: 3, itemsProcessed: 3 },
+        schema,
+        event: 'items.delete',
+        collection: 'articles',
+        keys: ['del-1', 'del-2', 'del-3'],
+        userId: null,
+      });
+      await timer.runPending();
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows[0]?.status).toBe('completed');
+      expect(rows[0]?.items_processed).toBe(5);
+      expect(rows[0]?.summary).toBe('Exported 2 items, deprecated 3 keys across 2 events');
+    });
+
+    it("finalises a mixed-success burst as 'partial'", async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'failed', error: new Error('boom') },
+        schema,
+        event: 'items.update',
+        collection: 'news',
+        keys: ['n1'],
+        userId: null,
+      });
+      await timer.runPending();
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows[0]?.status).toBe('partial');
+      expect(rows[0]?.items_processed).toBe(1);
+      expect(rows[0]?.summary).toBe('Exported 1 item across 1 event; 1 failed');
+    });
+
+    it("finalises an all-failure burst as 'failed'", async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'failed', error: new Error('boom') },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'no-project' },
+        schema,
+        event: 'items.update',
+        collection: 'news',
+        keys: ['n1'],
+        userId: null,
+      });
+      await timer.runPending();
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows[0]?.status).toBe('failed');
+      expect(rows[0]?.items_processed).toBe(0);
+      expect(rows[0]?.summary).toBe('All 2 events failed');
+    });
+  });
+
+  describe('lazy sweep of orphan in_progress rows', () => {
+    it('finalises orphan upload-automated rows as aborted on the first event after bundle init', async () => {
+      const orphans: FakeRow[] = [
+        { id: 'orphan-1', event_type: 'upload-automated', status: 'in_progress', started_at: '2026-05-19T09:00:00.000Z' },
+        { id: 'orphan-2', event_type: 'upload-automated', status: 'in_progress', started_at: '2026-05-19T09:30:00.000Z' },
+      ];
+      const { fake, coordinator } = setup(orphans);
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      const o1 = rows.find((r) => r.id === 'orphan-1');
+      const o2 = rows.find((r) => r.id === 'orphan-2');
+      expect(o1?.status).toBe('aborted');
+      expect(o1?.summary).toBe('Bundle restarted before burst completed');
+      expect(o2?.status).toBe('aborted');
+    });
+
+    it('runs the sweep only once across the coordinator lifetime', async () => {
+      const fake = makeFakeItemsService({
+        localazy_sync_log: [
+          { id: 'orphan-1', event_type: 'upload-automated', status: 'in_progress', started_at: '2026-05-19T09:00:00.000Z' },
+        ],
+      });
+      const timer = makeFakeTimer();
+      const coordinator = createAutomatedExportBurstCoordinator({
+        ItemsService: fake.FakeService as ItemsServiceCtor,
+        generateId,
+        idleWindowMs: 30_000,
+        now: () => Date.parse('2026-05-19T10:00:00.000Z'),
+        setTimeoutFn: timer.setTimeoutFn,
+        clearTimeoutFn: timer.clearTimeoutFn,
+      });
+
+      // First event sweeps.
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+      // Inject a second orphan after the sweep — it should NOT get cleaned up because
+      // the sweep already ran.
+      fake.tables.get('localazy_sync_log')?.push({
+        id: 'orphan-2',
+        event_type: 'upload-automated',
+        status: 'in_progress',
+        started_at: '2026-05-19T09:45:00.000Z',
+      });
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a2'],
+        userId: null,
+      });
+
+      const orphan2 = (fake.tables.get('localazy_sync_log') ?? []).find((r) => r.id === 'orphan-2');
+      expect(orphan2?.status).toBe('in_progress'); // untouched
+    });
+
+    it('leaves non-burst event_types alone during the sweep', async () => {
+      const fake = makeFakeItemsService({
+        localazy_sync_log: [
+          { id: 'webhook-1', event_type: 'webhook', status: 'in_progress', started_at: '2026-05-19T09:00:00.000Z' },
+          { id: 'download-1', event_type: 'download-incremental', status: 'in_progress', started_at: '2026-05-19T09:00:00.000Z' },
+        ],
+      });
+      const timer = makeFakeTimer();
+      const coordinator = createAutomatedExportBurstCoordinator({
+        ItemsService: fake.FakeService as ItemsServiceCtor,
+        generateId,
+        idleWindowMs: 30_000,
+        now: () => Date.parse('2026-05-19T10:00:00.000Z'),
+        setTimeoutFn: timer.setTimeoutFn,
+        clearTimeoutFn: timer.clearTimeoutFn,
+      });
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: null,
+      });
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      expect(rows.find((r) => r.id === 'webhook-1')?.status).toBe('in_progress');
+      expect(rows.find((r) => r.id === 'download-1')?.status).toBe('in_progress');
+    });
+  });
+
+  describe('per-entry message format', () => {
+    it('uses an "Exported" verb for export outcomes and "Deprecated" for deprecation outcomes', async () => {
+      const { fake, timer, coordinator } = setup();
+
+      await coordinator.recordExportOutcome({
+        outcome: { kind: 'exported', itemsProcessed: 1 },
+        schema,
+        event: 'items.update',
+        collection: 'articles',
+        keys: ['a1'],
+        userId: 'u1',
+      });
+      await coordinator.recordDeprecationOutcome({
+        outcome: { kind: 'deprecated', keysCount: 2, itemsProcessed: 2 },
+        schema,
+        event: 'items.delete',
+        collection: 'articles',
+        keys: ['d1', 'd2'],
+        userId: 'u2',
+      });
+      await timer.runPending();
+
+      const rows = fake.tables.get('localazy_sync_log') ?? [];
+      const entries = JSON.parse((rows[0]?.entries ?? '[]') as string);
+      expect(entries[0].message).toBe('Exported articles content for 1 item (a1)');
+      expect(entries[0].data.user).toBe('u1');
+      expect(entries[0].data.event).toBe('items.update');
+      expect(entries[0].data.outcome).toBe('exported');
+      expect(entries[1].message).toBe('Deprecated keys for articles for 2 items (d1, d2)');
+      expect(entries[1].data.user).toBe('u2');
+      expect(entries[1].data.outcome).toBe('deprecated');
+    });
+  });
+});

--- a/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
+++ b/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
@@ -1,0 +1,465 @@
+import type { MutationOptions, SchemaOverview } from '@directus/types';
+import { AutomatedExportOutcome } from '../../../../common/services/orchestrator/automated-export-pipeline';
+import { AutomatedDeprecationOutcome } from '../../../../common/services/orchestrator/automated-deprecation-pipeline';
+import { SyncLogEntry, SyncLogSession } from '../../../../common/models/collections-data/sync-log';
+import { createSyncLogWriter } from '../../../../common/services/orchestrator/sync-log-writer';
+import type { SyncLogWriter } from '../../../../common/services/orchestrator/ports';
+import { createServerSyncLogStorage } from '../../shared/sync-log-storage';
+import type { ItemsServiceCtor } from '../types/directus-services';
+
+/**
+ * Event_type column value for hook-triggered Automated export bursts. Sits next to
+ * `upload-incremental` and `upload-full` in the `localazy_sync_log` taxonomy; the
+ * module's Activity-page composables (PR 65) map it onto the Export tab. See
+ * `docs/adr/0002-automated-export-burst-coalescing.md`.
+ */
+const BURST_EVENT_TYPE = 'upload-automated';
+
+/**
+ * `initiator` column value carried on every burst session row. Per ADR-0002 the burst
+ * spans both Automated export and Automated deprecation activity across all users —
+ * session-level attribution is fixed to "hook" with `initiator_user = null`. Per-entry
+ * user attribution lives inside each entry's `data.user`.
+ */
+const BURST_INITIATOR = 'hook';
+
+const SYNC_LOG_COLLECTION = 'localazy_sync_log';
+
+/** Default idle window before the burst auto-finalises. */
+const DEFAULT_IDLE_WINDOW_MS = 30_000;
+
+/**
+ * Per-event input the bundle's `hook/index.ts` hands to the coordinator after it has run
+ * the export pipeline and observed the outcome. The coordinator decides — based on the
+ * outcome variant and ADR-0002's Q3 filter — whether to open or extend the burst.
+ */
+export type RecordExportOutcomeInput = {
+  outcome: AutomatedExportOutcome;
+  schema: SchemaOverview;
+  /** Directus event string, e.g. `'items.update'`. Surfaced in the entry's `data.event`. */
+  event: string;
+  /** Directus collection the event fired on (e.g. `'articles'`, `'directus_translations'`). */
+  collection: string;
+  /** Affected item keys (length is the per-event item count for the message line). */
+  keys: string[];
+  /** `accountability.user` id, or `null` if the event ran without an authenticated user. */
+  userId: string | null;
+};
+
+export type RecordDeprecationOutcomeInput = {
+  outcome: AutomatedDeprecationOutcome;
+  schema: SchemaOverview;
+  event: string;
+  collection: string;
+  keys: string[];
+  userId: string | null;
+};
+
+/**
+ * Public surface the hook handler interacts with. Both methods are fire-and-forget from
+ * the handler's perspective — the coordinator owns the open/extend/close lifecycle, the
+ * session id, the idle timer, the lazy orphan sweep, and the appendEntry calls.
+ */
+export type AutomatedExportBurstCoordinator = {
+  recordExportOutcome(input: RecordExportOutcomeInput): Promise<void>;
+  recordDeprecationOutcome(input: RecordDeprecationOutcomeInput): Promise<void>;
+};
+
+/**
+ * Dependency bag for `createAutomatedExportBurstCoordinator`. Required deps stay narrow
+ * (`ItemsService`, `generateId`); the optional ones exist so unit tests can substitute
+ * deterministic timers and clocks without monkey-patching globals.
+ */
+export type AutomatedExportBurstCoordinatorDeps = {
+  ItemsService: ItemsServiceCtor;
+  /** Per-session UUID factory. Production passes `node:crypto`'s `randomUUID`. */
+  generateId: () => string;
+  /** Idle window in ms. Defaults to 30 000 (ADR-0002). */
+  idleWindowMs?: number;
+  /** Clock injection seam — defaults to `Date.now`. Tests pass a fake. */
+  now?: () => number;
+  /** Timer scheduler seam — defaults to global `setTimeout`. */
+  setTimeoutFn?: (callback: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Timer clearer seam — defaults to global `clearTimeout`. */
+  clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+/**
+ * Mutable, lock-protected per-burst state. `seq` stamps each timer scheduling so a stale
+ * timer firing after the burst was extended (or replaced after a close+reopen race)
+ * doesn't accidentally finalise the now-current burst — the timer callback compares its
+ * captured `seq` against the live `currentBurst.seq` and bails when they differ.
+ */
+type BurstState = {
+  sessionId: string;
+  /** Captured from the first event in the burst. Schema rotation mid-burst isn't supported (no production path triggers it). */
+  schema: SchemaOverview;
+  /** Counters rolled into the terminal status + summary on `finalise`. */
+  accumulator: {
+    good: number; // info-level entries (exported / deprecated with keysCount > 0)
+    bad: number; // error-level entries (failed / no-project / payment-disabled / could-not-fetch-import-content)
+    exportedItems: number; // sum of itemsProcessed from `exported` outcomes
+    deprecatedKeys: number; // sum of keysCount from `deprecated` outcomes
+  };
+  /** Active idle-timer handle. Reset on every extend. */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** Sequence number incremented on open + each extend; carried by the timer callback for staleness check. */
+  seq: number;
+};
+
+/**
+ * Idempotent mutex-via-promise-chain. Every state mutation (open / extend / close / sweep)
+ * runs inside `withLock` so the in-memory `currentBurst` ref is read and written
+ * atomically across concurrent hook events. The chain catches errors so a failing call
+ * can't poison the queue for subsequent callers.
+ */
+function makeLock() {
+  let chain: Promise<unknown> = Promise.resolve();
+  return function withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = chain.then(fn, fn);
+    chain = next.catch(() => undefined);
+    return next;
+  };
+}
+
+/**
+ * Derive the terminal `status` + `summary` from a closed burst's accumulator. ADR-0002
+ * Q8: `completed` when every appended entry was info-level, `partial` when there is a
+ * mix, `failed` when every entry was error-level. The 0/0 case is unreachable because
+ * the Q3 filter wouldn't have opened the burst.
+ */
+function finaliseTerminalState(accumulator: BurstState['accumulator']): { status: string; summary: string } {
+  const { good, bad, exportedItems, deprecatedKeys } = accumulator;
+  const eventsCount = good + bad;
+  const exportedLine = exportedItems > 0 ? `Exported ${exportedItems} ${exportedItems === 1 ? 'item' : 'items'}` : '';
+  const deprecatedLine = deprecatedKeys > 0 ? `deprecated ${deprecatedKeys} ${deprecatedKeys === 1 ? 'key' : 'keys'}` : '';
+  const goodParts = [exportedLine, deprecatedLine].filter(Boolean).join(', ');
+
+  if (bad === 0) {
+    return {
+      status: 'completed',
+      summary: `${goodParts || 'No items processed'} across ${eventsCount} ${eventsCount === 1 ? 'event' : 'events'}`,
+    };
+  }
+  if (good === 0) {
+    return {
+      status: 'failed',
+      summary: `All ${bad} ${bad === 1 ? 'event' : 'events'} failed`,
+    };
+  }
+  return {
+    status: 'partial',
+    summary: `${goodParts || 'No items processed'} across ${good} ${good === 1 ? 'event' : 'events'}; ${bad} failed`,
+  };
+}
+
+/**
+ * Format a single milestone entry's `message` field for the Activity-detail UI. The
+ * user-name lookup happens at read-time on the module side (extension of
+ * `use-sync-log-user-names.ts`); the `data.user` field carries the raw id so the
+ * resolver can batch-fetch names alongside the row's `initiator_user`.
+ */
+function formatExportEntryMessage(kind: AutomatedExportOutcome['kind'], collection: string, keys: string[]): string {
+  const keysLabel = keys.length > 0 ? ` for ${keys.length} ${keys.length === 1 ? 'item' : 'items'} (${keys.join(', ')})` : '';
+  const target = `${collection} content${keysLabel}`;
+  switch (kind) {
+    case 'exported':
+      return `Exported ${target}`;
+    case 'failed':
+      return `Failed to export ${target}`;
+    case 'no-project':
+      return `Could not load Localazy project while exporting ${target}`;
+    case 'payment-disabled':
+      return `Sync operations disabled due to payment status while exporting ${target}`;
+    // Filtered-out kinds — shouldn't reach this branch because the Q3 filter skips them.
+    default:
+      return `Exported ${target}`;
+  }
+}
+
+function formatDeprecationEntryMessage(kind: AutomatedDeprecationOutcome['kind'], collection: string, keys: string[]): string {
+  const keysLabel = keys.length > 0 ? ` for ${keys.length} ${keys.length === 1 ? 'item' : 'items'} (${keys.join(', ')})` : '';
+  const target = `${collection}${keysLabel}`;
+  switch (kind) {
+    case 'deprecated':
+      return `Deprecated keys for ${target}`;
+    case 'failed':
+      return `Failed to deprecate ${target}`;
+    case 'no-project':
+      return `Could not load Localazy project while deprecating ${target}`;
+    case 'payment-disabled':
+      return `Sync operations disabled due to payment status while deprecating ${target}`;
+    case 'could-not-fetch-import-content':
+      return `Could not fetch import content while deprecating ${target}`;
+    default:
+      return `Deprecated keys for ${target}`;
+  }
+}
+
+/**
+ * Q3 filter for export outcomes. Returns the per-entry level when the outcome should
+ * open / extend a burst, or `null` to silently drop. Mirrors today's
+ * `outcome-reporters.ts` severity gate: anything `debug` is dropped, anything `info` or
+ * `error` opens a burst.
+ */
+function classifyExportOutcome(outcome: AutomatedExportOutcome): { level: 'info' | 'error'; itemsProcessed: number } | null {
+  switch (outcome.kind) {
+    case 'exported':
+      return { level: 'info', itemsProcessed: outcome.itemsProcessed };
+    case 'failed':
+    case 'no-project':
+    case 'payment-disabled':
+      return { level: 'error', itemsProcessed: 0 };
+    // Silenced: missing-context, export-disabled, nothing-to-export
+    default:
+      return null;
+  }
+}
+
+function classifyDeprecationOutcome(outcome: AutomatedDeprecationOutcome): { level: 'info' | 'error'; itemsProcessed: number } | null {
+  switch (outcome.kind) {
+    case 'deprecated':
+      // ADR-0002 Q3: silenced when nothing matched. The pipeline always invokes
+      // `deprecateLocalazyKeys` even with an empty array (the helper itself short-circuits),
+      // so a zero-keys outcome is just "no actionable activity".
+      if (outcome.itemsProcessed === 0) return null;
+      return { level: 'info', itemsProcessed: outcome.itemsProcessed };
+    case 'failed':
+    case 'no-project':
+    case 'payment-disabled':
+    case 'could-not-fetch-import-content':
+      return { level: 'error', itemsProcessed: 0 };
+    // Silenced: missing-context, deprecation-disabled
+    default:
+      return null;
+  }
+}
+
+/**
+ * Factory for the process-singleton burst coordinator. The returned coordinator captures
+ * the Directus runtime references (`ItemsService`, `generateId`, timers) up front and
+ * exposes a stateful surface — calls to `recordExportOutcome` / `recordDeprecationOutcome`
+ * lazily construct the `SyncLogWriter` against the first event's schema, lazy-sweep
+ * orphaned `in_progress` rows from prior process lifetimes, then open or extend the
+ * current burst.
+ *
+ * Production wires one coordinator at `defineHook` time and shares it across every
+ * action callback. Tests inject deterministic timers + clocks to assert lifecycle
+ * transitions without real-time waits.
+ */
+export function createAutomatedExportBurstCoordinator(deps: AutomatedExportBurstCoordinatorDeps): AutomatedExportBurstCoordinator {
+  const {
+    ItemsService,
+    generateId,
+    idleWindowMs = DEFAULT_IDLE_WINDOW_MS,
+    now = () => Date.now(),
+    setTimeoutFn = (cb, ms) => setTimeout(cb, ms),
+    clearTimeoutFn = (h) => clearTimeout(h),
+  } = deps;
+
+  const withLock = makeLock();
+
+  let writer: SyncLogWriter | null = null;
+  let currentBurst: BurstState | null = null;
+  let hasSwept = false;
+  let nextSeq = 0;
+
+  function getOrCreateWriter(schema: SchemaOverview): SyncLogWriter {
+    if (writer) return writer;
+    writer = createSyncLogWriter({
+      storage: createServerSyncLogStorage(ItemsService, schema),
+      generateId,
+    });
+    return writer;
+  }
+
+  /**
+   * One-shot scan of `localazy_sync_log` for orphan `upload-automated` rows from prior
+   * process lifetimes. Bundle restart mid-burst leaves a row in `status='in_progress'` (the
+   * in-memory timer dies with the process); this sweep finalises any such rows so the
+   * Activity page never shows perpetual in-progress sessions from past lives. Tracked
+   * under `hasSwept` so subsequent events skip the query.
+   */
+  async function sweepOrphans(schema: SchemaOverview): Promise<void> {
+    try {
+      const service = new ItemsService<Partial<SyncLogSession>>(SYNC_LOG_COLLECTION, { schema, accountability: null });
+      const orphans = await service.readByQuery({
+        filter: {
+          event_type: { _eq: BURST_EVENT_TYPE },
+          status: { _eq: 'in_progress' },
+        },
+        fields: ['id'],
+        limit: -1,
+      });
+      const finishedAt = new Date(now()).toISOString();
+      for (const row of orphans) {
+        if (typeof row.id !== 'string') continue;
+        try {
+          await service.updateOne(
+            row.id,
+            {
+              status: 'aborted',
+              finished_at: finishedAt,
+              summary: 'Bundle restarted before burst completed',
+            },
+            { emitEvents: false } as MutationOptions,
+          );
+        } catch {
+          // Best-effort: skip this row, the retention trim will eventually drop it.
+        }
+      }
+    } catch {
+      // Best-effort: if the sweep query fails (transient DB error, schema mid-init,
+      // missing collection on a brand-new install), proceed without sweep. The next
+      // bundle restart will retry.
+    }
+  }
+
+  /**
+   * Finalise the open burst when its idle timer fires. Captures the burst's `seq` at
+   * scheduling time so a late-firing timer (whose burst has since been extended or
+   * replaced) bails without touching the live state.
+   */
+  function scheduleClose(expectedSeq: number): void {
+    if (!currentBurst) return;
+    currentBurst.timer = setTimeoutFn(() => {
+      // Errors must not propagate out of a `setTimeout` callback — that would surface
+      // as an unhandled rejection. Wrap the lock acquisition + finalise in a discarded promise.
+      void withLock(async () => {
+        if (!currentBurst || currentBurst.seq !== expectedSeq || writer === null) return;
+        const burst = currentBurst;
+        currentBurst = null;
+        const { status, summary } = finaliseTerminalState(burst.accumulator);
+        const itemsProcessed = burst.accumulator.exportedItems + burst.accumulator.deprecatedKeys;
+        try {
+          await writer.finish(burst.sessionId, { status, summary, itemsProcessed });
+        } catch {
+          // Writer swallows finish failures itself; the catch here is belt-and-braces in
+          // case the contract ever changes.
+        }
+      }).catch(() => undefined);
+    }, idleWindowMs);
+  }
+
+  /**
+   * Core open/extend/append path shared by both `recordExportOutcome` and
+   * `recordDeprecationOutcome`. Runs under the mutex so two concurrent action callbacks
+   * land their session creation + entry append atomically.
+   */
+  async function appendEntryToBurst(args: {
+    schema: SchemaOverview;
+    level: 'info' | 'error';
+    message: string;
+    data: Record<string, unknown>;
+    exportedItemsDelta: number;
+    deprecatedKeysDelta: number;
+  }): Promise<void> {
+    await withLock(async () => {
+      // Lazy sweep — runs exactly once per coordinator lifetime, on the first actionable
+      // outcome. Skipped on subsequent calls regardless of outcome filtering.
+      if (!hasSwept) {
+        hasSwept = true;
+        await sweepOrphans(args.schema);
+      }
+
+      const writerInstance = getOrCreateWriter(args.schema);
+
+      // Open or extend.
+      if (!currentBurst) {
+        let sessionId: string;
+        try {
+          sessionId = await writerInstance.startSession({
+            eventType: BURST_EVENT_TYPE,
+            initiator: BURST_INITIATOR,
+            initiatorUser: null,
+          });
+        } catch {
+          // Couldn't open the session — best-effort: skip this outcome entirely. The
+          // pipeline already ran and its side effects landed; the Activity-page surface is
+          // strictly observational, so a failed open isn't worth surfacing.
+          return;
+        }
+        currentBurst = {
+          sessionId,
+          schema: args.schema,
+          accumulator: { good: 0, bad: 0, exportedItems: 0, deprecatedKeys: 0 },
+          timer: null,
+          seq: ++nextSeq,
+        };
+      } else {
+        // Extend: clear the prior timer (still pending) before we reschedule.
+        if (currentBurst.timer) {
+          clearTimeoutFn(currentBurst.timer);
+          currentBurst.timer = null;
+        }
+        currentBurst.seq = ++nextSeq;
+      }
+
+      // Update accumulator before scheduling so a contender / read during the burst sees
+      // the most recent counts (the row itself isn't patched mid-flight; the persisted
+      // counter is only written on finalise).
+      if (args.level === 'info') currentBurst.accumulator.good += 1;
+      else currentBurst.accumulator.bad += 1;
+      currentBurst.accumulator.exportedItems += args.exportedItemsDelta;
+      currentBurst.accumulator.deprecatedKeys += args.deprecatedKeysDelta;
+
+      const entry: SyncLogEntry = {
+        timestamp: new Date(now()).toISOString(),
+        level: args.level,
+        message: args.message,
+        data: args.data,
+      };
+      // Awaited inside the lock so a contender / test reading the row right after the
+      // hook callback returns sees the entry already on disk. The writer's per-session
+      // promise chain still serialises this against any other in-flight appends (e.g.
+      // late-arriving completions from a previous coordinator call site), so order is
+      // preserved either way; the await just shifts the visibility boundary.
+      await writerInstance.appendEntry(currentBurst.sessionId, entry);
+
+      // Reschedule the idle close.
+      scheduleClose(currentBurst.seq);
+    });
+  }
+
+  return {
+    async recordExportOutcome(input) {
+      const classification = classifyExportOutcome(input.outcome);
+      if (!classification) return;
+      const message = formatExportEntryMessage(input.outcome.kind, input.collection, input.keys);
+      await appendEntryToBurst({
+        schema: input.schema,
+        level: classification.level,
+        message,
+        data: {
+          user: input.userId,
+          event: input.event,
+          collection: input.collection,
+          keys: input.keys,
+          outcome: input.outcome.kind,
+        },
+        exportedItemsDelta: classification.itemsProcessed,
+        deprecatedKeysDelta: 0,
+      });
+    },
+
+    async recordDeprecationOutcome(input) {
+      const classification = classifyDeprecationOutcome(input.outcome);
+      if (!classification) return;
+      const message = formatDeprecationEntryMessage(input.outcome.kind, input.collection, input.keys);
+      await appendEntryToBurst({
+        schema: input.schema,
+        level: classification.level,
+        message,
+        data: {
+          user: input.userId,
+          event: input.event,
+          collection: input.collection,
+          keys: input.keys,
+          outcome: input.outcome.kind,
+        },
+        exportedItemsDelta: 0,
+        deprecatedKeysDelta: classification.itemsProcessed,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Activity-page Automated-export tracking feature (Phase 1 = PR 62/#80, Phase 2 = PR 63/#81). Adds the in-process burst coordinator that converts hook-triggered Automated export / Automated deprecation pipeline outcomes into coalesced \`localazy_sync_log\` rows. See \`docs/adr/0002-automated-export-burst-coalescing.md\` for the design rationale.

### What the new \`automated-export-burst-coordinator.ts\` owns

- **The current-burst ref + idle timer** (default 30 s; injectable for tests).
- **A promise-chain mutex** around the open / extend / close transitions so concurrent action callbacks land their session creation + entry append atomically.
- **A sequence-stamped timer** so a late-firing scheduled close (whose burst was extended or replaced in the meantime) bails without touching the live state.
- **The Q3 outcome filter** — \`nothing-to-export\`, \`missing-context\`, \`export-disabled\`, \`deprecation-disabled\`, and zero-keys \`deprecated\` outcomes are silently dropped; everything else opens or extends a burst.
- **Per-entry message format + structured \`data\` blob** (\`user\`, \`event\`, \`collection\`, \`keys\`, \`outcome\` kind) for read-time name resolution in PR 65.
- **Terminal status + summary derivation** on close — \`completed\` / \`partial\` / \`failed\` with separate \`exported\` / \`deprecated\` counters in the summary line per the Q8 decision.
- **Lazy sweep** of orphan \`upload-automated\` \`in_progress\` rows on the first event after bundle init, finalised as \`aborted\` with summary \`\"Bundle restarted before burst completed\"\`.

### Integration into \`hook/index.ts\`

The hook instantiates one coordinator at \`defineHook\` time and calls \`recordExportOutcome\` / \`recordDeprecationOutcome\` on each action callback, after the existing \`reportAutomated…Outcome\` calls (**additive, not replacing** — Directus logger output stays as before; the coordinator just adds the persistent Activity-page surface).

The pipelines themselves are unchanged — they stay pure, returning discriminated outcomes that the bundle-edge coordinator interprets.

## Test plan

- [x] \`npm run check\` — lint + format + typecheck + **566 tests pass** (up 20 from Phase 2's 546 baseline).
- [x] \`npm run build\` — production build of both extensions succeeds.
- [x] New \`automated-export-burst-coordinator.test.ts\` covers:
  - Q3 outcome filter (\`exported\` / \`failed\` / \`no-project\` / \`payment-disabled\` open a burst; \`nothing-to-export\` / \`missing-context\` / \`export-disabled\` and zero-keys \`deprecated\` are silently dropped).
  - Coalescing within the idle window (multiple events extend the same burst; timer fires open a new one).
  - Terminal status derivation (\`completed\` / \`partial\` / \`failed\`) and summary formatting for export-only / deprecation-only / mixed bursts.
  - Lazy sweep of orphan \`in_progress\` \`upload-automated\` rows; runs only once per coordinator lifetime; leaves other \`event_type\`s alone.
  - Per-entry message format + \`data\` blob shape.
- [x] Existing \`hook/index.test.ts\` continues to pass (the coordinator silently no-ops against the existing test's \`vi.fn()\` ItemsService fake, which lets prior pipeline-composition assertions stay untouched).

## What lands next

- **PR 65** (Phase 4): module-side Activity-page UI — \`tabForEventType('upload-automated')\` → Export tab, \`formatEventType('upload-automated')\` → \"Automated export\", Upload→Export tab rename per CONTEXT.md, per-entry user-name resolution in \`use-sync-log-user-names.ts\`.
- **PR 66** (Phase 5): end-to-end manual smoke test against a local Directus instance + any follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)