### PR TITLE
PR 65/N: surface burst sessions on the Activity page

### DIFF
--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -48,7 +48,7 @@
 
       <div class="sessions-tabs">
         <v-tabs v-model="activeTabModel">
-          <v-tab value="upload">Upload</v-tab>
+          <v-tab value="upload">Export</v-tab>
           <v-tab value="download">Download</v-tab>
           <v-tab value="webhook">Webhooks</v-tab>
         </v-tabs>

--- a/extensions/module/src/ActivityDetail.vue
+++ b/extensions/module/src/ActivityDetail.vue
@@ -33,6 +33,7 @@
                 <v-icon :name="iconForLevel(entry.level)" small class="entry-icon" />
                 <span class="entry-timestamp">{{ formatTime(entry.timestamp) }}</span>
                 <span class="entry-message">{{ entry.message }}</span>
+                <span v-if="entryUser(entry)" class="entry-user">by {{ entryUser(entry) }}</span>
               </div>
               <pre v-if="entry.data" class="entry-data">{{ JSON.stringify(entry.data, null, 2) }}</pre>
             </div>
@@ -51,7 +52,8 @@ import SessionMetadata from './components/Activity/SessionMetadata.vue';
 import { useLocalazySyncLogStore } from './stores/localazy-sync-log-store';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useSyncLogEntries } from './composables/use-sync-log-entries';
-import type { SyncLogSession } from '../../common/models/collections-data/sync-log';
+import { useSyncLogUserNames } from './composables/use-sync-log-user-names';
+import type { SyncLogEntry, SyncLogSession } from '../../common/models/collections-data/sync-log';
 
 const route = useRoute();
 const sessionId = computed(() => String(route.params.sessionId || ''));
@@ -68,6 +70,19 @@ const breadcrumb = computed(() => [
 ]);
 
 const { entries, formatTime, iconForLevel } = useSyncLogEntries(session);
