### PR TITLE
PR 67/N: Activity page → 2 tabs + Triggered by filter

### DIFF
--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -34,6 +34,10 @@
           <label class="filter-label">Status</label>
           <v-select v-model="statusFilter" :items="STATUS_OPTIONS" multiple placeholder="All statuses" />
         </div>
+        <div class="filter-field initiator-field">
+          <label class="filter-label">Triggered by</label>
+          <v-select v-model="initiatorFilter" :items="INITIATOR_OPTIONS" multiple placeholder="All triggers" />
+        </div>
         <div class="date-range">
           <div class="filter-field">
             <label class="filter-label">From</label>
@@ -49,8 +53,7 @@
       <div class="sessions-tabs">
         <v-tabs v-model="activeTabModel">
           <v-tab value="upload">Export</v-tab>
-          <v-tab value="download">Download</v-tab>
-          <v-tab value="webhook">Webhooks</v-tab>
+          <v-tab value="download">Import</v-tab>
         </v-tabs>
       </div>
 
@@ -129,12 +132,23 @@ function onSortPreferencesChange(next: SortPreferences) {
   }, 600);
 }
 
-const { activeTab, statusFilter, dateFrom, dateTo, page, totalPages, currentSort, setSort, filteredSessions, paginatedSessions } =
-  useActivityLog({
-    sessions,
-    initialSortPreferences,
-    onSortPreferencesChange,
-  });
+const {
+  activeTab,
+  statusFilter,
+  initiatorFilter,
+  dateFrom,
+  dateTo,
+  page,
+  totalPages,
+  currentSort,
+  setSort,
+  filteredSessions,
+  paginatedSessions,
+} = useActivityLog({
+  sessions,
+  initialSortPreferences,
+  onSortPreferencesChange,
+});
 
 // `<v-select :items>` shape: `{ text, value }`. The statuses mirror StatusLabel.vue's
 // known set; an unknown status read from disk still passes through the filter (the
@@ -146,6 +160,17 @@ const STATUS_OPTIONS = [
   { text: 'Aborted', value: 'aborted' },
   { text: 'Skipped', value: 'skipped' },
   { text: 'In progress', value: 'in_progress' },
+];
+
+// Two-way classification — see `classifyInitiator` in use-activity-log.ts. "Automation"
+// covers hook bursts (`initiator='hook'`) and inbound webhooks (`initiator='webhook'`);
+// "User" covers UI-triggered runs (Directus user-id initiators). Option text uses
+// nouns rather than adjectives so the "Triggered by: <option>" phrasing reads
+// naturally in the dropdown context. The persisted `InitiatorKind` value
+// ('automated'/'manual') stays unchanged.
+const INITIATOR_OPTIONS = [
+  { text: 'Automation', value: 'automated' },
+  { text: 'User', value: 'manual' },
 ];
 
 // Directus' `<v-tabs>` is declared as a single-select group (`multiple: false`) but
