### PR TITLE
PR 68/N: fix webhook hang + Directus 11 admin gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,29 @@ CI (`.github/workflows/qa.yml`) runs `npm run check` then a production build on 
 ## Coding conventions
 
 - **Avoid `as any` and `as unknown` casts unless truly necessary.** Both bypass TypeScript's safety net and tend to mask real bugs. Prefer real types — even partial ones via `Partial<T>` / `Pick<T, K>` — or narrow the consumer's signature so the cast isn't needed. When a cast is unavoidable (mocking a complex third-party type in a test is the most common case), use a single targeted cast (`as TargetType`) rather than the `as unknown as TargetType` double-cast escape hatch, and keep its scope as small as possible.
+
+- **Never hard-code Localazy collection names.** Always import `LOCALAZY_COLLECTIONS` from `extensions/common/models/collections-data/collection-names.ts`. The literals look interchangeable but they are not:
+  - `localazy_data` — UI grouping folder in `directus_collections`. **No backing table.** Reading it with `ItemsService.readByQuery()` throws `Cannot read properties of undefined (reading 'primary')` inside Directus' schema traversal — and if the caller doesn't `try/catch` it surfaces as an unhandled rejection that makes the HTTP request hang until the client times out.
+  - `localazy_config_data` — the actual single-row collection storing the OAuth token + project id.
+  - The other names (`localazy_settings`, `localazy_content_transfer_setup`, `localazy_sync_state`, `localazy_sync_log`) are real collections.
+
+  A duplicated local `LOCALAZY_COLLECTIONS` block in `endpoint/index.ts` once mislabeled the folder as the data collection and silently hung the webhook handler for every delivery. Don't reintroduce a per-file copy of these names.
+
+## Directus 10 shapes redefined in Directus 11
+
+We support Directus 11, so the shapes below are the current truth. They are listed here because the Directus 10 shapes still live in older guides, blog posts, and the SDK's training-data fingerprint — code-completion and AI assistants will happily reach for them. When you touch system-collection fields, verify the relocation first.
+
+- **`admin_access` and `app_access` moved from `directus_roles` to `directus_policies`.** Directus 11 added a policy layer between users/roles and permissions. There is no `directus_users.admin_access` column. The traversal is:
+
+  `directus_users.role` (m2o) → `directus_roles.policies` (o2m to `directus_access`) → `directus_access.policy` (m2o to `directus_policies`) → `admin_access`.
+
+  To query users-who-are-admins, import the shared filter from `extensions/common/utilities/admin-users-filter.ts`:
+
+  ```ts
+  import { ADMIN_USERS_FILTER } from '.../common/utilities/admin-users-filter';
+  // ADMIN_USERS_FILTER === { role: { policies: { policy: { admin_access: { _eq: true } } } } }
+  ```
+
+  Reading `directus_users` with `fields: ['admin_access']` makes `ItemsService.readOne()` throw — when the caller's `catch` clause maps that to "user missing" you get the symptom "webhook fails on every delivery because the configured user no longer exists" even though the user is still right there. The webhook gate hit exactly this trap (see `endpoint/index.ts` `lookupWebhookUser`).
+
+Add new entries here when you find another Directus 10 shape that Directus 11 has restructured.

--- a/extensions/common/models/collections-data/collection-names.ts
+++ b/extensions/common/models/collections-data/collection-names.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical names of every Directus collection owned by this extension.
+ *
+ * Import this constant. Never hard-code these strings.
+ *
+ * IMPORTANT: `groupingFolder` is the UI folder/group registered in `directus_collections`
+ * to group the other Localazy collections in the admin sidebar. It has NO backing table.
+ * Reading it via `ItemsService(...).readByQuery(...)` throws inside Directus' schema
+ * traversal (`schema.collections['localazy_data']` is `undefined`), which surfaces as an
+ * unhandled rejection if the caller doesn't try/catch. Do NOT confuse it with `config`
+ * (the actual single-row collection storing the OAuth token + project id).
+ *
+ * Past bug (PR 67-era): `extensions/sync-hook/src/endpoint/index.ts` declared a local
+ * `LOCALAZY_COLLECTIONS` with `data: 'localazy_data'` (the folder name) instead of
+ * `'localazy_config_data'`, which caused the webhook handler to hang on every delivery.
+ * The duplicated local constant was the root cause — keep this file as the single source.
+ */
+export const LOCALAZY_COLLECTIONS = {
+  /** UI grouping folder — no backing table. Used only by the installer. */
+  groupingFolder: 'localazy_data',
+  /** Singleton: master toggle + automated-import config. */
+  settings: 'localazy_settings',
+  /** Singleton: per-collection field-enable map for content sync. */
+  contentTransferSetup: 'localazy_content_transfer_setup',
+  /** Singleton: Localazy OAuth token + project id + cached project metadata. */
+  config: 'localazy_config_data',
+  /** Singleton: incremental-import cursor state. */
+  syncState: 'localazy_sync_state',
+  /** Row-per-session: Activity-page log of webhook + hook + manual sync runs. */
+  syncLog: 'localazy_sync_log',
+} as const;
+
+export type LocalazyCollectionName = (typeof LOCALAZY_COLLECTIONS)[keyof typeof LOCALAZY_COLLECTIONS];

