### PR TITLE
PR 69/N: search lens for the Import & Export tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ Thanks for your interest in contributing to the Localazy Directus extension.
 
 This is an npm-workspaces monorepo with three packages under `extensions/`:
 
-| Path                    | Published as                                       | Purpose                                                                                                                                        |
-| ----------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `extensions/module/`    | `@localazy/directus-extension-localazy`            | UI module (Vue 3 + Pinia). The Localazy admin pages — Overview, Import & Export, Project Setup, Additional Settings, About.                    |
-| `extensions/sync-hook/` | `@localazy/directus-extension-localazy-automation` | Server-side hook (plain TypeScript). Automates content upload on Directus item / translation / settings changes.                               |
-| `extensions/common/`    | (internal)                                         | Shared TypeScript code — services, models, types — consumed by both extensions. Not published; Rollup inlines it into each extension's bundle. |
+| Path                    | Published as                                       | Purpose                                                                                                                                                                                                                                                                   |
+| ----------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extensions/module/`    | `@localazy/directus-extension-localazy`            | UI module (Vue 3 + Pinia). The Localazy admin pages — Overview, Import & Export, Project Setup, Additional Settings, About.                                                                                                                                               |
+| `extensions/sync-hook/` | `@localazy/directus-extension-localazy-automation` | Server-side bundle (plain TypeScript). Two children: a **hook** that automates content upload on Directus item / translation / settings changes, and an **endpoint** exposing `GET /localazy-automation/status` so the module can detect whether the bundle is installed. |
+| `extensions/common/`    | (internal)                                         | Shared TypeScript code — services, models, types — consumed by both extensions. Not published; Rollup inlines it into each extension's bundle.                                                                                                                            |
 
 ## Prerequisites
 

--- a/docs/adr/0003-import-export-tree-search-as-lens.md
+++ b/docs/adr/0003-import-export-tree-search-as-lens.md
@@ -1,0 +1,34 @@
+# Import & Export tree search is a transient lens; bulk actions scope to it additively
+
+## Context
+
+The Import & Export page (`Sync.vue`) renders a hierarchical tree of Directus collections and their fields, with checkboxes that drive `localazy_content_transfer_setup.enabled_fields`. Two pre-existing visibility toggles (`Show untranslatable fields`, `Show collections without translatable fields`) already narrow the tree. We are adding a text search box to filter the tree further.
+
+The non-obvious design question isn't search itself — it's how search interacts with the bulk-action surface that already lives on this page. The page-level `Select all` / `Deselect all` (in `SyncOptionButtons.vue`) replaces `enabledFields` wholesale today. The per-collection checkbox in `CollectionItem.vue` is a similar "all-or-nothing" toggle scoped to that collection. Once a filter narrows the tree, the meaning of "all" becomes ambiguous: all of the schema, or all of the visible subset?
+
+The obvious code-level reading is "Select all selects all" — keep the global behaviour, let filter be purely visual. The user-level reading is the opposite: "I just narrowed the tree to what I care about; the button labelled `Select all` should now mean `Select all of these`." Diverging on which reading is canonical is what makes this worth recording.
+
+## Decision
+
+1. **Search is a transient lens, not a stored filter.** Input resets on every visit to the page; no URL param, no store. The lens has no concept of "remembering what was hidden" — it recomputes from the current input on every keystroke.
+
+2. **Filter composition is AND across all narrowing controls.** Search composes with both existing visibility toggles. A field hidden by `Show untranslatable fields=OFF` does not become visible because its name matches the search. The empty-state message explicitly mentions the toggles when one is OFF, so a zero-match user has the option of widening the candidate set before reformulating the query.
+
+3. **Match propagation rule:** a node is shown if it matches _or_ any descendant matches; a node matched by its own name shows all its descendants in full (a collection-name match isn't allowed to also filter the fields inside, because the user's intent at that point is to look at the collection). The Translation strings row participates in the filter on equal footing with collection rows.
+
+4. **Bulk actions scope to the lens, additively.** While a non-empty search input is active:
+   - Page-level `Select all` adds every _visible_ translatable field to `enabledFields` without touching selections in hidden collections. Page-level `Deselect all` removes only visible fields.
+   - The per-collection checkbox in `CollectionItem.vue` toggles only the _visible_ translatable fields of that collection. Its `model-value` and `indeterminate` state are computed against the visible subset.
+   - When the input is empty, both bulk actions revert to their existing global / collection-scoped semantics.
+
+   The additive rule is load-bearing — replacing wholesale would let a filtered `Select all` silently wipe selections in the hidden tree, which is the worst possible surprise from a button labelled `Select all`.
+
+5. **Expansion state is owned by the lens while it's active.** Each keystroke recomputes which nodes are shown and auto-expands all of them, including ancestors of any deep match. Manual collapses during the filter don't survive the next recompute. On clear, the tree reverts to its pre-filter expansion state — the lens is removed and what was underneath is restored verbatim.
+
+## Consequences
+
+- `EnabledFieldsService` (the consumer of `enabledFields`) is unaffected — selection state remains a flat list of `{ collection, fields[] }`. The lens lives entirely in the view layer.
+- The per-collection checkbox in `CollectionItem.vue` gains a "visible subset" notion that today's code doesn't have. Its `localSelections`, `someTranslatableFieldsChecked`, and `allTranslatableFieldsChecked` computeds need a filtered-fields input alongside the existing full-collection inputs. The structural test (`AutomationForm.structure.test.ts` is unrelated; we'll need new tests in `Sync.vue`'s neighbourhood covering visible-subset toggle semantics).
+- The "filter as a lens" framing closes the door on a "saved filters" or "filter presets" feature in this page later. If that becomes a real need, it would have to be a stored-filter feature distinct from this transient search.
+- The pre-filter expansion snapshot is held in component-local state — it dies on unmount, which is fine because the lens itself dies on unmount.
+- A future user complaint of "I filtered, hit `Select all`, and it didn't select the rest of my collections" is the design working as intended; the answer is to clear the filter first. The button copy stays `Select all`, not `Select all visible`, because the latter is verbose for the 90% case where no filter is active.

--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -86,9 +86,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import Navigation from './components/Navigation.vue';
 import SessionsTable from './components/Activity/SessionsTable.vue';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
@@ -104,6 +104,7 @@ import {
 } from './composables/use-activity-log';
 
 const router = useRouter();
+const route = useRoute();
 
 // Boot: ensures the installer's heal step runs so the `localazy_sync_log` collection
 // (added in PR D) lands on already-installed instances. The list store reload is
@@ -148,6 +149,21 @@ const {
   sessions,
   initialSortPreferences,
   onSortPreferencesChange,
+});
+
+// Persist the active tab in the URL hash so a reload (or a copied link) lands on
+// the same tab. Restore on first mount; mirror future changes via `router.replace`
+// so tab switches don't pollute the browser history.
+const VALID_TAB_HASHES: readonly ActivityTab[] = ['upload', 'download'];
+function tabFromHash(hash: string): ActivityTab | null {
+  const value = hash.replace(/^#/, '');
+  return (VALID_TAB_HASHES as readonly string[]).includes(value) ? (value as ActivityTab) : null;
+}
+const initialTabFromHash = tabFromHash(route.hash);
+if (initialTabFromHash) activeTab.value = initialTabFromHash;
+watch(activeTab, (next) => {
+  if (route.hash === `#${next}`) return;
+  void router.replace({ hash: `#${next}` });
 });
 
 // `<v-select :items>` shape: `{ text, value }`. The statuses mirror StatusLabel.vue's

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -46,7 +46,35 @@
         @deselect-all="deselectAll"
       />
 