@@ -278,6 +303,12 @@ onBeforeMount(() => {
   min-width: 240px;
   /* Match the date picker's 40px activator height — Directus form components
      pick this variable up from the surrounding scope. */
+  --theme--form--field--input--height: 40px;
+}
+
+.initiator-field {
+  flex: 0 0 200px;
+  min-width: 200px;
   --theme--form--field--input--height: 40px;
 }
 

--- a/extensions/module/src/components/Activity/SessionMetadata.vue
+++ b/extensions/module/src/components/Activity/SessionMetadata.vue
@@ -17,7 +17,7 @@
       <div class="metadata-value">{{ formatDuration(session) }}</div>
     </div>
     <div class="metadata-cell">
-      <div class="metadata-label">Initiated by</div>
+      <div class="metadata-label">Triggered by</div>
       <div class="metadata-value">{{ session.initiator }}</div>
     </div>
     <div class="metadata-cell">

--- a/extensions/module/src/components/Activity/SessionsTable.vue
+++ b/extensions/module/src/components/Activity/SessionsTable.vue
@@ -79,12 +79,12 @@ const emit = defineEmits<{
   (event: 'update:page', page: number): void;
 }>();
 
-// Order matches Strapi's layout: Status / Started at / Duration / Initiator / Summary.
+// Order matches Strapi's layout: Status / Started at / Duration / Triggered by / Summary.
 const columns: Array<{ key: SortKey; label: string }> = [
   { key: 'status', label: 'Status' },
   { key: 'started_at', label: 'Started at' },
   { key: 'duration', label: 'Duration' },
-  { key: 'initiator', label: 'Initiated by' },
+  { key: 'initiator', label: 'Triggered by' },
   { key: 'summary', label: 'Summary' },
 ];
 </script>

--- a/extensions/module/src/composables/use-activity-log.test.ts
+++ b/extensions/module/src/composables/use-activity-log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  classifyInitiator,
   compareSessions,
   filterSessions,
   formatDuration,
@@ -30,20 +31,45 @@ const baseSession: SyncLogSession = {
 const make = (overrides: Partial<SyncLogSession>): SyncLogSession => ({ ...baseSession, ...overrides });
 
 describe('tabForEventType', () => {
-  it('routes upload-* to upload', () => {
+  it('routes upload-* to upload (Export tab)', () => {
     expect(tabForEventType('upload-incremental')).toBe('upload');
     expect(tabForEventType('upload-full')).toBe('upload');
     expect(tabForEventType('upload-automated')).toBe('upload');
   });
 
-  it('routes download-* to download', () => {
+  it('routes download-* to download (Import tab)', () => {
     expect(tabForEventType('download-incremental')).toBe('download');
     expect(tabForEventType('download-full')).toBe('download');
   });
 
-  it('routes webhook and unknown values to webhook', () => {
-    expect(tabForEventType('webhook')).toBe('webhook');
-    expect(tabForEventType('manual-override')).toBe('webhook');
+  // `'webhook'` is inbound Localazy → Directus and semantically a download; routing
+  // it to the Import tab is the simplification PR 67 introduces. The Initiator filter
+  // is where users distinguish webhook-driven runs from UI-driven ones.
+  it('routes webhook to download (Import tab)', () => {
+    expect(tabForEventType('webhook')).toBe('download');
+  });
+
+  it('routes unknown event types to download as the safe fallback', () => {
+    expect(tabForEventType('manual-override')).toBe('download');
+    expect(tabForEventType('some-future-event')).toBe('download');
+  });
+});
+
+describe('classifyInitiator', () => {
+  it("classifies the reserved 'hook' and 'webhook' markers as automated", () => {
+    expect(classifyInitiator('hook')).toBe('automated');
+    expect(classifyInitiator('webhook')).toBe('automated');
+  });
+
+  it('classifies a Directus user UUID as manual', () => {
+    expect(classifyInitiator('c1edb242-a6d8-43ff-82c9-b5eebc39595a')).toBe('manual');
+  });
+
+  it('classifies a non-UUID, non-reserved string as automated (defensive default)', () => {
+    // Future markers — anything system-driven that hasn't been added to the reserved
+    // set yet — default to automated rather than misclassifying as user activity.
+    expect(classifyInitiator('scheduled')).toBe('automated');
+    expect(classifyInitiator('')).toBe('automated');
   });
 });
 
@@ -66,29 +92,54 @@ describe('formatDuration', () => {
 });
 
 describe('filterSessions', () => {
+  // Initiator column in production carries either a Directus user UUID (manual runs)
+  // or one of the reserved markers `'webhook'` / `'hook'` (automated runs). The fixture
+  // mirrors that so the new Initiator filter classifies rows as it would in real data.
+  const ALICE = '00000000-0000-4000-8000-000000000001';
+  const BOB = '00000000-0000-4000-8000-000000000002';
   const sessions: SyncLogSession[] = [
-    make({ id: '1', event_type: 'upload-incremental', initiator: 'alice', status: 'completed' }),
-    make({ id: '2', event_type: 'upload-full', initiator: 'bob', status: 'failed' }),
-    make({ id: '3', event_type: 'download-incremental', initiator: 'alice', status: 'skipped' }),
-    make({ id: '4', event_type: 'webhook', initiator: 'webhook', status: 'completed' }),
+    make({ id: '1', event_type: 'upload-incremental', initiator: ALICE, status: 'completed' }),
+    make({ id: '2', event_type: 'upload-full', initiator: BOB, status: 'failed' }),
+    make({ id: '3', event_type: 'upload-automated', initiator: 'hook', status: 'completed' }),
+    make({ id: '4', event_type: 'download-incremental', initiator: ALICE, status: 'skipped' }),
+    make({ id: '5', event_type: 'webhook', initiator: 'webhook', status: 'completed' }),
   ];
 
-  it('filters by tab', () => {
-    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2']);
-    expect(filterSessions(sessions, { tab: 'download' }).map((s) => s.id)).toEqual(['3']);
-    expect(filterSessions(sessions, { tab: 'webhook' }).map((s) => s.id)).toEqual(['4']);
+  it('filters by tab — webhook event_type lands in download (Import) now', () => {
+    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2', '3']);
+    expect(filterSessions(sessions, { tab: 'download' }).map((s) => s.id)).toEqual(['4', '5']);
   });
 
   it('treats an empty / missing `statuses` set as "show all"', () => {
-    expect(filterSessions(sessions, { tab: 'upload', statuses: [] }).map((s) => s.id)).toEqual(['1', '2']);
-    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2']);
+    expect(filterSessions(sessions, { tab: 'upload', statuses: [] }).map((s) => s.id)).toEqual(['1', '2', '3']);
+    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2', '3']);
   });
 
   it('filters by `statuses` as an OR set', () => {
-    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed'] }).map((s) => s.id)).toEqual(['1']);
-    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed', 'failed'] }).map((s) => s.id)).toEqual(['1', '2']);
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed'] }).map((s) => s.id)).toEqual(['1', '3']);
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed', 'failed'] }).map((s) => s.id)).toEqual(['1', '2', '3']);
     // A status that no upload row carries returns nothing within the tab.
     expect(filterSessions(sessions, { tab: 'upload', statuses: ['skipped'] }).map((s) => s.id)).toEqual([]);
+  });
+
+  it('filters by `initiators` — manual surfaces only user-UUID rows', () => {
+    expect(filterSessions(sessions, { tab: 'upload', initiators: ['manual'] }).map((s) => s.id)).toEqual(['1', '2']);
+    expect(filterSessions(sessions, { tab: 'download', initiators: ['manual'] }).map((s) => s.id)).toEqual(['4']);
+  });
+
+  it("filters by `initiators` — automated surfaces 'hook' and 'webhook' rows", () => {
+    expect(filterSessions(sessions, { tab: 'upload', initiators: ['automated'] }).map((s) => s.id)).toEqual(['3']);
+    expect(filterSessions(sessions, { tab: 'download', initiators: ['automated'] }).map((s) => s.id)).toEqual(['5']);
+  });
+
+  it('treats an empty / missing `initiators` set as "show all"', () => {
+    expect(filterSessions(sessions, { tab: 'upload', initiators: [] }).map((s) => s.id)).toEqual(['1', '2', '3']);
+    expect(filterSessions(sessions, { tab: 'upload' }).map((s) => s.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('combines status + initiator as AND', () => {
+    // Only upload rows that are BOTH completed AND manual.
+    expect(filterSessions(sessions, { tab: 'upload', statuses: ['completed'], initiators: ['manual'] }).map((s) => s.id)).toEqual(['1']);
   });
 
   it('filters by dateFrom / dateTo', () => {

--- a/extensions/module/src/composables/use-activity-log.ts
+++ b/extensions/module/src/composables/use-activity-log.ts
@@ -1,8 +1,20 @@
 import { computed, ref, watch, type Ref } from 'vue';
 import type { SyncLogSession } from '../../../common/models/collections-data/sync-log';
 
-/** Tabs surfaced on the Activity page. Mirrors Strapi's three-tab grouping. */
-export type ActivityTab = 'upload' | 'download' | 'webhook';
+/**
+ * Tabs surfaced on the Activity page. Two-axis simplification: the tab dimension is
+ * pure direction (outbound = Export, inbound = Import). Trigger source (automated vs
+ * manual) lives in the "Triggered by" filter + the per-row "Triggered by" column.
+ */
+export type ActivityTab = 'upload' | 'download';
+
+/**
+ * Coarse classification of `localazy_sync_log.initiator` for the new "Triggered by"
+ * filter. The persisted column carries free strings (`'hook'`, `'webhook'`, a Directus
+ * user UUID, …); this classifier reduces them to "automated" (system-driven via hook
+ * bursts or inbound webhooks) vs "manual" (user-triggered from the module UI).
+ */
+export type InitiatorKind = 'automated' | 'manual';
 
 export type SortKey = 'status' | 'started_at' | 'duration' | 'initiator' | 'summary';
 export type SortDirection = 'asc' | 'desc';
@@ -17,17 +29,40 @@ const DEFAULT_SORT: SortPreference = { key: 'started_at', direction: 'desc' };
 
 /**
  * Maps a `localazy_sync_log.event_type` value to the Activity tab it belongs to.
- * The mapping is intentionally permissive — anything starting with `upload-` lands in
- * Upload, `download-` in Download, the literal `webhook` in Webhooks, and every
- * unknown value is bucketed into Webhooks too (defensive — future event types
- * shouldn't disappear from the UI just because we haven't taught the mapping yet).
+ * - `upload-*` (`upload-incremental`, `upload-full`, `upload-automated`) → Export tab
+ * - `download-*` (`download-incremental`, `download-full`) → Import tab
+ * - `webhook` (inbound Localazy → Directus) → Import tab; semantically a download,
+ *   just system-triggered. The "Triggered by" column / filter is where users
+ *   distinguish webhook-driven runs from UI-driven ones.
+ * - Anything else → Import tab as a safe fallback (future event types remain visible
+ *   while we teach the mapping).
  *
  * Pure helper so the tab-routing logic stays testable.
  */
 export function tabForEventType(eventType: string): ActivityTab {
   if (eventType.startsWith('upload')) return 'upload';
-  if (eventType.startsWith('download')) return 'download';
-  return 'webhook';
+  return 'download';
+}
+
+/**
+ * Reserved `initiator` markers that flag a system-driven session. Everything else is a
+ * Directus user UUID and counts as manual. Centralised so the filter classifier and
+ * `formatInitiator` / `useSyncLogUserNames` share one source of truth.
+ */
+const AUTOMATED_INITIATORS: ReadonlySet<string> = new Set(['hook', 'webhook']);
+
+/**
+ * Classify a session row's `initiator` column into the coarse "automated vs manual"
+ * dimension the new filter exposes. Pure helper. Unknown markers (anything the future
+ * may add that isn't a UUID) default to `'automated'` so a new system-driven event
+ * type doesn't quietly mis-classify as user activity.
+ */
+export function classifyInitiator(initiator: string): InitiatorKind {
+  if (AUTOMATED_INITIATORS.has(initiator)) return 'automated';
+  // Heuristic: real Directus user ids are UUIDs (36 chars with dashes); a raw string
+  // that isn't a UUID and isn't in the reserved set is most likely a future marker.
+  const isLikelyUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(initiator);
+  return isLikelyUuid ? 'manual' : 'automated';
 }
 
 /**
@@ -118,25 +153,30 @@ export function formatStartedAt(session: SyncLogSession): string {
 }
 
 /**
- * Pure: filters a session list by the current tab, status set, and date range.
- * Extracted so the filter behaviour is testable without mounting the Vue component.
+ * Pure: filters a session list by the current tab, status set, initiator-kind set,
+ * and date range. Extracted so the filter behaviour is testable without mounting the
+ * Vue component.
  *
- * `statuses` is an OR set — an empty (or omitted) array means "no status filter,
- * show all". Mirrors the multi-select interface in the Activity page header.
+ * `statuses` and `initiators` are OR sets — an empty (or omitted) array means
+ * "no filter on this dimension, show all". Mirrors the multi-select interface in the
+ * Activity page header.
  */
 export function filterSessions(
   sessions: SyncLogSession[],
   opts: {
     tab: ActivityTab;
     statuses?: string[];
+    initiators?: InitiatorKind[];
     dateFrom?: Date;
     dateTo?: Date;
   },
 ): SyncLogSession[] {
   const statusSet = opts.statuses && opts.statuses.length > 0 ? new Set(opts.statuses) : null;
+  const initiatorSet = opts.initiators && opts.initiators.length > 0 ? new Set(opts.initiators) : null;
   return sessions.filter((session) => {
     if (tabForEventType(session.event_type) !== opts.tab) return false;
     if (statusSet && !statusSet.has(session.status)) return false;
+    if (initiatorSet && !initiatorSet.has(classifyInitiator(session.initiator))) return false;
 
     const startedMs = Date.parse(session.started_at);
     // Cutoffs are interpreted as UTC midnight to match `session.started_at`'s UTC ISO
@@ -226,6 +266,7 @@ export function useActivityLog(input: {
 }) {
   const activeTab = ref<ActivityTab>('upload');
   const statusFilter = ref<string[]>([]);
+  const initiatorFilter = ref<InitiatorKind[]>([]);
   // Default range mirrors Strapi: From = 30 days ago, To = today. UTC midnight on both
   // ends so the cutoffs line up with `filterSessions`' UTC-based comparison.
   const today = new Date();
@@ -245,7 +286,7 @@ export function useActivityLog(input: {
 
   // Whenever the filter inputs change, reset to page 1 — otherwise a 5-page result
   // suddenly collapsing to 1 page would leave the user on a non-existent page 4.
-  watch([statusFilter, dateFrom, dateTo, activeTab], () => {
+  watch([statusFilter, initiatorFilter, dateFrom, dateTo, activeTab], () => {
     page.value = 1;
   });
 
@@ -264,6 +305,7 @@ export function useActivityLog(input: {
     filterSessions(input.sessions.value, {
       tab: activeTab.value,
       statuses: statusFilter.value,
+      initiators: initiatorFilter.value,
       dateFrom: dateFrom.value,
       dateTo: dateTo.value,
     }),
@@ -277,6 +319,7 @@ export function useActivityLog(input: {
   return {
     activeTab,
     statusFilter,
+    initiatorFilter,
     dateFrom,
     dateTo,
     page,


### PR DESCRIPTION
## Summary

Collapse the Activity page's tab dimension to pure direction (**Export** / **Import**) and surface the trigger source as a new **Triggered by** filter alongside Status.

The old Webhooks tab carried exactly one event_type (\`webhook\`) which is semantically a download — system-triggered, but still inbound Localazy → Directus. It now routes into Import. The filter is where users distinguish webhook / hook bursts from UI-driven runs; the per-row "Triggered by" column ("Triggered automatically" / "Triggered by webhook" / "Triggered by Dan") already shows the trigger at row level.

### \`use-activity-log.ts\`

- \`ActivityTab\` narrowed to \`'upload' | 'download'\`.
- \`tabForEventType('webhook')\` now returns \`'download'\`; the unknown-value fallback also lands in Import (was Webhooks before).
- New \`InitiatorKind = 'automated' | 'manual'\` + \`classifyInitiator\` helper. Reserved markers \`'hook'\` and \`'webhook'\` classify as automated; UUID-shaped values as manual; anything else defaults to automated so a future system-driven marker doesn't quietly mis-classify as user activity.
- \`filterSessions\` takes an optional \`initiators: InitiatorKind[]\` set (OR semantics; empty/missing = show all). Combines with status as AND.
- \`useActivityLog\` exposes a new \`initiatorFilter\` ref and resets the page on its change.

### \`Activity.vue\`

- \`<v-tab value=\"webhook\">Webhooks</v-tab>\` removed.
- New \`<v-select>\` labelled **Triggered by** next to Status, multi-select with \`Automation\` / \`User\` options. The option text uses nouns rather than adjectives so "Triggered by: Automation" / "Triggered by: User" reads naturally; the persisted \`InitiatorKind\` values stay \`'automated'\` / \`'manual'\`.

### Label consistency

Column header + detail metadata label both rename **Initiated by** → **Triggered by**, matching the row text and the new filter.

### Migration

The persisted sort-preferences blob may still carry a \`'webhook'\` key from previous sessions — \`Partial<Record<ActivityTab, …>>\` makes that a no-op, no migration needed.

## Test plan

- [x] \`npm run check\` — lint + format + typecheck + **581 tests pass** (up 8 from PR 66's 573).
- [x] \`npm run build\` — production build of both extensions succeeds.
- [x] New tests: \`classifyInitiator\` (3 cases), \`filterSessions\` with initiator filter (3 new cases — automated-only, manual-only, status-AND-initiator combination).
- [x] Updated tests: \`tabForEventType('webhook')\` → \`'download'\`; unknown event types → \`'download'\`.
- [x] Browser smoke test: Webhooks tab gone, "Triggered by" filter renders with "Automation"/"User" options, filtering by Automation shows hook bursts only, filtering by User shows manual UI-triggered runs only, column header reads "Triggered by".

🤖 Generated with [Claude Code](https://claude.com/claude-code)