### PR TITLE
PR 70/N: tree search — reveal whole subtree under a name-matched collection

### DIFF
--- a/extensions/module/src/components/Sync/CollectionItem.vue
+++ b/extensions/module/src/components/Sync/CollectionItem.vue
@@ -58,6 +58,7 @@
         :show-untranslatable-field="showUntranslatableField"
         :show-untranslatable-collections="showUntranslatableCollections"
         :normalized-query="normalizedQuery"
+        :in-matched-subtree="childInMatchedSubtree"
         @update:selections="$emit('update:selections', $event)"
       />
     </div>
@@ -72,10 +73,10 @@ import { useGetFieldsForTranslationRelation } from '../../composables/use-get-fi
 import { EnabledField } from '../../../../common/models/collections-data/content-transfer-setup';
 import { FieldsUtilsService } from '../../../../common/utilities/fields-utils-service';
 import {
+  descendantsInMatchedSubtree,
   getNestedCollections as visibilityGetNested,
   isCollectionShown,
   renderedFieldsFor,
-  subtreeHasMatch,
   visibleFieldsForCollection,
   visibleTranslatableFieldsFor,
   VisibilityContext,
@@ -110,6 +111,14 @@ const props = defineProps({
   normalizedQuery: {
     type: String,
     required: true,
+  },
+  // Set by the parent CollectionItem when this node is being rendered as a
+  // descendant of a name-matched ancestor (Q3 / ADR-0003). When `true`, the
+  // lens is effectively off for this node — every nested collection and field
+  // is shown unfiltered, so a search like "deals" reveals the whole subtree.
+  inMatchedSubtree: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -164,27 +173,43 @@ const localSelections = computed({
 const selectionsForCollection = computed(() => props.selections.find((selection) => selection.collection === props.collection.collection));
 const otherSelections = computed(() => props.selections.filter((selection) => selection.collection !== props.collection.collection));
 
-const nestedCollections = computed(() =>
-  visibilityGetNested(props.collection, visibilityContext.value).filter((c) => isCollectionShown(c, visibilityContext.value)),
+// `inMatchedSubtree` propagates to this collection's children if either (a)
+// this node is itself a descendant of a matched ancestor, or (b) this node's
+// own name matches the active lens. Children render unfiltered in either case.
+const childInMatchedSubtree = computed(() =>
+  descendantsInMatchedSubtree(props.collection, visibilityContext.value, props.inMatchedSubtree),
 );
 
-// Fields actually rendered under the lens: a collection-name match shows all
-// (lens-unrelated) rendered fields; otherwise only fields whose own names match.
+const nestedCollections = computed(() =>
+  visibilityGetNested(props.collection, visibilityContext.value).filter((c) =>
+    isCollectionShown(c, visibilityContext.value, childInMatchedSubtree.value),
+  ),
+);
+
+// Fields actually rendered under the lens: an ancestor's name match (or this
+// collection's own) shows all rendered fields; otherwise only fields whose
+// own names match.
 const allRenderedFields = computed<Field[]>(() => renderedFieldsFor(props.collection, visibilityContext.value));
-const renderedFields = computed<Field[]>(() => visibleFieldsForCollection(props.collection, visibilityContext.value));
+const renderedFields = computed<Field[]>(() =>
+  visibleFieldsForCollection(props.collection, visibilityContext.value, props.inMatchedSubtree),
+);
 
 // `shouldRender` collapses three predicates: legacy visibility rules from
 // CollectionItem.vue plus the lens. Delegated to `isCollectionShown` so the
 // page-level scope-additive selection sees the same answer.
-const shouldRender = computed(() => isCollectionShown(props.collection, visibilityContext.value));
+const shouldRender = computed(() => isCollectionShown(props.collection, visibilityContext.value, props.inMatchedSubtree));
 const isExpandable = computed(() => nestedCollections.value.length > 0 || renderedFields.value.length > 0);
 
 // Visible translatable fields — the scope the per-collection checkbox operates
 // on under an active lens; falls back to the full rendered list otherwise so
 // the legacy "translatable only" rule still drives unfiltered selection.
-const visibleTranslatableFields = computed<Field[]>(() => visibleTranslatableFieldsFor(props.collection, visibilityContext.value));
+// Inside a name-matched subtree the lens is effectively off, so the scope
+// becomes the full translatable set (same as unfiltered behaviour).
+const visibleTranslatableFields = computed<Field[]>(() =>
+  visibleTranslatableFieldsFor(props.collection, visibilityContext.value, props.inMatchedSubtree),
+);
 const translatableFieldsForToggle = computed<Field[]>(() =>
-  lensActive.value ? visibleTranslatableFields.value : allRenderedFields.value.filter(isTranslatableField),
+  lensActive.value && !props.inMatchedSubtree ? visibleTranslatableFields.value : allRenderedFields.value.filter(isTranslatableField),
 );
 
 const enabledFieldNames = computed<string[]>(() => selectionsForCollection.value?.fields ?? []);
@@ -238,11 +263,13 @@ function onUpdateCollectionSelection() {
 
 // Expansion state: the lens drives it while active (Q12 / ADR-0003). When the
 // lens flips off, restore the user's pre-lens expansion. `preLensExpanded`
-// remembers what `isExpanded` was the moment the lens turned on.
+// remembers what `isExpanded` was the moment the lens turned on. Any node
+// that survives `shouldRender` under an active lens is auto-expanded — both
+// "I matched" nodes and "I'm inside a matched subtree" nodes need their body
+// visible for the user to actually act on the result.
 const userExpanded = ref(allRenderedFields.value.length === 0);
 const preLensExpanded = ref<boolean | null>(null);
-const lensExpansion = computed<boolean>(() => lensActive.value && subtreeHasMatch(props.collection, visibilityContext.value));
-const isExpanded = computed(() => (lensActive.value ? lensExpansion.value : userExpanded.value));
+const isExpanded = computed(() => (lensActive.value ? true : userExpanded.value));
 
 watch(lensActive, (active, wasActive) => {
   if (active && !wasActive) {

--- a/extensions/module/src/composables/tree-visibility.test.ts
+++ b/extensions/module/src/composables/tree-visibility.test.ts
@@ -143,6 +143,39 @@ describe('buildVisibleTranslatableSelection', () => {
       { collection: 'pages', fields: ['heading'] },
     ]);
   });
+
+  it('reveals every nested collection when an ancestor folder name matches', () => {
+    // Q3 / ADR-0003: a name-matched folder (no translatable fields of its own)
+    // must expose its entire descendant subtree, not an empty body. Regression
+    // test for the "Partnership Deals" case in PR #87 follow-up.
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('content') });
+    expect(buildVisibleTranslatableSelection([content], ctx)).toEqual([
+      { collection: 'articles', fields: ['title', 'body'] },
+      { collection: 'pages', fields: ['heading'] },
+    ]);
+  });
+});
+
+describe('isCollectionShown — name-matched subtree', () => {
+  it('shows a non-matching descendant when its ancestor flagged the subtree as matched', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('content') });
+    // `content` matches on its own; `articles` does not — but it's inside the matched subtree.
+    expect(isCollectionShown(articles, ctx, /* inMatchedSubtree */ true)).toBe(true);
+  });
+
+  it('still hides a node that the base visibility rules already exclude, even inside a matched subtree', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: () => true });
+    // `settings` is untranslatable and the toggle is off; the matched-subtree
+    // flag does not override base visibility.
+    expect(isCollectionShown(settings, ctx, true)).toBe(false);
+  });
+});
+
+describe('visibleFieldsForCollection — inside a matched subtree', () => {
+  it('returns every rendered field when inside a name-matched subtree, regardless of own-name match', () => {
+    const ctx = makeCtx({ isActive: true, isMatch: (s) => s.toLowerCase().includes('content') });
+    expect(visibleFieldsForCollection(articles, ctx, true).map((f) => f.field)).toEqual(['title', 'body']);
+  });
 });
 
 describe('unionEnabledFields — scope-additive Select all', () => {

--- a/extensions/module/src/composables/tree-visibility.ts
+++ b/extensions/module/src/composables/tree-visibility.ts
@@ -46,30 +46,45 @@ export function subtreeHasMatch(collection: AppCollection, ctx: VisibilityContex
   return getNestedCollections(collection, ctx).some((child) => subtreeHasMatch(child, ctx));
 }
 
+// `inMatchedSubtree` carries the "an ancestor's name matched the lens"
+// signal through the recursion. Inside such a subtree the lens is effectively
+// off (Q3 / ADR-0003 — a collection-name match reveals every descendant in
+// full, including nested collections and their fields).
+
 // Should the collection appear in the tree right now? The pre-lens half is a
 // straight port of CollectionItem.vue's `shouldRender`; the lens then prunes
-// any branch that has nothing to reveal.
-export function isCollectionShown(collection: AppCollection, ctx: VisibilityContext): boolean {
+// any branch that has nothing to reveal — unless an ancestor's name matched,
+// in which case the lens is silenced for this subtree.
+export function isCollectionShown(collection: AppCollection, ctx: VisibilityContext, inMatchedSubtree = false): boolean {
   const nested = getNestedCollections(collection, ctx);
   const baseShown = nested.length > 0 || ctx.isTranslatableCollection(collection) || ctx.showUntranslatableCollections;
   if (!baseShown) return false;
+  if (inMatchedSubtree) return true;
   return subtreeHasMatch(collection, ctx);
 }
 
-// Which fields the collection renders right now. A collection-name match shows
-// every field (Q3 / ADR-0003 — collection-level intent overrides field-level
-// filtering); otherwise only fields whose names match the lens.
-export function visibleFieldsForCollection(collection: AppCollection, ctx: VisibilityContext): Field[] {
+// Which fields the collection renders right now. A collection-name match (or
+// any ancestor's name match) shows every field unfiltered; otherwise only
+// fields whose own names match the lens.
+export function visibleFieldsForCollection(collection: AppCollection, ctx: VisibilityContext, inMatchedSubtree = false): Field[] {
   const rendered = renderedFieldsFor(collection, ctx);
-  if (!ctx.isActive) return rendered;
+  if (!ctx.isActive || inMatchedSubtree) return rendered;
   if (collectionNameMatches(collection, ctx)) return rendered;
   return rendered.filter((f) => ctx.isMatch(f.name));
 }
 
 // Translatable fields among the currently visible ones — the set the
 // scope-additive Select all / per-collection checkbox operates on.
-export function visibleTranslatableFieldsFor(collection: AppCollection, ctx: VisibilityContext): Field[] {
-  return visibleFieldsForCollection(collection, ctx).filter(FieldsUtilsService.isTranslatableField);
+export function visibleTranslatableFieldsFor(collection: AppCollection, ctx: VisibilityContext, inMatchedSubtree = false): Field[] {
+  return visibleFieldsForCollection(collection, ctx, inMatchedSubtree).filter(FieldsUtilsService.isTranslatableField);
+}
+
+// Are this collection's descendants inside a name-matched subtree? True iff an
+// ancestor already flagged the subtree as matched, OR this collection's own
+// name matches the active lens (in which case its children inherit the flag).
+export function descendantsInMatchedSubtree(collection: AppCollection, ctx: VisibilityContext, inMatchedSubtree: boolean): boolean {
+  if (inMatchedSubtree) return true;
+  return ctx.isActive && collectionNameMatches(collection, ctx);
 }
 
 // Flattened {collection, fields[]} list of every visible translatable field in
@@ -77,15 +92,16 @@ export function visibleTranslatableFieldsFor(collection: AppCollection, ctx: Vis
 // union and the master-checkbox indeterminate state under an active lens.
 export function buildVisibleTranslatableSelection(rootCollections: AppCollection[], ctx: VisibilityContext): EnabledField[] {
   const out: EnabledField[] = [];
-  const walk = (collection: AppCollection): void => {
-    if (!isCollectionShown(collection, ctx)) return;
+  const walk = (collection: AppCollection, inMatchedSubtree: boolean): void => {
+    if (!isCollectionShown(collection, ctx, inMatchedSubtree)) return;
     if (ctx.isTranslatableCollection(collection)) {
-      const visible = visibleTranslatableFieldsFor(collection, ctx);
+      const visible = visibleTranslatableFieldsFor(collection, ctx, inMatchedSubtree);
       if (visible.length > 0) out.push({ collection: collection.collection, fields: visible.map((f) => f.field) });
     }
-    for (const nested of getNestedCollections(collection, ctx)) walk(nested);
+    const childInSubtree = descendantsInMatchedSubtree(collection, ctx, inMatchedSubtree);
+    for (const nested of getNestedCollections(collection, ctx)) walk(nested, childInSubtree);
   };
-  for (const root of rootCollections) walk(root);
+  for (const root of rootCollections) walk(root, false);
   return out;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #87. The original implementation honoured Q3 / ADR-0003 only for *fields* of a name-matched collection (it would show every field, even non-matching ones), but the same rule should apply to *nested collections* and their fields. Without it, typing `"deals"` reveals `Partnership Deals` as a lone row with an empty body — its translatable child `Partnership Actions` was filtered out because its own subtree contained no match.

This PR threads an `inMatchedSubtree` flag through the recursion in `tree-visibility.ts` and `CollectionItem.vue`. Once any ancestor's name matches, every descendant renders in full — nested folders, their nested collections, and all the fields — and is fully clickable. The page-level `Select all` and the per-collection toggle update in lockstep because they consume the same helpers.

## Test plan

- [ ] `npm run check` — 617 tests pass (4 new).
- [ ] `npm run build` — both extensions build clean.
- [ ] Local dev: with `Partnership Deals → Partnership Actions → {Title, Description}` in the schema, type `"deals"` in the search. The folder, the nested collection, and both fields should all appear, expanded and clickable.
- [ ] Hit `Select all` while the search is active → the nested collection's translatable fields are selected; existing selections outside the visible subtree remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)