+      <div class="search-row">
+        <v-input
+          v-model="searchQuery"
+          class="search-input"
+          placeholder="Search collections and fields"
+          :nullable="false"
+          @keydown.esc="clearSearch"
+        >
+          <template #prepend>
+            <v-icon name="search" class="search-icon" />
+          </template>
+          <template #append>
+            <v-icon v-if="isSearchActive" name="close" clickable class="clear-icon" @click="clearSearch" />
+          </template>
+        </v-input>
+      </div>
+
       <div v-if="installed" class="page">
+        <div v-if="isSearchActive && !hasAnyVisibleTreeNode && !translationStringsVisible" class="empty-results">
+          <p class="empty-results-title">No collections or fields match “{{ searchQuery }}”.</p>
+          <p v-if="suggestEnablingToggles" class="empty-results-hint">
+            Try a different search term, or open
+            <span class="empty-results-options">Options</span> to enable
+            <span v-if="!showUntranslatableField">“Show untranslatable fields”</span>
+            <span v-if="!showUntranslatableField && !showUntranslatableCollections"> and </span>
+            <span v-if="!showUntranslatableCollections">“Show collections without translatable fields”</span>.
+          </p>
+        </div>
+
         <div class="collection-list">
           <collection-item
             v-for="col in iteratedCollections"
@@ -57,14 +85,17 @@
             :selections="enabledFields"
             :show-untranslatable-field="showUntranslatableField"
             :show-untranslatable-collections="showUntranslatableCollections"
+            :normalized-query="normalizedQuery"
             @update:selections="enabledFields = $event"
           />
         </div>
 
         <translation-strings-content
+          v-if="translationStringsVisible"
           v-model:should-synchronize="synchronizeTranslationStrings"
+          :normalized-query="normalizedQuery"
           :class="{
-            'translation-strings-separator': iteratedCollections.length > 0,
+            'translation-strings-separator': hasAnyVisibleTreeNode,
           }"
         />
       </div>
@@ -104,6 +135,14 @@ import { EnabledField } from '../../common/models/collections-data/content-trans
 import { EnabledFieldsService } from '../../common/utilities/enabled-fields-service';
 import { defaultConfiguration } from './data/default-configuration';
 import { useRouter } from 'vue-router';
+import { useTreeSearch } from './composables/use-tree-search';
+import {
+  buildVisibleTranslatableSelection,
+  isCollectionShown,
+  subtractEnabledFields,
+  unionEnabledFields,
+  VisibilityContext,
+} from './composables/tree-visibility';
 
 const { translatableRootCollections, rootCollections, translatableCollections, collections } = useCollectionsOrganizer();
 const { getTranslatableFields } = useGetFieldsForTranslationRelation();
@@ -206,6 +245,23 @@ const iteratedCollections = computed(() =>
   showUntranslatableCollections.value ? rootCollections.value : translatableRootCollections.value,
 );
 