+
+// Feed the single loaded session into the user-name resolver so per-entry `data.user`
+// ids get batch-fetched alongside the session-level `initiator_user`. The resolver
+// returns `null` until the fetch settles; the template guards on a non-null result so
+// the "by …" suffix only renders once we have something useful to show.
+const sessionsForResolver = computed<SyncLogSession[]>(() => (session.value ? [session.value] : []));
+const { lookupUserName } = useSyncLogUserNames(sessionsForResolver);
+
+function entryUser(entry: SyncLogEntry): string | null {
+  const candidate = entry.data?.user;
+  if (typeof candidate !== 'string' || candidate.length === 0) return null;
+  return lookupUserName(candidate);
+}
 
 onBeforeMount(async () => {
   await boot();
@@ -162,6 +177,13 @@ onBeforeMount(async () => {
 .entry-message {
   font-size: 13px;
   color: var(--theme--foreground);
+}
+
+.entry-user {
+  font-size: 12px;
+  color: var(--theme--foreground-subdued);
+  font-style: italic;
+  margin-left: 4px;
 }
 
 .entry-info .entry-icon {

--- a/extensions/module/src/composables/use-activity-log.test.ts
+++ b/extensions/module/src/composables/use-activity-log.test.ts
@@ -33,6 +33,7 @@ describe('tabForEventType', () => {
   it('routes upload-* to upload', () => {
     expect(tabForEventType('upload-incremental')).toBe('upload');
     expect(tabForEventType('upload-full')).toBe('upload');
+    expect(tabForEventType('upload-automated')).toBe('upload');
   });
 
   it('routes download-* to download', () => {
@@ -194,8 +195,11 @@ describe('formatEventType', () => {
   it('maps each known event type to a human-readable label', () => {
     expect(formatEventType('download-incremental')).toBe('Incremental download');
     expect(formatEventType('download-full')).toBe('Full download');
-    expect(formatEventType('upload-incremental')).toBe('Incremental upload');
-    expect(formatEventType('upload-full')).toBe('Full upload');
+    // user-facing copy says "export" per CONTEXT.md's resolved upload/export ambiguity;
+    // the persisted column keeps `upload-*` to avoid a coordinated migration.
+    expect(formatEventType('upload-incremental')).toBe('Incremental export');
+    expect(formatEventType('upload-full')).toBe('Full export');
+    expect(formatEventType('upload-automated')).toBe('Automated export');
     expect(formatEventType('webhook')).toBe('Webhook');
   });
 

--- a/extensions/module/src/composables/use-activity-log.ts
+++ b/extensions/module/src/composables/use-activity-log.ts
@@ -33,8 +33,14 @@ export function tabForEventType(eventType: string): ActivityTab {
 /**
  * Free-string `event_type` → human-readable label. Mirrors the values the orchestrator
  * + webhook flow persist (`download-incremental`, `download-full`, `upload-incremental`,
- * `upload-full`, `webhook`). Unknown values pass through verbatim so a future
- * `event_type` doesn't disappear from the UI before we've taught the mapping. Pure.
+ * `upload-full`, `upload-automated`, `webhook`). Unknown values pass through verbatim so
+ * a future `event_type` doesn't disappear from the UI before we've taught the mapping.
+ *
+ * Note: user-facing copy says "export" per CONTEXT.md's resolved upload/export
+ * ambiguity; the column values keep `upload-*` because the rename is column-coordinated
+ * (out of scope here).
+ *
+ * Pure.
  */
 export function formatEventType(eventType: string): string {
   switch (eventType) {
@@ -43,9 +49,11 @@ export function formatEventType(eventType: string): string {
     case 'download-full':
       return 'Full download';
     case 'upload-incremental':
-      return 'Incremental upload';
+      return 'Incremental export';
     case 'upload-full':
-      return 'Full upload';
+      return 'Full export';
+    case 'upload-automated':
+      return 'Automated export';
     case 'webhook':
       return 'Webhook';
     default:

--- a/extensions/module/src/composables/use-sync-log-user-names.test.ts
+++ b/extensions/module/src/composables/use-sync-log-user-names.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { collectEntryUserIds } from './use-sync-log-user-names';
+
+describe('collectEntryUserIds', () => {
+  it('returns no ids for null / undefined / empty input', () => {
+    const sink = new Set<string>();
+    collectEntryUserIds(null, sink);
+    collectEntryUserIds(undefined, sink);
+    collectEntryUserIds('', sink);
+    expect(sink.size).toBe(0);
+  });
+
+  it('returns no ids for malformed JSON', () => {
+    const sink = new Set<string>();
+    collectEntryUserIds('{not json', sink);
+    expect(sink.size).toBe(0);
+  });
+
+  it('returns no ids for a non-array payload', () => {
+    const sink = new Set<string>();
+    collectEntryUserIds('{"foo":"bar"}', sink);
+    expect(sink.size).toBe(0);
+  });
+
+  it("collects each entry's data.user id, deduped via the Set sink", () => {
+    const sink = new Set<string>();
+    collectEntryUserIds(
+      JSON.stringify([
+        { timestamp: 't1', level: 'info', message: 'a', data: { user: 'u-1' } },
+        { timestamp: 't2', level: 'info', message: 'b', data: { user: 'u-2' } },
+        { timestamp: 't3', level: 'info', message: 'c', data: { user: 'u-1' } }, // dup
+      ]),
+      sink,
+    );
+    expect(Array.from(sink).sort()).toEqual(['u-1', 'u-2']);
+  });
+
+  it('skips entries with a missing data envelope or a non-string user field', () => {
+    const sink = new Set<string>();
+    collectEntryUserIds(
+      JSON.stringify([
+        { timestamp: 't1', level: 'info', message: 'no data' },
+        { timestamp: 't2', level: 'info', message: 'null user', data: { user: null } },
+        { timestamp: 't3', level: 'info', message: 'empty user', data: { user: '' } },
+        { timestamp: 't4', level: 'info', message: 'valid', data: { user: 'u-1' } },
+      ]),
+      sink,
+    );
+    expect(Array.from(sink)).toEqual(['u-1']);
+  });
+
+  it('appends to an existing sink without clearing it', () => {
+    const sink = new Set<string>(['pre-existing']);
+    collectEntryUserIds(JSON.stringify([{ timestamp: 't', level: 'info', message: 'a', data: { user: 'u-1' } }]), sink);
+    expect(Array.from(sink).sort()).toEqual(['pre-existing', 'u-1']);
+  });
+});

--- a/extensions/module/src/composables/use-sync-log-user-names.ts
+++ b/extensions/module/src/composables/use-sync-log-user-names.ts
@@ -1,6 +1,6 @@
 import { ref, watch, type Ref } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
-import type { SyncLogSession } from '../../../common/models/collections-data/sync-log';
+import type { SyncLogEntry, SyncLogSession } from '../../../common/models/collections-data/sync-log';
 
 /**
  * Subset of Directus' `directus_users` row we read here. The columns are intentionally
@@ -21,10 +21,40 @@ function pickName(user: UserRow): string | null {
 }
 
 /**
- * Resolves the human name behind each `localazy_sync_log.initiator` id referenced in the
- * supplied sessions. Watches the sessions ref, batches one `/users?filter[id][_in]=...`
- * fetch per fresh set of unmapped ids, and caches the result so subsequent reloads
- * don't re-fetch users already known.
+ * Walk a single session row's `entries` JSON and collect every per-entry
+ * `data.user` id. The burst coordinator (PR 64) writes one entry per pipeline run with a
+ * structured `data: { user, event, collection, keys, outcome }`; this helper extracts
+ * the user ids so they participate in the same batched fetch the session-level
+ * `initiator_user` already drives.
+ *
+ * Tolerant of malformed rows: a JSON-parse failure, a non-array payload, or an entry
+ * missing the `data` envelope returns no ids rather than crashing the resolver.
+ */
+export function collectEntryUserIds(entriesJson: string | null | undefined, sink: Set<string>): void {
+  if (!entriesJson) return;
+  try {
+    const parsed: unknown = JSON.parse(entriesJson);
+    if (!Array.isArray(parsed)) return;
+    for (const entry of parsed as SyncLogEntry[]) {
+      const data = entry.data;
+      if (!data) continue;
+      const candidate = data.user;
+      if (typeof candidate === 'string' && candidate.length > 0) {
+        sink.add(candidate);
+      }
+    }
+  } catch {
+    // Malformed entries column — fall through. The detail view's own parse will hit
+    // the same error and render the empty-state.
+  }
+}
+
+/**
+ * Resolves the human name behind each Directus user id referenced in the supplied
+ * sessions — both the session-level `initiator` / `initiator_user` and every per-entry
+ * `data.user` inside `entries`. Watches the sessions ref, batches one
+ * `/users?filter[id][_in]=...` fetch per fresh set of unmapped ids, and caches the
+ * result so subsequent reloads don't re-fetch users already known.
  *
  * Failures are absorbed: any id that can't be resolved (request failed, user deleted,
  * permissions blocked) is recorded as `null` in the cache so we don't loop and
@@ -50,6 +80,14 @@ export function useSyncLogUserNames(sessions: Ref<SyncLogSession[]>) {
         if (candidate && !(candidate in namesById.value)) {
           idsToFetch.add(candidate);
         }
+        // Per-entry user ids from burst sessions (`upload-automated`) or any future
+        // event_type that writes them. Filtered against the cache so a row whose entry
+        // ids are already resolved doesn't enqueue them again.
+        const entryIds = new Set<string>();
+        collectEntryUserIds(row.entries, entryIds);
+        entryIds.forEach((id) => {
+          if (!(id in namesById.value)) idsToFetch.add(id);
+        });
       }
       if (idsToFetch.size === 0) return;
       // Optimistically claim the ids so a second `watch` tick (e.g. concurrent reload)


### PR DESCRIPTION
## Summary

Phase 4 of the Activity-page Automated-export tracking feature (Phases 1–3 = PRs #80, #81, #82). The bundle now writes coalesced \`upload-automated\` burst rows to \`localazy_sync_log\`; this PR wires the module-side UI to render them.

### Three changes, all small

- **\`formatEventType\` updated.** Learns the new \`upload-automated\` key (\"Automated export\") and the existing upload labels are renamed (\"Incremental export\", \"Full export\") per CONTEXT.md's resolved upload/export ambiguity. The Activity page's first tab label flips from \"Upload\" to \"Export\" to match — the tab \`value\` stays \`upload\` so \`tabForEventType\` and the persisted \`event_type\` column don't need to change.
- **\`use-sync-log-user-names.ts\` extended.** Its batched \`/users?filter[id][_in]=...\` resolution now also walks each row's \`entries\` JSON and collects per-entry \`data.user\` ids (the burst coordinator writes one such id per pipeline run). Resolution is shared with session-level \`initiator_user\`, so a single fetch covers both granularities.
- **\`ActivityDetail.vue\` renders user attribution.** Feeds the loaded session into the user-name resolver and renders \`by {resolved name}\` next to each entry's message, derived from \`entry.data.user\`. The \"by …\" suffix is hidden until the fetch settles so we never show a raw UUID.

\`tabForEventType\` works unchanged — anything starting with \`upload-\` already routes to the Upload (now Export) tab. The persisted column shape is unchanged.

## Test plan

- [x] \`npm run check\` — lint + format + typecheck + **572 tests pass** (up 6 from Phase 3's 566).
- [x] \`npm run build\` — production build of both extensions succeeds.
- [x] Updated \`use-activity-log.test.ts\`: \`tabForEventType('upload-automated')\` → \`'upload'\`, \`formatEventType\` assertions updated for the rename and the new key.
- [x] New \`use-sync-log-user-names.test.ts\`: six cases covering the \`collectEntryUserIds\` helper (null / undefined / empty / malformed JSON / non-array tolerance; dedupe via the Set sink; skip entries missing the \`data\` envelope or with non-string \`user\`; append to an existing sink without clearing).

## What lands next

- **PR 66** (Phase 5): end-to-end manual smoke test against a local Directus instance plus any cleanup follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)