### PR TITLE
PR 72/N: dark-mode readability sweep + Sync search input border

### DIFF
--- a/extensions/module/src/Activity.vue
+++ b/extensions/module/src/Activity.vue
@@ -290,7 +290,7 @@ onBeforeMount(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 13px;
   margin-bottom: 16px;
 }
@@ -331,7 +331,7 @@ onBeforeMount(() => {
 .filter-label {
   font-size: 12px;
   font-weight: 600;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }

--- a/extensions/module/src/ActivityDetail.vue
+++ b/extensions/module/src/ActivityDetail.vue
@@ -106,7 +106,7 @@ onBeforeMount(async () => {
 .empty-state {
   padding: 48px;
   text-align: center;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
 }
 
 .metadata-section {
@@ -126,7 +126,7 @@ onBeforeMount(async () => {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   letter-spacing: 0.5px;
   margin-bottom: 4px;
 }
@@ -168,7 +168,7 @@ onBeforeMount(async () => {
 }
 
 .entry-timestamp {
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 12px;
   white-space: nowrap;
   min-width: 80px;
@@ -181,7 +181,7 @@ onBeforeMount(async () => {
 
 .entry-user {
   font-size: 12px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-style: italic;
   margin-left: 4px;
 }
@@ -202,7 +202,7 @@ onBeforeMount(async () => {
   background-color: var(--theme--background-subdued);
   border-radius: var(--theme--border-radius);
   font-size: 12px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/extensions/module/src/AdvancedSettings.vue
+++ b/extensions/module/src/AdvancedSettings.vue
@@ -225,7 +225,7 @@ async function onSaveChanges() {
 
 .operator-tools-note {
   font-size: 13px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   margin: 0 0 12px 0;
   max-width: 640px;
 }
@@ -247,7 +247,7 @@ async function onSaveChanges() {
   display: contents;
 
   dt {
-    color: var(--theme--foreground-subdued);
+    color: var(--theme--foreground);
     font-weight: 600;
   }
 

--- a/extensions/module/src/Automation.vue
+++ b/extensions/module/src/Automation.vue
@@ -142,7 +142,7 @@ onBeforeMount(() => {
   align-items: center;
   gap: 8px;
   margin-top: 24px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 14px;
 }
 
@@ -152,7 +152,7 @@ onBeforeMount(() => {
 
 .bundle-version {
   font-size: 12px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   margin-top: 16px;
   margin-bottom: 16px;
 

--- a/extensions/module/src/Sync.vue
+++ b/extensions/module/src/Sync.vue
@@ -351,16 +351,24 @@ function deselectAll() {
 
   .search-input {
     width: 100%;
+    /* Directus' v-input reads its border from --v-input-border-color and the
+       hover / focus variants below. Without these, the input renders borderless
+       in both modes. Resting uses the theme's regular border (not the subdued
+       one — it needs to read as an interactive field, not a panel divider);
+       hover bumps it to accent; focus picks up the brand colour. */
+    --v-input-border-color: var(--theme--border-color);
+    --v-input-border-color-hover: var(--theme--border-color-accent);
+    --v-input-border-color-focus: var(--theme--primary);
   }
 
   .search-icon {
-    color: var(--theme--foreground-subdued);
+    color: var(--theme--foreground);
   }
 
   .clear-icon {
-    color: var(--theme--foreground-subdued);
+    color: var(--theme--foreground);
     &:hover {
-      color: var(--theme--foreground);
+      color: var(--theme--primary);
     }
   }
 }
@@ -371,7 +379,7 @@ function deselectAll() {
   background-color: var(--theme--background-subdued);
   border: 1px dashed var(--theme--border-color-subdued);
   border-radius: var(--theme--border-radius);
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 13px;
 
   .empty-results-title {
@@ -402,7 +410,7 @@ function deselectAll() {
   border-radius: var(--theme--border-radius);
   cursor: pointer;
   font-size: 13px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   transition: background-color var(--fast) var(--transition);
 
   &:hover,

--- a/extensions/module/src/components/Activity/SessionMetadata.vue
+++ b/extensions/module/src/components/Activity/SessionMetadata.vue
@@ -60,7 +60,7 @@ defineProps<{
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   letter-spacing: 0.5px;
 }
 

--- a/extensions/module/src/components/Activity/SessionsTable.vue
+++ b/extensions/module/src/components/Activity/SessionsTable.vue
@@ -104,7 +104,7 @@ const columns: Array<{ key: SortKey; label: string }> = [
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   letter-spacing: 0.5px;
 
   &.active {
@@ -143,7 +143,7 @@ const columns: Array<{ key: SortKey; label: string }> = [
 .empty-state {
   padding: 56px 32px;
   text-align: center;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 14px;
 }
 </style>

--- a/extensions/module/src/components/Activity/StatusLabel.vue
+++ b/extensions/module/src/components/Activity/StatusLabel.vue
@@ -83,6 +83,6 @@ const statusClass = computed(() => {
 
 .status-neutral {
   background: var(--theme--background-subdued);
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
 }
 </style>

--- a/extensions/module/src/components/Automation/AutomationForm.vue
+++ b/extensions/module/src/components/Automation/AutomationForm.vue
@@ -298,6 +298,6 @@ onMounted(() => {
 
 .hint {
   margin-top: 6px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
 }
 </style>

--- a/extensions/module/src/components/Automation/WebhookSetup.vue
+++ b/extensions/module/src/components/Automation/WebhookSetup.vue
@@ -198,7 +198,7 @@ watch(
   display: flex;
   gap: 8px;
   align-items: center;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   font-size: 14px;
 }
 
@@ -246,7 +246,7 @@ watch(
 .step-description {
   margin: 6px 0 0 0;
   font-size: 13px;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
 
   code {
     background: var(--theme--background-subdued);

--- a/extensions/module/src/components/Modals/ProgressTrackerModal.vue
+++ b/extensions/module/src/components/Modals/ProgressTrackerModal.vue
@@ -6,7 +6,7 @@
         <div v-for="(progress, idx) in progressTracker" :key="idx">
           <v-icon v-if="progress.type === 'error'" name="clear" color="var(--theme--danger)" />
           <v-icon v-else-if="idx + 1 < progressTracker.length || !loading" name="check" color="var(--theme--success)" />
-          <v-icon v-else name="arrow_right_alt" color="var(--theme--foreground-subdued)" />
+          <v-icon v-else name="arrow_right_alt" color="var(--theme--foreground)" />
           <span>
             {{ progress.message }}
           </span>

--- a/extensions/module/src/components/Overview/ConnectionLanguages.vue
+++ b/extensions/module/src/components/Overview/ConnectionLanguages.vue
@@ -231,7 +231,7 @@ $radius: var(--border-radius, var(--theme--border-radius));
 $bg-card: var(--background-normal, var(--theme--background-normal, var(--theme--background)));
 $bg-subdued: var(--background-subdued, var(--theme--background-subdued));
 $fg-normal: var(--foreground-normal, var(--theme--foreground));
-$fg-subdued: var(--foreground-subdued, var(--theme--foreground-subdued));
+$fg-subdued: var(--foreground-subdued, var(--theme--foreground));
 $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme--foreground)));
 $mono: var(--family-monospace, var(--theme--family-monospace, ui-monospace, SFMono-Regular, Menlo, monospace));
 
@@ -325,6 +325,6 @@ $mono: var(--family-monospace, var(--theme--family-monospace, ui-monospace, SFMo
 }
 
 .hidden-language {
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
 }
 </style>

--- a/extensions/module/src/components/Overview/ConnectionOverview.vue
+++ b/extensions/module/src/components/Overview/ConnectionOverview.vue
@@ -148,7 +148,7 @@ async function onReconnect() {
 $divider-color: var(--border-normal, var(--theme--border-color-accent));
 $radius: var(--border-radius, var(--theme--border-radius));
 $fg-normal: var(--foreground-normal, var(--theme--foreground));
-$fg-subdued: var(--foreground-subdued, var(--theme--foreground-subdued));
+$fg-subdued: var(--foreground-subdued, var(--theme--foreground));
 $fg-accent: var(--foreground-accent, var(--theme--foreground-accent, var(--theme--foreground)));
 
 .connection-label {

--- a/extensions/module/src/components/Sync/CollectionItem.vue
+++ b/extensions/module/src/components/Sync/CollectionItem.vue
@@ -322,7 +322,7 @@ watch(allRenderedFields, (next) => {
 
 .collection-group-chevron {
   margin-right: 0 !important;
-  color: var(--theme--foreground-subdued);
+  color: var(--theme--foreground);
   transform: rotate(0deg);
   transition: transform var(--medium) var(--transition);
 


### PR DESCRIPTION
## Summary

- **Readability sweep**: Replace \`--theme--foreground-subdued\` with \`--theme--foreground\` for body copy, labels, table headers, metadata rows, empty states, and the last-sync banner across the Localazy module (Activity / ActivityDetail / Automation / AdvancedSettings / Sync, plus several child components). The subdued token reads too gray to use for text the user actually needs to read; hierarchy is preserved through font-size and font-weight.
- **Search input border**: \`v-input\` in \`Sync.vue\` rendered borderless because \`--v-input-border-color\` wasn't set. Wire up resting / hover / focus colours using the same theme tokens used elsewhere on the page.

## Test plan

- [ ] \`npm run check\` — 617 tests pass.
- [ ] \`npm run build\` — both extensions build clean.
- [ ] Reload module pages in both light and dark themes; previously-gray labels and metadata are clearly readable.
- [ ] The Import & Export search input now has a visible border at rest, a stronger one on hover, and a primary-coloured focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)