+// Search lens (ADR-0003) — transient page-local state; resets on every visit.
+const { query: searchQuery, normalizedQuery, isActive: isSearchActive, clear: clearSearch } = useTreeSearch();
+
+// Translation Strings label string is duplicated in TranslationStringsContent.vue —
+// keep both in sync if one moves.
+const TRANSLATION_STRINGS_LABEL = 'Translation Strings';
+
+const visibilityContext = computed<VisibilityContext>(() => ({
+  isActive: isSearchActive.value,
+  isMatch: (label: string) => (normalizedQuery.value.length === 0 ? true : label.toLowerCase().includes(normalizedQuery.value)),
+  allCollections: collections.value,
+  getFieldsForCollection: getTranslatableFields,
+  showUntranslatableField: showUntranslatableField.value,
+  showUntranslatableCollections: showUntranslatableCollections.value,
+  isTranslatableCollection: (c) => translatableCollections.value.some((tc) => tc.collection === c.collection),
+}));
+
 const allTranslatableFields = computed(() =>
   translatableCollections.value.map((c) => ({
     collection: c.collection,
@@ -213,17 +269,55 @@ const allTranslatableFields = computed(() =>
   })),
 );
 
-const someTranslatableFieldsChecked = computed(() => enabledFields.value.length > 0);
-const allTranslatableFieldsChecked = computed(() => enabledFields.value.length === allTranslatableFields.value.length);
+// Visible-only translatable selection, used by the scope-additive Select all
+// path and by the master-checkbox state under an active lens.
+const visibleTranslatableSelection = computed(() => buildVisibleTranslatableSelection(iteratedCollections.value, visibilityContext.value));
+
+const hasAnyVisibleTreeNode = computed(() => iteratedCollections.value.some((c) => isCollectionShown(c, visibilityContext.value)));
+
+const translationStringsVisible = computed(() => !isSearchActive.value || visibilityContext.value.isMatch(TRANSLATION_STRINGS_LABEL));
+
+const suggestEnablingToggles = computed(() => !showUntranslatableField.value || !showUntranslatableCollections.value);
+
+// Master-checkbox state: under a lens, scope to the visible subset; otherwise
+// keep the original "every translatable field globally" rule.
+const someTranslatableFieldsChecked = computed(() => {
+  if (!isSearchActive.value) return enabledFields.value.length > 0;
+  const visible = visibleTranslatableSelection.value;
+  return visible.some((entry) =>
+    entry.fields.some((field) => enabledFields.value.find((e) => e.collection === entry.collection)?.fields.includes(field)),
+  );
+});
+
+const allTranslatableFieldsChecked = computed(() => {
+  if (!isSearchActive.value) return enabledFields.value.length === allTranslatableFields.value.length;
+  const visible = visibleTranslatableSelection.value;
+  if (visible.length === 0) return false;
+  return visible.every((entry) => {
+    const current = enabledFields.value.find((e) => e.collection === entry.collection);
+    return !!current && entry.fields.every((f) => current.fields.includes(f));
+  });
+});
 
 function selectAll() {
-  enabledFields.value = allTranslatableFields.value;
-  synchronizeTranslationStrings.value = true;
+  if (!isSearchActive.value) {
+    enabledFields.value = allTranslatableFields.value;
+    synchronizeTranslationStrings.value = true;
+    return;
+  }
+  // Lens-scoped, additive (ADR-0003): preserve selections outside the visible set.
+  enabledFields.value = unionEnabledFields(enabledFields.value, visibleTranslatableSelection.value);
+  if (translationStringsVisible.value) synchronizeTranslationStrings.value = true;
 }
 
 function deselectAll() {
-  enabledFields.value = [];
-  synchronizeTranslationStrings.value = false;
+  if (!isSearchActive.value) {
+    enabledFields.value = [];
+    synchronizeTranslationStrings.value = false;
+    return;
+  }
+  enabledFields.value = subtractEnabledFields(enabledFields.value, visibleTranslatableSelection.value);
+  if (translationStringsVisible.value) synchronizeTranslationStrings.value = false;
 }
 </script>
 
@@ -250,6 +344,50 @@ function deselectAll() {
   padding-top: 8px;
   margin-top: 8px;
   border-top: 1px solid var(--theme--border-color);
+}
+
+.search-row {
+  margin-top: 16px;
+
+  .search-input {
+    width: 100%;
+  }
+
+  .search-icon {
+    color: var(--theme--foreground-subdued);
+  }
+
+  .clear-icon {
+    color: var(--theme--foreground-subdued);
+    &:hover {
+      color: var(--theme--foreground);
+    }
+  }
+}
+
+.empty-results {
+  margin: 16px 0;
+  padding: 16px;
+  background-color: var(--theme--background-subdued);
+  border: 1px dashed var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
+  color: var(--theme--foreground-subdued);
+  font-size: 13px;
+
+  .empty-results-title {
+    margin: 0 0 4px 0;
+    font-weight: 500;
+    color: var(--theme--foreground);
+  }
+
+  .empty-results-hint {
+    margin: 0;
+  }
+
+  .empty-results-options {
+    font-weight: 500;
+    color: var(--theme--foreground);
+  }
 }
 
 .last-sync-banner {

--- a/extensions/module/src/components/Sync/CollectionItem.vue
+++ b/extensions/module/src/components/Sync/CollectionItem.vue
@@ -17,19 +17,19 @@
         class="collection-item collection-item-clickable"
         :value="collection.collection"
         :indeterminate="someTranslatableFieldsChecked && !allTranslatableFieldsChecked"
-        :model-value="selections.map((selection) => selection.collection)"
+        :model-value="visibleCollectionSelectionValue"
         @update:model-value="onUpdateCollectionSelection"
       >
         <span>
           <v-icon :color="collection.color || 'var(--theme--primary)'" class="collection-icon" :name="collection.icon" />
-          <span class="collection-name">{{ collection.name }}</span>
+          <highlighted-label class="collection-name" :label="collection.name" :normalized-query="normalizedQuery" />
         </span>
       </v-checkbox>
 
       <v-list-item v-else class="collection-item collection-item-unclickable v-list-item">
         <span>
           <v-icon :color="collection.color || 'var(--theme--primary)'" class="collection-icon" :name="collection.icon" />
-          <span class="collection-name">{{ collection.name }}</span>
+          <highlighted-label class="collection-name" :label="collection.name" :normalized-query="normalizedQuery" />
         </span>
       </v-list-item>
     </template>
@@ -44,7 +44,7 @@
       :title="!isTranslatableField(field) ? `${field.type} is not translatable` : ''"
       @update:model-value="localSelections = $event"
     >
-      <span>{{ field.name }}</span>
+      <highlighted-label :label="field.name" :normalized-query="normalizedQuery" />
     </v-checkbox>
 
     <div class="collection-group">
@@ -57,6 +57,7 @@
         :selections="selections"
         :show-untranslatable-field="showUntranslatableField"
         :show-untranslatable-collections="showUntranslatableCollections"
+        :normalized-query="normalizedQuery"
         @update:selections="$emit('update:selections', $event)"
       />
     </div>
@@ -64,12 +65,22 @@
 </template>
 
 <script lang="ts" setup>
-import { PropType, computed, ref } from 'vue';
+import { PropType, computed, ref, watch } from 'vue';
 import { AppCollection, Field } from '@directus/types';
 import { isEqualWith } from 'lodash';
 import { useGetFieldsForTranslationRelation } from '../../composables/use-get-fields-for-translation-relation';
 import { EnabledField } from '../../../../common/models/collections-data/content-transfer-setup';
 import { FieldsUtilsService } from '../../../../common/utilities/fields-utils-service';
+import {
+  getNestedCollections as visibilityGetNested,
+  isCollectionShown,
+  renderedFieldsFor,
+  subtreeHasMatch,
+  visibleFieldsForCollection,
+  visibleTranslatableFieldsFor,
+  VisibilityContext,
+} from '../../composables/tree-visibility';
+import HighlightedLabel from './HighlightedLabel.vue';
 
 const props = defineProps({
   collection: {
@@ -96,10 +107,36 @@ const props = defineProps({
     type: Boolean,
     required: true,
   },
+  normalizedQuery: {
+    type: String,
+    required: true,
+  },
 });
 
 const emits = defineEmits(['update:selections']);
 
+const isTranslatableField = FieldsUtilsService.isTranslatableField;
+
+// Shared visibility context — the same shape Sync.vue feeds to the page-level
+// scope-additive helpers, so the lens semantics stay in lockstep on both sides.
+const { getTranslatableFields } = useGetFieldsForTranslationRelation();
+const visibilityContext = computed<VisibilityContext>(() => ({
+  isActive: props.normalizedQuery.length > 0,
+  isMatch: (label: string) => (props.normalizedQuery.length === 0 ? true : label.toLowerCase().includes(props.normalizedQuery)),
+  allCollections: props.collections,
+  getFieldsForCollection: getTranslatableFields,
+  showUntranslatableField: props.showUntranslatableField,
+  showUntranslatableCollections: props.showUntranslatableCollections,
+  isTranslatableCollection: (c) => props.translatableCollections.some((tc) => tc.collection === c.collection),
+}));
+
+const isTranslatableCollection = computed(() => visibilityContext.value.isTranslatableCollection(props.collection));
+
+const lensActive = computed(() => visibilityContext.value.isActive);
+
+// Full v-checkbox value set across collection + its (visible) translatable
+// fields, mirroring the original behaviour but pruned to the lens-visible set
+// while a search is active.
 const localSelections = computed({
   get(): string[] {
     return props.selections
@@ -110,9 +147,7 @@ const localSelections = computed({
     const collectionFieldsMap = selections.reduce((acc, selection) => {
       const [collection, field] = selection.split('-');
       if (collection && field) {
-        if (!acc.has(collection)) {
-          acc.set(collection, []);
-        }
+        if (!acc.has(collection)) acc.set(collection, []);
         acc.get(collection)?.push(field);
       }
       return acc;
@@ -129,62 +164,108 @@ const localSelections = computed({
 const selectionsForCollection = computed(() => props.selections.find((selection) => selection.collection === props.collection.collection));
 const otherSelections = computed(() => props.selections.filter((selection) => selection.collection !== props.collection.collection));
 
-const isTranslatableCollection = computed(() =>
-  props.translatableCollections.some((col) => col.collection === props.collection.collection),
+const nestedCollections = computed(() =>
+  visibilityGetNested(props.collection, visibilityContext.value).filter((c) => isCollectionShown(c, visibilityContext.value)),
 );
 
-const isTranslatableField = FieldsUtilsService.isTranslatableField;
+// Fields actually rendered under the lens: a collection-name match shows all
+// (lens-unrelated) rendered fields; otherwise only fields whose own names match.
+const allRenderedFields = computed<Field[]>(() => renderedFieldsFor(props.collection, visibilityContext.value));
+const renderedFields = computed<Field[]>(() => visibleFieldsForCollection(props.collection, visibilityContext.value));
 
-const nestedCollections = computed(() => props.collections.filter((collection) => collection.meta?.group === props.collection.collection));
-const collection = computed(() => props.collection);
-
-const { translatableFields, allFields } = useGetFieldsForTranslationRelation().getTranslatableFields(collection.value.collection);
-const renderedFields = computed(() => (props.showUntranslatableField ? allFields : translatableFields));
-const isExpanded = ref(renderedFields.value.length === 0);
-
-const shouldRender = computed(
-  () => nestedCollections.value.length > 0 || isTranslatableCollection.value || props.showUntranslatableCollections,
-);
+// `shouldRender` collapses three predicates: legacy visibility rules from
+// CollectionItem.vue plus the lens. Delegated to `isCollectionShown` so the
+// page-level scope-additive selection sees the same answer.
+const shouldRender = computed(() => isCollectionShown(props.collection, visibilityContext.value));
 const isExpandable = computed(() => nestedCollections.value.length > 0 || renderedFields.value.length > 0);
 
+// Visible translatable fields — the scope the per-collection checkbox operates
+// on under an active lens; falls back to the full rendered list otherwise so
+// the legacy "translatable only" rule still drives unfiltered selection.
+const visibleTranslatableFields = computed<Field[]>(() => visibleTranslatableFieldsFor(props.collection, visibilityContext.value));
+const translatableFieldsForToggle = computed<Field[]>(() =>
+  lensActive.value ? visibleTranslatableFields.value : allRenderedFields.value.filter(isTranslatableField),
+);
+
+const enabledFieldNames = computed<string[]>(() => selectionsForCollection.value?.fields ?? []);
+
 const someTranslatableFieldsChecked = computed(() => {
-  const fields = translatableFields.filter(isTranslatableField);
-  return (selectionsForCollection.value?.fields || []).some((field) => fields.some((f) => f.field === field));
+  const scope = translatableFieldsForToggle.value;
+  return enabledFieldNames.value.some((field) => scope.some((f) => f.field === field));
 });
 
+// The collection-level checkbox is "all checked" when every field in its
+// scope (visible-only under a lens) is enabled.
 const allTranslatableFieldsChecked = computed(() => {
-  const fields = translatableFields.filter(isTranslatableField);
-
-  return (
-    fields.length > 0 &&
-    isEqualWith(
-      fields,
-      selectionsForCollection.value?.fields || [],
-      (translatedFields: Field[], selectionFields: string[]) =>
-        translatedFields.length === selectionFields.length &&
-        translatedFields.every((translatableField) => selectionFields.includes(translatableField.field)),
-    )
+  const scope = translatableFieldsForToggle.value;
+  if (scope.length === 0) return false;
+  const enabled = enabledFieldNames.value;
+  return isEqualWith(
+    scope,
+    enabled,
+    (scopeFields: Field[], selectionFields: string[]) =>
+      scopeFields.length <= selectionFields.length && scopeFields.every((f) => selectionFields.includes(f.field)),
   );
 });
 
+// `v-checkbox`'s `:model-value` expects an array. Under a lens, surface the
+// collection slug only when every *visible* translatable field is on.
+const visibleCollectionSelectionValue = computed<string[]>(() => (allTranslatableFieldsChecked.value ? [props.collection.collection] : []));
+
 function onUpdateCollectionSelection() {
-  const fields = translatableFields.filter(isTranslatableField);
-  if (allTranslatableFieldsChecked.value) {
+  const scope = translatableFieldsForToggle.value;
+  const scopeNames = scope.map((f) => f.field);
+  const existing = enabledFieldNames.value;
+  const allScopeOn = allTranslatableFieldsChecked.value;
+
+  // Scope-additive (ADR-0003): only touch fields inside the current scope so
+  // hidden-but-enabled fields survive a click while the lens is active.
+  const remaining = existing.filter((f) => !scopeNames.includes(f));
+  const next = allScopeOn ? remaining : [...remaining, ...scopeNames];
+
+  if (next.length === 0) {
     emits('update:selections', otherSelections.value);
-  } else {
-    emits('update:selections', [
-      ...otherSelections.value,
-      {
-        collection: props.collection.collection,
-        fields: fields.map((field) => field.field),
-      },
-    ]);
+    return;
   }
+  emits('update:selections', [
+    ...otherSelections.value,
+    {
+      collection: props.collection.collection,
+      fields: next,
+    },
+  ]);
 }
 
+// Expansion state: the lens drives it while active (Q12 / ADR-0003). When the
+// lens flips off, restore the user's pre-lens expansion. `preLensExpanded`
+// remembers what `isExpanded` was the moment the lens turned on.
+const userExpanded = ref(allRenderedFields.value.length === 0);
+const preLensExpanded = ref<boolean | null>(null);
+const lensExpansion = computed<boolean>(() => lensActive.value && subtreeHasMatch(props.collection, visibilityContext.value));
+const isExpanded = computed(() => (lensActive.value ? lensExpansion.value : userExpanded.value));
+
+watch(lensActive, (active, wasActive) => {
+  if (active && !wasActive) {
+    preLensExpanded.value = userExpanded.value;
+  } else if (!active && wasActive && preLensExpanded.value !== null) {
+    userExpanded.value = preLensExpanded.value;
+    preLensExpanded.value = null;
+  }
+});
+
 function onGroupClick() {
-  isExpanded.value = !isExpanded.value;
+  // Clicks during an active lens are absorbed — the lens owns expansion (Q12a).
+  if (lensActive.value) return;
+  userExpanded.value = !userExpanded.value;
 }
+
+// When the collection becomes auto-collapsed by gaining children (e.g. a field
+// appears via a toggle change), keep the legacy "no fields => start expanded"
+// rule for the non-lens case.
+watch(allRenderedFields, (next) => {
+  if (lensActive.value) return;
+  if (next.length === 0) userExpanded.value = true;
+});
 </script>
 
 <style lang="scss" scoped>
@@ -227,4 +308,3 @@ function onGroupClick() {
   }
 }
 </style>
-../../../common/utilities/fields-utils-service

--- a/extensions/module/src/components/Sync/HighlightedLabel.vue
+++ b/extensions/module/src/components/Sync/HighlightedLabel.vue
@@ -1,0 +1,29 @@
+<template>
+  <span>
+    <template v-for="(segment, index) in segments" :key="index">
+      <mark v-if="segment.matched" class="match">{{ segment.text }}</mark>
+      <template v-else>{{ segment.text }}</template>
+    </template>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { splitHighlight, HighlightSegment } from '../../composables/use-tree-search';
+
+const props = defineProps({
+  label: { type: String, required: true },
+  normalizedQuery: { type: String, required: true },
+});
+
+const segments = computed<HighlightSegment[]>(() => splitHighlight(props.label, props.normalizedQuery));
+</script>
+
+<style lang="scss" scoped>
+.match {
+  background-color: var(--theme--primary-25, rgba(23, 198, 83, 0.2));
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 1px;
+}
+</style>

--- a/extensions/module/src/components/Sync/TranslationStringsContent.vue
+++ b/extensions/module/src/components/Sync/TranslationStringsContent.vue
@@ -3,8 +3,8 @@
     <v-checkbox v-model="shouldSynchronize" class="collection-item collection-item-clickable">
       <span>
         <v-icon color="var(--theme--primary)" class="collection-icon" name="translate" />
-        <span class="collection-name"
-          >Translation Strings
+        <span class="collection-name">
+          <highlighted-label :label="LABEL" :normalized-query="normalizedQuery" />
           <a
             href="https://docs.directus.io/user-guide/content-module/translation-strings.html"
             target="_blank"
@@ -21,9 +21,19 @@
 </template>
 
 <script lang="ts" setup>
+import HighlightedLabel from './HighlightedLabel.vue';
+
 // Previously this component had a hand-rolled v-model that re-emitted the OLD prop
 // value, so the toggle silently no-op'd. defineModel binds correctly to v-checkbox.
 const shouldSynchronize = defineModel<boolean>('shouldSynchronize', { required: true });
+
+defineProps({
+  normalizedQuery: { type: String, required: true },
+});
+
+// Surfaced label used both for highlighting and for the page-level visibility
+// gate in Sync.vue (matched against the active lens) — keep the two in sync.
+const LABEL = 'Translation Strings';
 </script>
 
 <style lang="scss" scoped>

--- a/extensions/module/src/composables/tree-visibility.test.ts
+++ b/extensions/module/src/composables/tree-visibility.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { AppCollection, Field } from '@directus/types';
+import {
+  buildVisibleTranslatableSelection,
+  isCollectionShown,
+  subtractEnabledFields,
+  unionEnabledFields,
+  visibleFieldsForCollection,
+  VisibilityContext,
+} from './tree-visibility';
+
+// Minimal fixture: articles / pages (translatable) under a `content` folder,
+// plus an untranslatable `settings` collection at the root.
+function makeCollection(name: string, group?: string): AppCollection {
+  return {
+    collection: name,
+    name,
+    meta: { sort: 0, group: group ?? null } as AppCollection['meta'],
+    schema: null,
+    type: 'table',
+  } as AppCollection;
+}
+
+function makeField(collection: string, field: string, type = 'string'): Field {
+  return {
+    collection,
+    field,
+    name: field,
+    type,
+    schema: null,
+    meta: null,
+  } as Field;
+}
+
+const content = makeCollection('content');
+const articles = makeCollection('articles', 'content');
+const pages = makeCollection('pages', 'content');
+const settings = makeCollection('settings');
+
+const FIELDS_BY_COLLECTION: Record<string, { translatableFields: Field[]; allFields: Field[] }> = {
+  articles: {
+    translatableFields: [makeField('articles', 'title'), makeField('articles', 'body')],
+    allFields: [makeField('articles', 'title'), makeField('articles', 'body'), makeField('articles', 'created_at', 'timestamp')],
+  },
+  pages: {
+    translatableFields: [makeField('pages', 'heading')],
+    allFields: [makeField('pages', 'heading'), makeField('pages', 'slug', 'string')],
+  },
+  content: { translatableFields: [], allFields: [] },
+  settings: { translatableFields: [], allFields: [makeField('settings', 'theme', 'string')] },
+};
+
+function makeCtx(over: Partial<VisibilityContext> = {}): VisibilityContext {
+  const base: VisibilityContext = {
+    isActive: false,
+    isMatch: () => true,
+    allCollections: [content, articles, pages, settings],
+    getFieldsForCollection: (name) => FIELDS_BY_COLLECTION[name] ?? { translatableFields: [], allFields: [] },
+    showUntranslatableField: false,
+    showUntranslatableCollections: false,
+    isTranslatableCollection: (c) => c.collection === 'articles' || c.collection === 'pages',
+  };
+  return { ...base, ...over };
+}
+
+describe('isCollectionShown — lens inactive', () => {
+  it('shows translatable collections', () => {
+    const ctx = makeCtx();
+    expect(isCollectionShown(articles, ctx)).toBe(true);
+  });
+
+  it('shows folder collections with translatable descendants', () => {
+    const ctx = makeCtx();
+    expect(isCollectionShown(content, ctx)).toBe(true);
+  });
+
+  it('hides untranslatable collections unless the toggle is on', () => {
+    expect(isCollectionShown(settings, makeCtx())).toBe(false);
+    expect(isCollectionShown(settings, makeCtx({ showUntranslatableCollections: true }))).toBe(true);
+  });
+});
+
+describe('isCollectionShown — lens active', () => {
+  it('shows a collection whose own name matches', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('art') });
+    expect(isCollectionShown(articles, ctx)).toBe(true);
+  });
+
+  it('shows a folder whose descendant matches by name', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('articles') });
+    expect(isCollectionShown(content, ctx)).toBe(true);
+  });
+
+  it('shows a folder whose descendant has a matching field name', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('heading') });
+    expect(isCollectionShown(content, ctx)).toBe(true);
+    expect(isCollectionShown(pages, ctx)).toBe(true);
+    expect(isCollectionShown(articles, ctx)).toBe(false);
+  });
+
+  it('hides a collection that does not match and has no matching descendant', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('banner') });
+    expect(isCollectionShown(articles, ctx)).toBe(false);
+    expect(isCollectionShown(content, ctx)).toBe(false);
+  });
+});
+
+describe('visibleFieldsForCollection — collection-name match shows all', () => {
+  it('returns every rendered field when the collection name itself matches (Q3 / ADR-0003)', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('articles') });
+    expect(visibleFieldsForCollection(articles, ctx).map((f) => f.field)).toEqual(['title', 'body']);
+  });
+
+  it('returns only fields whose own names match when the collection name does not', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('title') });
+    expect(visibleFieldsForCollection(articles, ctx).map((f) => f.field)).toEqual(['title']);
+  });
+
+  it('returns every rendered field with the lens inactive (filter compose AND from Q4)', () => {
+    expect(visibleFieldsForCollection(articles, makeCtx()).map((f) => f.field)).toEqual(['title', 'body']);
+  });
+
+  it('honours the Show untranslatable fields toggle: lens-narrowed too', () => {
+    const ctx = makeCtx({ isActive: true, showUntranslatableField: true, isMatch: (s) => s.toLowerCase().includes('created') });
+    expect(visibleFieldsForCollection(articles, ctx).map((f) => f.field)).toEqual(['created_at']);
+  });
+});
+
+describe('buildVisibleTranslatableSelection', () => {
+  it('flattens the visible translatable selection for the page-level Select all', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('title') });
+    expect(buildVisibleTranslatableSelection([content], ctx)).toEqual([{ collection: 'articles', fields: ['title'] }]);
+  });
+
+  it('includes every translatable field of a collection whose own name matches', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('articles') });
+    expect(buildVisibleTranslatableSelection([content], ctx)).toEqual([{ collection: 'articles', fields: ['title', 'body'] }]);
+  });
+
+  it('returns the full set with the lens inactive', () => {
+    expect(buildVisibleTranslatableSelection([content], makeCtx())).toEqual([
+      { collection: 'articles', fields: ['title', 'body'] },
+      { collection: 'pages', fields: ['heading'] },
+    ]);
+  });
+});
+
+describe('unionEnabledFields — scope-additive Select all', () => {
+  it('merges fields per collection without dropping pre-existing entries', () => {
+    const a = [{ collection: 'articles', fields: ['title'] }];
+    const b = [{ collection: 'articles', fields: ['body'] }];
+    expect(unionEnabledFields(a, b)).toEqual([{ collection: 'articles', fields: ['title', 'body'] }]);
+  });
+
+  it('preserves collections that exist only on one side', () => {
+    const a = [{ collection: 'articles', fields: ['title'] }];
+    const b = [{ collection: 'pages', fields: ['heading'] }];
+    expect(unionEnabledFields(a, b)).toEqual([
+      { collection: 'articles', fields: ['title'] },
+      { collection: 'pages', fields: ['heading'] },
+    ]);
+  });
+
+  it('does not duplicate fields that overlap between inputs', () => {
+    const a = [{ collection: 'articles', fields: ['title', 'body'] }];
+    const b = [{ collection: 'articles', fields: ['title'] }];
+    expect(unionEnabledFields(a, b)).toEqual([{ collection: 'articles', fields: ['title', 'body'] }]);
+  });
+});
+
+describe('subtractEnabledFields — scope-additive Deselect all', () => {
+  it('removes only the fields present in the second list', () => {
+    const a = [{ collection: 'articles', fields: ['title', 'body'] }];
+    const b = [{ collection: 'articles', fields: ['title'] }];
+    expect(subtractEnabledFields(a, b)).toEqual([{ collection: 'articles', fields: ['body'] }]);
+  });
+
+  it('drops collections that become empty', () => {
+    const a = [{ collection: 'articles', fields: ['title'] }];
+    const b = [{ collection: 'articles', fields: ['title'] }];
+    expect(subtractEnabledFields(a, b)).toEqual([]);
+  });
+
+  it('leaves untouched collections alone', () => {
+    const a = [
+      { collection: 'articles', fields: ['title'] },
+      { collection: 'pages', fields: ['heading'] },
+    ];
+    const b = [{ collection: 'articles', fields: ['title'] }];
+    expect(subtractEnabledFields(a, b)).toEqual([{ collection: 'pages', fields: ['heading'] }]);
+  });
+});

