### PR TITLE
PR 66/N: cleanup follow-ups from the burst-coordinator review

### DIFF
--- a/extensions/module/src/composables/use-activity-log.test.ts
+++ b/extensions/module/src/composables/use-activity-log.test.ts
@@ -213,6 +213,10 @@ describe('formatInitiator', () => {
     expect(formatInitiator('webhook')).toBe('Triggered by webhook');
   });
 
+  it('returns the automated label for the literal "hook" initiator (burst sessions)', () => {
+    expect(formatInitiator('hook')).toBe('Triggered automatically');
+  });
+
   it('returns the resolved user name when the lookup succeeds', () => {
     const lookup = (id: string) => (id === 'user-1' ? 'Alice' : null);
     expect(formatInitiator('user-1', lookup)).toBe('Triggered by Alice');

--- a/extensions/module/src/composables/use-activity-log.ts
+++ b/extensions/module/src/composables/use-activity-log.ts
@@ -64,10 +64,13 @@ export function formatEventType(eventType: string): string {
 /**
  * `initiator` → human-readable label. Callers should populate `initiator` (the
  * orchestrator does so for every row it writes); an empty value falls through to the
- * generic "Triggered by user" label rather than crashing. Three input shapes:
+ * generic "Triggered by user" label rather than crashing. Four input shapes:
  *
  * - The literal `'webhook'` → `"Triggered by webhook"`. Both the webhook handler's
  *   early-reject rows and the orchestrator's webhook-driven runs persist this value.
+ * - The literal `'hook'` → `"Triggered automatically"`. The burst coordinator writes
+ *   this for Automated export bursts; per-entry user attribution lives inside the
+ *   entries blob, not at the session level.
  * - A Directus user id WITH a successful `lookupUserName` resolve → `"Triggered by <name>"`.
  *   Only the currently-logged-in user's name is reachable synchronously; other ids fall
  *   through to the generic label.
@@ -78,6 +81,7 @@ export function formatEventType(eventType: string): string {
  */
 export function formatInitiator(initiator: string, lookupUserName?: (userId: string) => string | null): string {
   if (initiator === 'webhook') return 'Triggered by webhook';
+  if (initiator === 'hook') return 'Triggered automatically';
   const resolved = lookupUserName?.(initiator);
   if (resolved) return `Triggered by ${resolved}`;
   return 'Triggered by user';

--- a/extensions/module/src/composables/use-sync-log-user-names.ts
+++ b/extensions/module/src/composables/use-sync-log-user-names.ts
@@ -72,11 +72,16 @@ export function useSyncLogUserNames(sessions: Ref<SyncLogSession[]>) {
     sessions,
     async (rows) => {
       const idsToFetch = new Set<string>();
+      // Reserved `initiator` markers — these are session-level annotations that the
+      // formatter handles directly (`'webhook'` → "Triggered by webhook", `'hook'` →
+      // "Triggered automatically"), not Directus user ids. Excluded from the fetch so we
+      // don't enqueue `/users?id=hook` requests that would always fail.
+      const NON_USER_INITIATORS = new Set(['webhook', 'hook']);
       for (const row of rows) {
         // Prefer the m2o column. Fall back to the free `initiator` string when it
-        // doesn't carry the `'webhook'` marker — older rows may have been written
-        // before `initiator_user` was always populated alongside.
-        const candidate = row.initiator_user ?? (row.initiator !== 'webhook' ? row.initiator : null);
+        // isn't one of the reserved markers — older rows may have been written before
+        // `initiator_user` was always populated alongside.
+        const candidate = row.initiator_user ?? (NON_USER_INITIATORS.has(row.initiator) ? null : row.initiator);
         if (candidate && !(candidate in namesById.value)) {
           idsToFetch.add(candidate);
         }

--- a/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.test.ts
+++ b/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.test.ts
@@ -525,9 +525,13 @@ describe('createAutomatedExportBurstCoordinator', () => {
       expect(entries[0].data.user).toBe('u1');
       expect(entries[0].data.event).toBe('items.update');
       expect(entries[0].data.outcome).toBe('exported');
-      expect(entries[1].message).toBe('Deprecated keys for articles for 2 items (d1, d2)');
+      // Deprecation messages count Localazy keys (operationally meaningful), not the
+      // Directus item deletions that triggered them. Item ids stay in `data.keys` for
+      // debugging.
+      expect(entries[1].message).toBe('Deprecated 2 keys in articles (triggered by deletion of 2 items)');
       expect(entries[1].data.user).toBe('u2');
       expect(entries[1].data.outcome).toBe('deprecated');
+      expect(entries[1].data.keys).toEqual(['d1', 'd2']);
     });
   });
 });

--- a/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
+++ b/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
@@ -92,8 +92,6 @@ export type AutomatedExportBurstCoordinatorDeps = {
  */
 type BurstState = {
   sessionId: string;
-  /** Captured from the first event in the burst. Schema rotation mid-burst isn't supported (no production path triggers it). */
-  schema: SchemaOverview;
   /** Counters rolled into the terminal status + summary on `finalise`. */
   accumulator: {
     good: number; // info-level entries (exported / deprecated with keysCount > 0)
@@ -177,22 +175,28 @@ function formatExportEntryMessage(kind: AutomatedExportOutcome['kind'], collecti
   }
 }
 
-function formatDeprecationEntryMessage(kind: AutomatedDeprecationOutcome['kind'], collection: string, keys: string[]): string {
-  const keysLabel = keys.length > 0 ? ` for ${keys.length} ${keys.length === 1 ? 'item' : 'items'} (${keys.join(', ')})` : '';
-  const target = `${collection}${keysLabel}`;
-  switch (kind) {
+/**
+ * The `outcome` carries `keysCount` (Localazy keys deprecated) for the `'deprecated'`
+ * variant; that's the operationally meaningful figure, not the count of Directus items
+ * deleted. A single item deletion can deprecate multiple Localazy keys (one per
+ * translatable field), so surfacing the deletion count here would underreport. Item ids
+ * still live in `data.keys` on the entry for debugging.
+ */
+function formatDeprecationEntryMessage(outcome: AutomatedDeprecationOutcome, collection: string, keys: string[]): string {
+  const itemSuffix = keys.length > 0 ? ` (triggered by deletion of ${keys.length} ${keys.length === 1 ? 'item' : 'items'})` : '';
+  switch (outcome.kind) {
     case 'deprecated':
-      return `Deprecated keys for ${target}`;
+      return `Deprecated ${outcome.keysCount} ${outcome.keysCount === 1 ? 'key' : 'keys'} in ${collection}${itemSuffix}`;
     case 'failed':
-      return `Failed to deprecate ${target}`;
+      return `Failed to deprecate keys in ${collection}${itemSuffix}`;
     case 'no-project':
-      return `Could not load Localazy project while deprecating ${target}`;
+      return `Could not load Localazy project while deprecating keys in ${collection}${itemSuffix}`;
     case 'payment-disabled':
-      return `Sync operations disabled due to payment status while deprecating ${target}`;
+      return `Sync operations disabled due to payment status while deprecating keys in ${collection}${itemSuffix}`;
     case 'could-not-fetch-import-content':
-      return `Could not fetch import content while deprecating ${target}`;
+      return `Could not fetch import content while deprecating keys in ${collection}${itemSuffix}`;
     default:
-      return `Deprecated keys for ${target}`;
+      return `Deprecated keys in ${collection}${itemSuffix}`;
   }
 }
 
@@ -381,7 +385,6 @@ export function createAutomatedExportBurstCoordinator(deps: AutomatedExportBurst
         }
         currentBurst = {
           sessionId,
-          schema: args.schema,
           accumulator: { good: 0, bad: 0, exportedItems: 0, deprecatedKeys: 0 },
           timer: null,
           seq: ++nextSeq,
@@ -445,7 +448,7 @@ export function createAutomatedExportBurstCoordinator(deps: AutomatedExportBurst
     async recordDeprecationOutcome(input) {
       const classification = classifyDeprecationOutcome(input.outcome);
       if (!classification) return;
-      const message = formatDeprecationEntryMessage(input.outcome.kind, input.collection, input.keys);
+      const message = formatDeprecationEntryMessage(input.outcome, input.collection, input.keys);
       await appendEntryToBurst({
         schema: input.schema,
         level: classification.level,


### PR DESCRIPTION
## Summary

Four small fixes spotted during the post-merge review of PRs 62-65:

- **\`formatInitiator\` now handles the \`'hook'\` marker** the same way it handles \`'webhook'\` — burst sessions render \"Triggered automatically\" instead of falling through to the generic \"Triggered by user\" label after a wasted lookup.
- **\`useSyncLogUserNames\` excludes both reserved markers** from the candidate id set, so the batched \`/users?filter[id][_in]=...\` fetch doesn't enqueue them as ids. Pre-fix the \`'hook'\` string was silently retried on every Activity reload.
- **Dead \`schema\` field removed from \`BurstState\`** — captured but never read; the schema lives on the lazily-constructed \`SyncLogWriter\` and is passed to \`sweepOrphans\` directly.
- **Deprecation entry messages reworded.** Previously read \"Deprecated keys for articles for 2 items (k1, k2)\" — the double \"for\" was awkward and the count was Directus items deleted, not Localazy keys deprecated (which is the operationally meaningful figure). Now reads \"Deprecated N keys in articles (triggered by deletion of M items)\" where N is \`outcome.keysCount\` and M is the event's keys array length. Item ids stay in \`data.keys\` for debugging.

No behavioural change to the open/extend/close lifecycle, the Q3 outcome filter, or the storage adapter.

## Test plan

- [x] \`npm run check\` — lint + format + typecheck + 573 tests pass (up 1 from Phase 4's 572 with the new \`formatInitiator('hook')\` case).
- [x] \`npm run build\` — production build of both extensions succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)