--- a/extensions/common/utilities/admin-users-filter.ts
+++ b/extensions/common/utilities/admin-users-filter.ts
@@ -1,0 +1,12 @@
+/**
+ * Filter for users whose role has at least one policy with `admin_access = true`.
+ *
+ * Directus 11 moved `admin_access` from `directus_roles` to `directus_policies`. The
+ * traversal is `directus_users.role` (m2o) → `directus_roles.policies` (o2m to
+ * `directus_access`) → `directus_access.policy` (m2o to `directus_policies`) →
+ * `admin_access`. The module-side user picker (AutomationForm) and the server-side
+ * webhook gate (sync-hook/endpoint) both apply this filter — keep it here so they can't
+ * drift apart and reintroduce "Configured webhook user no longer exists" false positives
+ * after a Directus major upgrade.
+ */
+export const ADMIN_USERS_FILTER = { role: { policies: { policy: { admin_access: { _eq: true } } } } } as const;

--- a/extensions/module/src/components/Automation/AutomationForm.filter.test.ts
+++ b/extensions/module/src/components/Automation/AutomationForm.filter.test.ts
@@ -2,30 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { ADMIN_USERS_FILTER } from '../../../../common/utilities/admin-users-filter';
 
 /**
- * Lightweight static-source assertion that the Admin-role filter passed to
- * `GET /users` keeps its Directus-11 shape — `role.policies.policy.admin_access._eq: true`.
- *
- * The full form mounts in Vue and would need `@directus/extensions-sdk` plus
- * `useStores()` to instantiate, which isn't worth the harness cost for this single
- * invariant. Reading the source is enough to catch the regression we care about:
- * someone "tidying" the filter into a shape Directus' API rejects (e.g. the v10 shape
- * `role.admin_access._eq` — Directus 11 moved `admin_access` from `directus_roles` to
- * `directus_policies`) would silently render an empty dropdown.
+ * Asserts that the Admin-role filter keeps its Directus-11 shape —
+ * `role.policies.policy.admin_access._eq: true` — and that AutomationForm.vue passes
+ * the shared constant through `api.get('/users')`. Reading the source is enough to
+ * catch the regression we care about: someone "tidying" the filter into a shape
+ * Directus' API rejects (e.g. the v10 shape `role.admin_access._eq` — Directus 11
+ * moved `admin_access` from `directus_roles` to `directus_policies`) would silently
+ * render an empty dropdown AND make the webhook gate fail every delivery.
  */
 const here = dirname(fileURLToPath(import.meta.url));
 const formSource = readFileSync(resolve(here, 'AutomationForm.vue'), 'utf8');
 
 describe('AutomationForm — Admin-role user filter', () => {
-  it('declares ADMIN_USERS_FILTER with the relation-traversal shape Directus 11 expects', () => {
-    // Match `{ role: { policies: { policy: { admin_access: { _eq: true } } } } }` while tolerating whitespace.
-    const re =
-      /ADMIN_USERS_FILTER\s*=\s*\{\s*role:\s*\{\s*policies:\s*\{\s*policy:\s*\{\s*admin_access:\s*\{\s*_eq:\s*true\s*\}\s*\}\s*\}\s*\}\s*\}/;
-    expect(formSource).toMatch(re);
+  it('the shared ADMIN_USERS_FILTER carries the relation-traversal shape Directus 11 expects', () => {
+    expect(ADMIN_USERS_FILTER).toEqual({ role: { policies: { policy: { admin_access: { _eq: true } } } } });
   });
 
-  it('passes the filter through `api.get` with `fields: id, first_name, last_name, email`', () => {
+  it('passes the shared filter through `api.get` with `fields: id, first_name, last_name, email`', () => {
     expect(formSource).toMatch(/api\.get<[^>]+>\(\s*['"]\/users['"]/);
     expect(formSource).toMatch(/filter:\s*ADMIN_USERS_FILTER/);
     expect(formSource).toMatch(/fields:\s*\[\s*['"]id['"]\s*,\s*['"]first_name['"]\s*,\s*['"]last_name['"]\s*,\s*['"]email['"]\s*\]/);

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -124,6 +124,7 @@ import { useApi } from '@directus/extensions-sdk';
 import type { Item } from '@directus/types';
 import { useLocalazyStore } from '../../stores/localazy-store';
 import { Settings } from '../../../../common/models/collections-data/settings';
+import { ADMIN_USERS_FILTER } from '../../../../common/utilities/admin-users-filter';
 import WebhookSetup from './WebhookSetup.vue';
 
 const localEdits = defineModel<Settings>('edits', { required: true });
@@ -141,16 +142,9 @@ type AdminUser = { id: string; first_name: string | null; last_name: string | nu
 const adminUsers = ref<AdminUser[]>([]);
 const loadingUsers = ref(false);
 
-/**
- * Filter for users whose role has at least one policy with `admin_access = true`.
- * In Directus 11, `admin_access` lives on `directus_policies`, not on `directus_roles`
- * (which was the v10 shape). The traversal is
- * `directus_users.role` (m2o) → `directus_roles.policies` (o2m to `directus_access`)
- * → `directus_access.policy` (m2o to `directus_policies`) → `admin_access`.
- * Excluding non-admin users client-side instead would still leak their existence
- * via the API response, and we'd pay the bandwidth for a list we then discard.
- */
-const ADMIN_USERS_FILTER = { role: { policies: { policy: { admin_access: { _eq: true } } } } } as const;
+// `ADMIN_USERS_FILTER` traverses Directus 11's user → role → policies → admin_access
+// path. Excluding non-admin users client-side instead would still leak their existence
+// via the API response, and we'd pay the bandwidth for a list we then discard.
 
 async function loadAdminUsers(): Promise<void> {
   loadingUsers.value = true;

--- a/extensions/module/src/stores/localazy-installer-store.ts
+++ b/extensions/module/src/stores/localazy-installer-store.ts
@@ -13,19 +13,11 @@ import { createLocalazyDataFields } from '../data/fields/localazy-data/create';
 import { createSyncStateFields } from '../data/fields/sync-state/create';
 import { createSyncLogFields } from '../data/fields/sync-log/create';
 import { computeFieldHealActions } from './utilities/heal-fields';
+import { LOCALAZY_COLLECTIONS } from '../../../common/models/collections-data/collection-names';
 
-/**
- * Collection names owned by this extension. Used by the installer and the per-singleton
- * stores. Don't hard-code these strings elsewhere — import the constant.
- */
-export const LOCALAZY_COLLECTIONS = {
-  groupingFolder: 'localazy_data',
-  settings: 'localazy_settings',
-  contentTransferSetup: 'localazy_content_transfer_setup',
-  config: 'localazy_config_data',
-  syncState: 'localazy_sync_state',
-  syncLog: 'localazy_sync_log',
-} as const;
+// Re-exported for backward compatibility — many module files import this name from the
+// installer store. New code should import directly from `common/models/collections-data/collection-names`.
+export { LOCALAZY_COLLECTIONS };
 
 type CollectionPlan = {
   name: string;

--- a/extensions/sync-hook/src/endpoint/index.test.ts
+++ b/extensions/sync-hook/src/endpoint/index.test.ts
@@ -74,8 +74,28 @@ function makeFakeItemsService(initial: Record<string, FakeRow[]>) {
       this.collection = collection;
       ctorCalls.push({ collection, options });
     }
-    async readByQuery(_q: unknown): Promise<T[]> {
-      return ((tables.get(this.collection) ?? []) as T[]).slice();
+    async readByQuery(q: unknown): Promise<T[]> {
+      const rows = ((tables.get(this.collection) ?? []) as T[]).slice();
+      // Tests of the admin-policy lookup pass a filter shaped like
+      //   { _and: [{ id: { _eq: <userId> } }, ADMIN_USERS_FILTER] }
+      // The fake user rows carry an `admin_access` boolean that stands in for the real
+      // user → role → policies traversal — when the filter is present, return the row
+      // only if that boolean is `true`. This is the smallest model that lets us cover
+      // the gate's three outcomes (existence + admin + not-admin) without a real schema.
+      const filter = (q as { filter?: Record<string, unknown> } | undefined)?.filter;
+      if (this.collection === 'directus_users' && filter && '_and' in filter) {
+        const clauses = (filter as { _and: Array<Record<string, unknown>> })._and;
+        const idClause = clauses.find((c) => 'id' in c) as { id?: { _eq?: string } } | undefined;
+        const hasAdminTraversal = clauses.some(
+          (c) =>
+            'role' in c &&
+            JSON.stringify((c as { role: unknown }).role) === JSON.stringify({ policies: { policy: { admin_access: { _eq: true } } } }),
+        );
+        if (idClause?.id?._eq !== undefined && hasAdminTraversal) {
+          return rows.filter((r) => r.id === idClause.id?._eq && r.admin_access === true);
+        }
+      }
+      return rows;
     }
     async readOne(id: string | number, _q?: unknown): Promise<T | null> {
       const row = (tables.get(this.collection) ?? []).find((r) => r.id === id);
@@ -263,7 +283,7 @@ describe('webhook handler — HMAC verification', () => {
     logger = makeFakeLogger();
     const { FakeService, tables: t } = makeFakeItemsService({
       localazy_settings: [defaultSettings()],
-      localazy_data: [defaultData()],
+      localazy_config_data: [defaultData()],
       localazy_content_transfer_setup: [defaultTransferSetup()],
       directus_users: [defaultUser()],
       localazy_sync_log: [],
@@ -351,7 +371,7 @@ describe('webhook handler — HMAC verification', () => {
   });
 
   it('not connected (no access_token) → 401 not_connected', async () => {
-    tables.set('localazy_data', [{ ...defaultData(), access_token: '' }]);
+    tables.set('localazy_config_data', [{ ...defaultData(), access_token: '' }]);
     const handler = createWebhookHandler(getDeps);
     const { res, captured } = makeFakeRes();
 
@@ -387,7 +407,7 @@ describe('webhook handler — gating outcomes', () => {
   function setupHandler(settingsOverride: Record<string, unknown> = {}, users: FakeRow[] = [defaultUser()]) {
     const { FakeService, tables: t } = makeFakeItemsService({
       localazy_settings: [defaultSettings(settingsOverride)],
-      localazy_data: [defaultData()],
+      localazy_config_data: [defaultData()],
       localazy_content_transfer_setup: [defaultTransferSetup()],
       directus_users: users,
       localazy_sync_log: [],

--- a/extensions/sync-hook/src/endpoint/index.ts
+++ b/extensions/sync-hook/src/endpoint/index.ts
@@ -14,13 +14,8 @@ import type { ItemsServiceCtor, DirectusLogger } from '../hook/types/directus-se
 import { decideGating } from './gating';
 import { verifyWebhookSignature, WebhookVerificationResult, WEBHOOK_HMAC_HEADER, WEBHOOK_TIMESTAMP_HEADER } from './hmac-verification';
 import { buildServerOrchestratorAdapters, WebhookDirectusApi } from './orchestrator-adapters';
-
-const LOCALAZY_COLLECTIONS = {
-  settings: 'localazy_settings',
-  data: 'localazy_data',
-  contentTransferSetup: 'localazy_content_transfer_setup',
-  syncLog: 'localazy_sync_log',
-} as const;
+import { LOCALAZY_COLLECTIONS } from '../../../common/models/collections-data/collection-names';
+import { ADMIN_USERS_FILTER } from '../../../common/utilities/admin-users-filter';
 
 /**
  * Minimal Express Request shape we touch in the handler. Keeping the type local (rather
@@ -102,12 +97,25 @@ function assertUserFound(lookup: UserLookup): asserts lookup is Extract<UserLook
 }
 
 async function lookupWebhookUser(ItemsService: ItemsServiceCtor, schema: SchemaOverview, userId: string): Promise<UserLookup> {
-  type UserRow = { id: string; admin_access: boolean | null; role: string | null };
+  type UserRow = { id: string; role: string | null };
   const service = new ItemsService<UserRow>('directus_users', { schema, accountability: null });
   try {
-    const row = await service.readOne(userId, { fields: ['id', 'admin_access', 'role'] });
+    const row = await service.readOne(userId, { fields: ['id', 'role'] });
     if (!row) return { found: false };
-    return { found: true, user: { id: row.id, admin_access: row.admin_access === true, role: row.role } };
+
+    // Directus 11 moved `admin_access` from `directus_users` / `directus_roles` onto
+    // `directus_policies`, reachable via `directus_access`. A second filtered query
+    // against `directus_users` with `ADMIN_USERS_FILTER` returns the row iff the user's
+    // role has at least one policy with `admin_access = true` — same predicate the
+    // module-side picker uses, so a user selectable in the UI passes the gate here.
+    const adminMatch = await service.readByQuery({
+      fields: ['id'],
+      filter: { _and: [{ id: { _eq: row.id } }, ADMIN_USERS_FILTER] },
+      limit: 1,
+    });
+    const adminAccess = adminMatch.length > 0;
+
+    return { found: true, user: { id: row.id, admin_access: adminAccess, role: row.role } };
   } catch {
     // ItemsService throws "Forbidden" / "Not Found" — either way we treat the user as
     // missing for gating purposes. The caller will log this as `user_missing`.
@@ -199,206 +207,225 @@ export function createWebhookHandler(getDeps: () => Promise<RegisterDependencies
     }
     const { ItemsService, schema, logger } = deps;
 
-    // 1. Read settings + localazy_data. Both reads need admin accountability — the
-    //    settings master toggle and the OAuth token belong to the extension, not to
-    //    the user that triggered the event (there isn't one yet).
-    const settings = await readSingleton<Settings>(ItemsService, LOCALAZY_COLLECTIONS.settings, schema);
-    if (!settings) {
-      res.status(503).json({ error: 'not_configured' });
-      return;
-    }
-
-    // Master-toggle-off short-circuit (Q12a). We deliberately respond 200 WITHOUT
-    // writing a log row: an unauthenticated POST must not append to the Activity table
-    // (it would let an attacker flood it with bad signatures while the toggle is off).
-    // The customer disabled automated import — they don't need an Activity entry for
-    // every refused delivery. HMAC verification is skipped here because there's no
-    // useful work to authenticate; the 200 prevents Localazy from retrying.
-    if (settings.automated_import !== true) {
-      res.status(200).json({ skipped: true, reason: 'disabled' });
-      return;
-    }
-
-    // 2. Localazy data — needed for the access token (to fetch the secret) and project
-    //    id (to scope the HMAC fetch + the import).
-    const localazyData = await readSingleton<LocalazyData>(ItemsService, LOCALAZY_COLLECTIONS.data, schema);
-    if (!localazyData || !localazyData.access_token) {
-      res.status(401).json({ error: 'not_connected' });
-      return;
-    }
-
-    // 3. Fetch the webhook secret fresh — per Q5b, no caching. A revoked token means the
-    //    secret fetch returns 401; we surface that to the caller without retry.
-    let secret: string;
+    // Top-level guard for the pre-response phase. Any throw here (a missing collection
+    // in the schema overview, a transient DB error, an unexpected Directus internal)
+    // must surface as a 500 instead of becoming an unhandled rejection that leaves the
+    // request hanging until Localazy's HTTP client times out.
     try {
-      secret = await LocalazyApiThrottleService.getWebhookSecret(localazyData.access_token, {
-        project: localazyData.project_id,
-      });
+      await handlePreResponse(req, res, ItemsService, schema, logger);
     } catch (err) {
-      logger.warn({ err }, 'Localazy webhook: secret fetch failed');
-      res.status(401).json({ error: 'secret_fetch_failed' });
-      return;
+      logger.error({ err }, 'Localazy webhook: unexpected error before response');
+      res.status(500).json({ error: 'internal_error' });
     }
+  };
+}
 
-    // 4. Verify timestamp + HMAC.
-    const verification: WebhookVerificationResult = verifyWebhookSignature({
-      secret,
-      body: req.body,
-      hmacHeader: readHeader(req, WEBHOOK_HMAC_HEADER),
-      timestampHeader: readHeader(req, WEBHOOK_TIMESTAMP_HEADER),
+async function handlePreResponse(
+  req: WebhookRequest,
+  res: WebhookResponse,
+  ItemsService: ItemsServiceCtor,
+  schema: SchemaOverview,
+  logger: DirectusLogger,
+): Promise<void> {
+  // 1. Read settings + localazy_config_data. Both reads need admin accountability — the
+  //    settings master toggle and the OAuth token belong to the extension, not to
+  //    the user that triggered the event (there isn't one yet).
+  const settings = await readSingleton<Settings>(ItemsService, LOCALAZY_COLLECTIONS.settings, schema);
+  if (!settings) {
+    res.status(503).json({ error: 'not_configured' });
+    return;
+  }
+
+  // Master-toggle-off short-circuit (Q12a). We deliberately respond 200 WITHOUT
+  // writing a log row: an unauthenticated POST must not append to the Activity table
+  // (it would let an attacker flood it with bad signatures while the toggle is off).
+  // The customer disabled automated import — they don't need an Activity entry for
+  // every refused delivery. HMAC verification is skipped here because there's no
+  // useful work to authenticate; the 200 prevents Localazy from retrying.
+  if (settings.automated_import !== true) {
+    res.status(200).json({ skipped: true, reason: 'disabled' });
+    return;
+  }
+
+  // 2. Localazy data — needed for the access token (to fetch the secret) and project
+  //    id (to scope the HMAC fetch + the import).
+  const localazyData = await readSingleton<LocalazyData>(ItemsService, LOCALAZY_COLLECTIONS.config, schema);
+  if (!localazyData || !localazyData.access_token) {
+    res.status(401).json({ error: 'not_connected' });
+    return;
+  }
+
+  // 3. Fetch the webhook secret fresh — per Q5b, no caching. A revoked token means the
+  //    secret fetch returns 401; we surface that to the caller without retry.
+  let secret: string;
+  try {
+    secret = await LocalazyApiThrottleService.getWebhookSecret(localazyData.access_token, {
+      project: localazyData.project_id,
     });
-    if (!verification.ok) {
-      if (verification.reason === 'stale_timestamp') {
-        res.status(400).json({ error: 'stale_timestamp' });
-      } else {
-        // missing_headers and invalid_signature both → 401. We deliberately don't write
-        // a sync_log row on verification failure — that would let an attacker flood the
-        // Activity table with spam.
-        res.status(401).json({ error: verification.reason });
-      }
-      return;
+  } catch (err) {
+    logger.warn({ err }, 'Localazy webhook: secret fetch failed');
+    res.status(401).json({ error: 'secret_fetch_failed' });
+    return;
+  }
+
+  // 4. Verify timestamp + HMAC.
+  const verification: WebhookVerificationResult = verifyWebhookSignature({
+    secret,
+    body: req.body,
+    hmacHeader: readHeader(req, WEBHOOK_HMAC_HEADER),
+    timestampHeader: readHeader(req, WEBHOOK_TIMESTAMP_HEADER),
+  });
+  if (!verification.ok) {
+    if (verification.reason === 'stale_timestamp') {
+      res.status(400).json({ error: 'stale_timestamp' });
+    } else {
+      // missing_headers and invalid_signature both → 401. We deliberately don't write
+      // a sync_log row on verification failure — that would let an attacker flood the
+      // Activity table with spam.
+      res.status(401).json({ error: verification.reason });
     }
+    return;
+  }
 
-    // 5. Gating (Q12). The user lookup happens here so the gate sees both the configured
-    //    user id and the resolved `admin_access` flag.
-    const userId = settings.automated_import_user;
-    const userLookup: UserLookup = userId ? await lookupWebhookUser(ItemsService, schema, userId) : { found: false };
+  // 5. Gating (Q12). The user lookup happens here so the gate sees both the configured
+  //    user id and the resolved `admin_access` flag.
+  const userId = settings.automated_import_user;
+  const userLookup: UserLookup = userId ? await lookupWebhookUser(ItemsService, schema, userId) : { found: false };
 
-    const decision = decideGating({
-      settings,
-      user: userLookup.found ? { id: userLookup.user.id, userHasAdminAccess: userLookup.user.admin_access } : null,
-      userExists: userLookup.found,
+  const decision = decideGating({
+    settings,
+    user: userLookup.found ? { id: userLookup.user.id, userHasAdminAccess: userLookup.user.admin_access } : null,
+    userExists: userLookup.found,
+  });
+
+  if (decision.kind === 'skip') {
+    await writeOutcomeSessionRow(ItemsService, schema, {
+      status: 'skipped',
+      summary: 'Automated import is disabled',
+      userId: null,
     });
+    res.status(200).json({ skipped: true, reason: decision.reason });
+    return;
+  }
+  if (decision.kind === 'fail') {
+    const summary =
+      decision.reason === 'no_user'
+        ? 'No webhook user configured'
+        : decision.reason === 'user_missing'
+          ? 'Configured webhook user no longer exists'
+          : 'Configured webhook user no longer has Admin role';
+    await writeOutcomeSessionRow(ItemsService, schema, {
+      status: 'failed',
+      summary,
+      userId: userId ?? null,
+    });
+    res.status(200).json({ failed: true, reason: decision.reason });
+    return;
+  }
 
-    if (decision.kind === 'skip') {
-      await writeOutcomeSessionRow(ItemsService, schema, {
-        status: 'skipped',
-        summary: 'Automated import is disabled',
-        userId: null,
-      });
-      res.status(200).json({ skipped: true, reason: decision.reason });
-      return;
-    }
-    if (decision.kind === 'fail') {
-      const summary =
-        decision.reason === 'no_user'
-          ? 'No webhook user configured'
-          : decision.reason === 'user_missing'
-            ? 'Configured webhook user no longer exists'
-            : 'Configured webhook user no longer has Admin role';
-      await writeOutcomeSessionRow(ItemsService, schema, {
-        status: 'failed',
-        summary,
-        userId: userId ?? null,
-      });
-      res.status(200).json({ failed: true, reason: decision.reason });
-      return;
-    }
+  // Narrow `userLookup` to its `found: true` variant. The gate's `proceed` decision
+  // implies `userLookup.found === true` (the `no_user` / `user_missing` failure paths
+  // above cover the `false` variant); the `assert` makes that implication explicit so
+  // TS narrows downstream. The defensive `if (!userLookup.found)` block this replaces
+  // was dead code per Q12b/Q12c — the gate already returned by the time we got here.
+  assertUserFound(userLookup);
+  const resolvedUser = userLookup.user;
 
-    // Narrow `userLookup` to its `found: true` variant. The gate's `proceed` decision
-    // implies `userLookup.found === true` (the `no_user` / `user_missing` failure paths
-    // above cover the `false` variant); the `assert` makes that implication explicit so
-    // TS narrows downstream. The defensive `if (!userLookup.found)` block this replaces
-    // was dead code per Q12b/Q12c — the gate already returned by the time we got here.
-    assertUserFound(userLookup);
-    const resolvedUser = userLookup.user;
+  // 6. Respond 200 immediately (Q5c) and run the import in the background.
+  res.status(200).json({ accepted: true });
 
-    // 6. Respond 200 immediately (Q5c) and run the import in the background.
-    res.status(200).json({ accepted: true });
-
-    // All post-response work is wrapped in try/catch so any throw — a failing schema
-    // read, a Localazy listProjects throw, a language-resolution explosion — surfaces
-    // as a best-effort `'failed'` log row instead of becoming an unhandled rejection.
-    setImmediate(async () => {
-      try {
-        const transferSetup = await readSingleton<ContentTransferSetupDatabase>(
-          ItemsService,
-          LOCALAZY_COLLECTIONS.contentTransferSetup,
-          schema,
-        );
-        if (!transferSetup) {
-          logger.warn('Localazy webhook: missing content_transfer_setup row, aborting');
-          await writeOutcomeSessionRow(ItemsService, schema, {
-            status: 'failed',
-            summary: 'Missing content_transfer_setup row',
-            userId,
-          });
-          return;
-        }
-
-        // Resolve the Localazy project. The webhook payload may carry an id but we read
-        // it off the saved `localazy_data` row instead — that's the project the user
-        // configured for this Directus install. A mismatched id would already be caught
-        // by the per-project HMAC secret.
-        const projects = await LocalazyApiThrottleService.listProjects(localazyData.access_token, {
-          organization: true,
-          languages: true,
-        });
-        const localazyProject = projects.find((p) => p.id === localazyData.project_id);
-        if (!localazyProject) {
-          logger.warn(
-            { projectId: localazyData.project_id },
-            'Localazy webhook: configured project no longer exists on Localazy side, aborting',
-          );
-          await writeOutcomeSessionRow(ItemsService, schema, {
-            status: 'failed',
-            summary: `Configured Localazy project (${localazyData.project_id}) no longer exists`,
-            userId,
-          });
-          return;
-        }
-
-        const writeAccountability = buildAccountability(resolvedUser);
-
-        // Resolve languages exactly once — verbatim from the saved field, or via the
-        // same `resolveImportLanguages()` the UI uses when the saved field is empty.
-        const langService = new SynchronizationLanguagesService(new WebhookDirectusApi(ItemsService, schema, null));
-        const allResolved = await langService.resolveImportLanguages(settings, localazyProject);
-        const resolvedLanguages = decision.fallbackLanguages
-          ? allResolved
-          : allResolved.filter((l) => decision.importLanguages.includes(l.directusForm));
-
-        // Build the orchestrator adapter bundle. Webhook-driven writes run under the
-        // configured user's accountability; lock + cursor + sync_log writes use admin
-        // accountability internally regardless. The notification recipient is the same
-        // resolved user — the bell-icon row is filed in their Directus inbox on a
-        // failure / partial / aborted outcome.
-        const adapters = buildServerOrchestratorAdapters({
-          ItemsService,
-          schema,
-          logger,
-          writeAccountability,
-          localazyProject,
-          notificationRecipientUserId: resolvedUser.id,
-        });
-
-        const enabledFields = EnabledFieldsService.parseFromDatabase(transferSetup.enabled_fields);
-
-        await runIncrementalImport(
-          {
-            ...adapters,
-            syncLogInitiator: { initiator: 'webhook', initiatorUser: null },
-          },
-          {
-            mode: 'incremental', // Q7 — webhook is always incremental
-            languages: resolvedLanguages,
-            enabledFields,
-            localazyData,
-            localazyProject,
-            settings,
-            initiator: 'webhook',
-          },
-        );
-      } catch (err) {
-        logger.error({ err }, 'Localazy webhook: dispatch failed');
+  // All post-response work is wrapped in try/catch so any throw — a failing schema
+  // read, a Localazy listProjects throw, a language-resolution explosion — surfaces
+  // as a best-effort `'failed'` log row instead of becoming an unhandled rejection.
+  setImmediate(async () => {
+    try {
+      const transferSetup = await readSingleton<ContentTransferSetupDatabase>(
+        ItemsService,
+        LOCALAZY_COLLECTIONS.contentTransferSetup,
+        schema,
+      );
+      if (!transferSetup) {
+        logger.warn('Localazy webhook: missing content_transfer_setup row, aborting');
         await writeOutcomeSessionRow(ItemsService, schema, {
           status: 'failed',
-          summary: 'Webhook dispatch failed unexpectedly',
+          summary: 'Missing content_transfer_setup row',
           userId,
         });
+        return;
       }
-    });
-  };
+
+      // Resolve the Localazy project. The webhook payload may carry an id but we read
+      // it off the saved `localazy_config_data` row instead — that's the project the user
+      // configured for this Directus install. A mismatched id would already be caught
+      // by the per-project HMAC secret.
+      const projects = await LocalazyApiThrottleService.listProjects(localazyData.access_token, {
+        organization: true,
+        languages: true,
+      });
+      const localazyProject = projects.find((p) => p.id === localazyData.project_id);
+      if (!localazyProject) {
+        logger.warn(
+          { projectId: localazyData.project_id },
+          'Localazy webhook: configured project no longer exists on Localazy side, aborting',
+        );
+        await writeOutcomeSessionRow(ItemsService, schema, {
+          status: 'failed',
+          summary: `Configured Localazy project (${localazyData.project_id}) no longer exists`,
+          userId,
+        });
+        return;
+      }
+
+      const writeAccountability = buildAccountability(resolvedUser);
+
+      // Resolve languages exactly once — verbatim from the saved field, or via the
+      // same `resolveImportLanguages()` the UI uses when the saved field is empty.
+      const langService = new SynchronizationLanguagesService(new WebhookDirectusApi(ItemsService, schema, null));
+      const allResolved = await langService.resolveImportLanguages(settings, localazyProject);
+      const resolvedLanguages = decision.fallbackLanguages
+        ? allResolved
+        : allResolved.filter((l) => decision.importLanguages.includes(l.directusForm));
+
+      // Build the orchestrator adapter bundle. Webhook-driven writes run under the
+      // configured user's accountability; lock + cursor + sync_log writes use admin
+      // accountability internally regardless. The notification recipient is the same
+      // resolved user — the bell-icon row is filed in their Directus inbox on a
+      // failure / partial / aborted outcome.
+      const adapters = buildServerOrchestratorAdapters({
+        ItemsService,
+        schema,
+        logger,
+        writeAccountability,
+        localazyProject,
+        notificationRecipientUserId: resolvedUser.id,
+      });
+
+      const enabledFields = EnabledFieldsService.parseFromDatabase(transferSetup.enabled_fields);
+
+      await runIncrementalImport(
+        {
+          ...adapters,
+          syncLogInitiator: { initiator: 'webhook', initiatorUser: null },
+        },
+        {
+          mode: 'incremental', // Q7 — webhook is always incremental
+          languages: resolvedLanguages,
+          enabledFields,
+          localazyData,
+          localazyProject,
+          settings,
+          initiator: 'webhook',
+        },
+      );
+    } catch (err) {
+      logger.error({ err }, 'Localazy webhook: dispatch failed');
+      await writeOutcomeSessionRow(ItemsService, schema, {
+        status: 'failed',
+        summary: 'Webhook dispatch failed unexpectedly',
+        userId,
+      });
+    }
+  });
 }
 
 /**

--- a/extensions/sync-hook/src/endpoint/orchestrator-adapters.ts
+++ b/extensions/sync-hook/src/endpoint/orchestrator-adapters.ts
@@ -25,6 +25,7 @@ import { SyncLogSession } from '../../../common/models/collections-data/sync-log
 import { createSyncLogWriter, SyncLogFailureCallback } from '../../../common/services/orchestrator/sync-log-writer';
 import { createServerSyncLogStorage } from '../shared/sync-log-storage';
 import { FAILURE_NOTIFICATION_WINDOW_MS, shouldSuppressFailureNotification } from './notification-dedupe';
+import { LOCALAZY_COLLECTIONS } from '../../../common/models/collections-data/collection-names';
 
 /**
  * Shape of the `localazy_sync_state` row the orchestrator's lock cares about. Mirrors the
@@ -41,16 +42,6 @@ type LockRow = Pick<
   | 'sync_last_heartbeat_at'
   | 'acquired_token'
 >;
-
-/**
- * Localazy collection names mirrored from the module side. Keeping these constants
- * inline (rather than importing from the module workspace) avoids dragging Vue's runtime
- * into the server-side bundle.
- */
-const LOCALAZY_COLLECTIONS = {
-  syncState: 'localazy_sync_state',
-  syncLog: 'localazy_sync_log',
-} as const;
 
 /**
  * Construct an `ItemsService` for a given collection using the supplied accountability.

--- a/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
+++ b/extensions/sync-hook/src/hook/services/automated-export-burst-coordinator.ts
@@ -6,6 +6,7 @@ import { createSyncLogWriter } from '../../../../common/services/orchestrator/sy
 import type { SyncLogWriter } from '../../../../common/services/orchestrator/ports';
 import { createServerSyncLogStorage } from '../../shared/sync-log-storage';
 import type { ItemsServiceCtor } from '../types/directus-services';
+import { LOCALAZY_COLLECTIONS } from '../../../../common/models/collections-data/collection-names';
 
 /**
  * Event_type column value for hook-triggered Automated export bursts. Sits next to
@@ -22,8 +23,6 @@ const BURST_EVENT_TYPE = 'upload-automated';
  * user attribution lives inside each entry's `data.user`.
  */
 const BURST_INITIATOR = 'hook';
-
-const SYNC_LOG_COLLECTION = 'localazy_sync_log';
 
 /** Default idle window before the burst auto-finalises. */
 const DEFAULT_IDLE_WINDOW_MS = 30_000;
@@ -286,7 +285,7 @@ export function createAutomatedExportBurstCoordinator(deps: AutomatedExportBurst
    */
   async function sweepOrphans(schema: SchemaOverview): Promise<void> {
     try {
-      const service = new ItemsService<Partial<SyncLogSession>>(SYNC_LOG_COLLECTION, { schema, accountability: null });
+      const service = new ItemsService<Partial<SyncLogSession>>(LOCALAZY_COLLECTIONS.syncLog, { schema, accountability: null });
       const orphans = await service.readByQuery({
         filter: {
           event_type: { _eq: BURST_EVENT_TYPE },

--- a/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
@@ -16,6 +16,7 @@ import { ExportToLocalazyService } from '../export-to-localazy-service';
 import { importFromLocalazyService } from '../import-from-localazy-service';
 import { TranslationStringsService } from '../../../../../common/services/translation-strings-service';
 import { DirectusApiService } from '../directus-service';
+import { LOCALAZY_COLLECTIONS } from '../../../../../common/models/collections-data/collection-names';
 import type { FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
 
 /**
@@ -32,16 +33,16 @@ export function makeBundleLocalazyContextLoader(deps: {
 }): AutomatedExportLocalazyContextLoader {
   return async () => {
     const { ItemsService, schema } = deps;
-    if (!schema.collections?.localazy_settings || !schema.collections?.localazy_content_transfer_setup) {
+    if (!schema.collections?.[LOCALAZY_COLLECTIONS.settings] || !schema.collections?.[LOCALAZY_COLLECTIONS.contentTransferSetup]) {
       return null;
     }
     try {
-      const settingsService = new ItemsService<Settings>('localazy_settings', { schema, accountability: null });
-      const transferSetupService = new ItemsService<ContentTransferSetupDatabase>('localazy_content_transfer_setup', {
+      const settingsService = new ItemsService<Settings>(LOCALAZY_COLLECTIONS.settings, { schema, accountability: null });
+      const transferSetupService = new ItemsService<ContentTransferSetupDatabase>(LOCALAZY_COLLECTIONS.contentTransferSetup, {
         schema,
         accountability: null,
       });
-      const localazyDataService = new ItemsService<LocalazyData>('localazy_config_data', { schema, accountability: null });
+      const localazyDataService = new ItemsService<LocalazyData>(LOCALAZY_COLLECTIONS.config, { schema, accountability: null });
 
       const [settings = null] = await settingsService.readByQuery({ fields: ['*'], limit: 1 });
       const [contentTransferSetup = null] = await transferSetupService.readByQuery({ fields: ['*'], limit: 1 });

--- a/extensions/sync-hook/src/shared/sync-log-storage.ts
+++ b/extensions/sync-hook/src/shared/sync-log-storage.ts
@@ -1,9 +1,8 @@
 import type { MutationOptions, SchemaOverview } from '@directus/types';
 import { SyncLogSession } from '../../../common/models/collections-data/sync-log';
 import { SyncLogStorage } from '../../../common/services/orchestrator/sync-log-writer';
+import { LOCALAZY_COLLECTIONS } from '../../../common/models/collections-data/collection-names';
 import type { ItemsServiceCtor } from '../hook/types/directus-services';
-
-const LOCALAZY_SYNC_LOG_COLLECTION = 'localazy_sync_log';
 
 /**
  * Server-side `SyncLogStorage` adapter — translates the deep writer's column-aware
@@ -22,7 +21,7 @@ const LOCALAZY_SYNC_LOG_COLLECTION = 'localazy_sync_log';
  */
 export function createServerSyncLogStorage(ItemsService: ItemsServiceCtor, schema: SchemaOverview): SyncLogStorage {
   function service() {
-    return new ItemsService<Partial<SyncLogSession>>(LOCALAZY_SYNC_LOG_COLLECTION, { schema, accountability: null });
+    return new ItemsService<Partial<SyncLogSession>>(LOCALAZY_COLLECTIONS.syncLog, { schema, accountability: null });
   }
   return {
     async createSession(row) {


### PR DESCRIPTION
## Summary

Two underlying bugs surfaced while testing the inbound Localazy webhook on a dump of a real customer DB — both at the boundary between our code and the current Directus 11 schema:

1. **Webhook hung on every delivery.** `endpoint/index.ts` had a duplicated local `LOCALAZY_COLLECTIONS` block with `data: 'localazy_data'`. That string is the UI grouping folder (no backing table); the row storing the OAuth token + project id lives in `localazy_config_data`. Reading the folder name made `getAllowedSort` throw inside Directus' `readByQuery`, the async handler returned a rejected promise, and Directus' Express layer left the connection hanging until the client timed out.
2. **After (1), the gate said "Configured webhook user no longer exists" on every delivery.** `lookupWebhookUser` requested `fields: ['id', 'admin_access', 'role']`, but Directus 11 has no `directus_users.admin_access` column — `admin_access` lives on `directus_policies`, reached via `directus_users.role → directus_roles.policies → directus_access.policy`. `ItemsService` threw, our catch returned `{ found: false }`.

## Changes

- **Lift `LOCALAZY_COLLECTIONS`** to `extensions/common/models/collections-data/collection-names.ts`. All six hard-coded call sites (endpoint, orchestrator adapters, burst coordinator, pipeline adapters, sync-log storage, installer store) now import the shared constant. `localazy-installer-store.ts` re-exports for module back-compat.
- **Harden the webhook handler.** Pre-response phase now runs inside a top-level try/catch — any future schema/DB explosion returns 500 instead of hanging.
- **Rewrite `lookupWebhookUser`** to read `id, role` and then issue a second filtered `readByQuery` using `ADMIN_USERS_FILTER` (lifted from `AutomationForm.vue` to `extensions/common/utilities/admin-users-filter.ts` so the picker and the gate apply the same predicate). The endpoint test's `FakeService.readByQuery` was taught to model the admin-filter shape so the three gate outcomes (existence / admin / not-admin) stay covered.
- **Documentation.** `CLAUDE.md` gains a "Never hard-code Localazy collection names" coding convention and a "Directus 10 shapes redefined in Directus 11" section documenting the `admin_access` / `app_access` relocation onto policies.

## Test plan

- [x] `npm run check` — lint + format + typecheck + 581 tests pass.
- [x] `npm run build:development` — clean build for both extensions.
- [x] Live verification against the local Docker Directus: `curl -X POST -H 'x-localazy-timestamp: <now>' -H 'x-localazy-hmac: dummy' http://localhost:8055/localazy-automation/transfer/download` returns `401 invalid_signature` (was timing out after 10 s before this PR).
- [ ] End-to-end: trigger a real webhook from Localazy and confirm a successful sync session in the Activity tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)