--- a/extensions/module/src/composables/tree-visibility.ts
+++ b/extensions/module/src/composables/tree-visibility.ts
@@ -1,0 +1,122 @@
+import { AppCollection, Field } from '@directus/types';
+import { EnabledField } from '../../../common/models/collections-data/content-transfer-setup';
+import { FieldsUtilsService } from '../../../common/utilities/fields-utils-service';
+
+// Pure functions that translate the page-level lens state (ADR-0003) into the
+// concrete set of nodes that should be visible in the Import & Export tree.
+//
+// CollectionItem.vue uses these to decide its own render output; Sync.vue uses
+// the same functions to compute the scope-additive Select all / Deselect all
+// targets. Same predicates on both sides keep the bulk-action arithmetic in
+// lockstep with what the user is looking at.
+
+export type VisibilityContext = {
+  isActive: boolean;
+  isMatch: (label: string) => boolean;
+  allCollections: AppCollection[];
+  getFieldsForCollection: (collectionName: string) => { translatableFields: Field[]; allFields: Field[] };
+  showUntranslatableField: boolean;
+  showUntranslatableCollections: boolean;
+  isTranslatableCollection: (collection: AppCollection) => boolean;
+};
+
+export function getNestedCollections(collection: AppCollection, ctx: VisibilityContext): AppCollection[] {
+  return ctx.allCollections.filter((c) => c.meta?.group === collection.collection);
+}
+
+// Field list a collection would render *before* the search lens narrows it,
+// honouring the existing `Show untranslatable fields` toggle. Mirror of
+// `renderedFields` in CollectionItem.vue.
+export function renderedFieldsFor(collection: AppCollection, ctx: VisibilityContext): Field[] {
+  const { allFields, translatableFields } = ctx.getFieldsForCollection(collection.collection);
+  return ctx.showUntranslatableField ? allFields : translatableFields;
+}
+
+export function collectionNameMatches(collection: AppCollection, ctx: VisibilityContext): boolean {
+  return ctx.isMatch(collection.name);
+}
+
+// Does this subtree contain anything the active lens should reveal? The
+// recursion mirrors how CollectionItem.vue renders children; if the lens is
+// inactive everything qualifies trivially.
+export function subtreeHasMatch(collection: AppCollection, ctx: VisibilityContext): boolean {
+  if (!ctx.isActive) return true;
+  if (collectionNameMatches(collection, ctx)) return true;
+  if (renderedFieldsFor(collection, ctx).some((f) => ctx.isMatch(f.name))) return true;
+  return getNestedCollections(collection, ctx).some((child) => subtreeHasMatch(child, ctx));
+}
+
+// Should the collection appear in the tree right now? The pre-lens half is a
+// straight port of CollectionItem.vue's `shouldRender`; the lens then prunes
+// any branch that has nothing to reveal.
+export function isCollectionShown(collection: AppCollection, ctx: VisibilityContext): boolean {
+  const nested = getNestedCollections(collection, ctx);
+  const baseShown = nested.length > 0 || ctx.isTranslatableCollection(collection) || ctx.showUntranslatableCollections;
+  if (!baseShown) return false;
+  return subtreeHasMatch(collection, ctx);
+}
+
+// Which fields the collection renders right now. A collection-name match shows
+// every field (Q3 / ADR-0003 — collection-level intent overrides field-level
+// filtering); otherwise only fields whose names match the lens.
+export function visibleFieldsForCollection(collection: AppCollection, ctx: VisibilityContext): Field[] {
+  const rendered = renderedFieldsFor(collection, ctx);
+  if (!ctx.isActive) return rendered;
+  if (collectionNameMatches(collection, ctx)) return rendered;
+  return rendered.filter((f) => ctx.isMatch(f.name));
+}
+
+// Translatable fields among the currently visible ones — the set the
+// scope-additive Select all / per-collection checkbox operates on.
+export function visibleTranslatableFieldsFor(collection: AppCollection, ctx: VisibilityContext): Field[] {
+  return visibleFieldsForCollection(collection, ctx).filter(FieldsUtilsService.isTranslatableField);
+}
+
+// Flattened {collection, fields[]} list of every visible translatable field in
+// the tree rooted at `rootCollections`. Drives the page-level Select all
+// union and the master-checkbox indeterminate state under an active lens.
+export function buildVisibleTranslatableSelection(rootCollections: AppCollection[], ctx: VisibilityContext): EnabledField[] {
+  const out: EnabledField[] = [];
+  const walk = (collection: AppCollection): void => {
+    if (!isCollectionShown(collection, ctx)) return;
+    if (ctx.isTranslatableCollection(collection)) {
+      const visible = visibleTranslatableFieldsFor(collection, ctx);
+      if (visible.length > 0) out.push({ collection: collection.collection, fields: visible.map((f) => f.field) });
+    }
+    for (const nested of getNestedCollections(collection, ctx)) walk(nested);
+  };
+  for (const root of rootCollections) walk(root);
+  return out;
+}
+
+// Union of two EnabledField lists, merged per collection. Used by `Select all`
+// while a lens is active: existing selections in hidden parts of the tree
+// must survive the click.
+export function unionEnabledFields(a: EnabledField[], b: EnabledField[]): EnabledField[] {
+  const map = new Map<string, Set<string>>();
+  for (const entry of a) map.set(entry.collection, new Set(entry.fields));
+  for (const entry of b) {
+    const existing = map.get(entry.collection) ?? new Set<string>();
+    for (const f of entry.fields) existing.add(f);
+    map.set(entry.collection, existing);
+  }
+  return [...map.entries()].map(([collection, fields]) => ({ collection, fields: [...fields] }));
+}
+
+// Subtract `b` from `a` per-collection; drops collections that end up empty.
+// Used by `Deselect all` while a lens is active.
+export function subtractEnabledFields(a: EnabledField[], b: EnabledField[]): EnabledField[] {
+  const subtract = new Map<string, Set<string>>();
+  for (const entry of b) subtract.set(entry.collection, new Set(entry.fields));
+  const out: EnabledField[] = [];
+  for (const entry of a) {
+    const drop = subtract.get(entry.collection);
+    if (!drop) {
+      out.push(entry);
+      continue;
+    }
+    const remaining = entry.fields.filter((f) => !drop.has(f));
+    if (remaining.length > 0) out.push({ collection: entry.collection, fields: remaining });
+  }
+  return out;
+}

--- a/extensions/module/src/composables/use-tree-search.test.ts
+++ b/extensions/module/src/composables/use-tree-search.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { matchesText, splitHighlight, useTreeSearch } from './use-tree-search';
+
+describe('matchesText', () => {
+  it('returns true when the query is empty (no lens is no narrowing)', () => {
+    expect(matchesText('Articles translations', '')).toBe(true);
+    expect(matchesText('', '')).toBe(true);
+  });
+
+  it('matches case-insensitively against the label (caller passes the query pre-lowercased)', () => {
+    expect(matchesText('Articles translations', 'art')).toBe(true);
+    expect(matchesText('Articles translations', 'trans')).toBe(true);
+    expect(matchesText('Articles translations', 'lations')).toBe(true);
+  });
+
+  it('returns false when the substring is absent', () => {
+    expect(matchesText('Articles translations', 'banner')).toBe(false);
+  });
+
+  it('treats whitespace inside the query as literal — single token only', () => {
+    expect(matchesText('Articles translations', 'les trans')).toBe(true);
+    expect(matchesText('Articles translations', 'art lations')).toBe(false);
+  });
+});
+
+describe('splitHighlight', () => {
+  it('returns a single unmatched segment when the query is empty', () => {
+    expect(splitHighlight('Articles', '')).toEqual([{ text: 'Articles', matched: false }]);
+  });
+
+  it('splits around a single match preserving original casing', () => {
+    expect(splitHighlight('Articles translations', 'art')).toEqual([
+      { text: 'Art', matched: true },
+      { text: 'icles translations', matched: false },
+    ]);
+  });
+
+  it('splits around multiple occurrences', () => {
+    expect(splitHighlight('aXaXa', 'a')).toEqual([
+      { text: 'a', matched: true },
+      { text: 'X', matched: false },
+      { text: 'a', matched: true },
+      { text: 'X', matched: false },
+      { text: 'a', matched: true },
+    ]);
+  });
+
+  it('returns a single unmatched segment when the query is absent from the label', () => {
+    expect(splitHighlight('Articles', 'banner')).toEqual([{ text: 'Articles', matched: false }]);
+  });
+});
+
+describe('useTreeSearch', () => {
+  it('trims and lowercases the input for matching', () => {
+    const lens = useTreeSearch();
+    lens.query.value = '  ART  ';
+    expect(lens.normalizedQuery.value).toBe('art');
+    expect(lens.isActive.value).toBe(true);
+    expect(lens.isMatch('articles translations')).toBe(true);
+    expect(lens.isMatch('Banner')).toBe(false);
+  });
+
+  it('treats a blank input as inactive', () => {
+    const lens = useTreeSearch();
+    expect(lens.isActive.value).toBe(false);
+    lens.query.value = '   ';
+    expect(lens.isActive.value).toBe(false);
+    // Inactive lens matches everything (no narrowing).
+    expect(lens.isMatch('anything')).toBe(true);
+  });
+
+  it('coalesces a null query value to empty (defensive against v-input)', () => {
+    const lens = useTreeSearch();
+    // Simulate the `v-input` clear-to-null path.
+    lens.query.value = null as unknown as string;
+    expect(lens.normalizedQuery.value).toBe('');
+    expect(lens.isActive.value).toBe(false);
+  });
+
+  it('clear() resets the query', () => {
+    const lens = useTreeSearch();
+    lens.query.value = 'foo';
+    lens.clear();
+    expect(lens.query.value).toBe('');
+    expect(lens.isActive.value).toBe(false);
+  });
+});

--- a/extensions/module/src/composables/use-tree-search.ts
+++ b/extensions/module/src/composables/use-tree-search.ts
@@ -1,0 +1,46 @@
+import { computed, ref } from 'vue';
+
+export type HighlightSegment = { text: string; matched: boolean };
+
+export function matchesText(label: string, normalizedQuery: string): boolean {
+  if (!normalizedQuery) return true;
+  return label.toLowerCase().includes(normalizedQuery);
+}
+
+// Splits a label into matched / unmatched segments for rendering. Returned segments
+// reuse the original label's casing — `normalizedQuery` only drives where to cut.
+// Always returns at least one segment so the caller can `v-for` without a fallback.
+export function splitHighlight(label: string, normalizedQuery: string): HighlightSegment[] {
+  if (!normalizedQuery) return [{ text: label, matched: false }];
+  const lower = label.toLowerCase();
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+  while (cursor < label.length) {
+    const idx = lower.indexOf(normalizedQuery, cursor);
+    if (idx < 0) {
+      segments.push({ text: label.slice(cursor), matched: false });
+      break;
+    }
+    if (idx > cursor) segments.push({ text: label.slice(cursor, idx), matched: false });
+    segments.push({ text: label.slice(idx, idx + normalizedQuery.length), matched: true });
+    cursor = idx + normalizedQuery.length;
+  }
+  return segments;
+}
+
+// Owns the page-level search query. Designed to be a transient lens (ADR-0003):
+// the input resets on every visit because the composable is instantiated by the
+// hosting component, and dies with it on route unmount.
+export function useTreeSearch() {
+  const query = ref<string>('');
+  // `v-input` can emit `null` when cleared depending on its `nullable` prop —
+  // coalesce defensively so the rest of the lens never sees a nullish value.
+  const normalizedQuery = computed(() => (query.value ?? '').trim().toLowerCase());
+  const isActive = computed(() => normalizedQuery.value.length > 0);
+  const isMatch = (label: string) => matchesText(label, normalizedQuery.value);
+  const highlight = (label: string) => splitHighlight(label, normalizedQuery.value);
+  const clear = () => {
+    query.value = '';
+  };
+  return { query, normalizedQuery, isActive, isMatch, highlight, clear };
+}

--- a/extensions/sync-hook/README.md
+++ b/extensions/sync-hook/README.md
@@ -16,7 +16,7 @@
 
 ## ⚠️ Installation requirements
 
-This extension is a **non-sandboxed Directus bundle** (a hook child plus a small endpoint child for health checks) — it uses Directus' `ItemsService` and `FieldsService` directly to read and modify your translatable content. Non-sandboxed extensions are not installed via the Marketplace by default.
+This extension is a **non-sandboxed Directus bundle** (a hook child plus a small endpoint child the module pings to detect whether the bundle is installed) — it uses Directus' `ItemsService` and `FieldsService` directly to read and modify your translatable content. Non-sandboxed extensions are not installed via the Marketplace by default.
 
 **Before installing, set this in your Directus configuration:**
 


### PR DESCRIPTION
## Summary

- Adds a transient search box above the Import & Export tree (`Sync.vue`) that filters by display name across collections, fields, and the Translation Strings row, with the matched substring highlighted (`HighlightedLabel.vue`).
- Bulk actions become lens-aware while a search is active: page-level **Select all** / **Deselect all** and the per-collection checkbox all scope-additively to the visible subset, so hidden selections survive a click. The math lives in `composables/tree-visibility.ts` and is shared by both `Sync.vue` and `CollectionItem.vue`.
- Records the load-bearing decisions (lens-as-transient + additive Select all + expansion-as-lens-owned + AND-composition with the existing visibility toggles) in [ADR-0003](docs/adr/0003-import-export-tree-search-as-lens.md).
- Folds in three previously unstaged doc / UX touch-ups: Activity page persists the active tab in the URL hash; `CONTRIBUTING.md` and the sync-hook README clarify the bundle now ships both a hook child and an endpoint child.

## Test plan

- [ ] Run `npm run check` (lint + format + typecheck + 613 tests) → all green.
- [ ] Run `npm run build` → both extensions build.
- [ ] In `npm run dev`, open Import & Export and try the search box:
  - [ ] Type a field name (e.g. `title`) — only matching fields show, parent collections auto-expand.
  - [ ] Type a collection name (e.g. `articles`) — collection shows with all its fields.
  - [ ] Type something nonexistent — empty-state message renders, hint mentions whichever visibility toggle is currently OFF.
  - [ ] With a few collections enabled outside the visible scope, type to narrow, hit **Select all** — visible fields become selected, hidden selections remain intact.
  - [ ] Hit **Deselect all** — only visible fields are deselected.
  - [ ] Toggle a per-collection checkbox while the lens is active — only its visible fields flip.
  - [ ] Clear the input via the × button or **Escape** — tree restores to its pre-lens expansion state.
- [ ] Reload the Activity page on `#upload` and on `#download` — each lands on the right tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)