### PR TITLE
PR 73/N: fix two fresh-install UX bugs (loadContext race + phantom-dirty Project Setup)

### DIFF
--- a/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
+++ b/extensions/module/src/components/ProjectSetup/ProjectSetupForm.vue
@@ -154,20 +154,14 @@ const languageSelectOptions = computed(() =>
   }),
 );
 
-watchEffect(() => {
-  const lookupLanguageCollection = possibleLanguageCollections.find((col) => col.value.toLocaleLowerCase() === 'languages');
-  if (lookupLanguageCollection) {
-    localEdits.value.language_collection = lookupLanguageCollection.value;
-  }
-});
-
-watchEffect(() => {
-  const lookupLanguageCodeField = possibleLanguageCodeFields.value.find((col) => col.value.toLocaleLowerCase() === 'code');
-  if (lookupLanguageCodeField) {
-    localEdits.value.language_code_field = lookupLanguageCodeField.value;
-  }
-});
-
+// When the user picks a new language collection from the dropdown, the watcher below
+// clears `language_code_field`. This effect then re-runs (it depends on
+// `possibleLanguageCodeFields`, which is keyed off `language_collection`) and re-fills
+// the field with `code` if the new collection has one. The initial mount case — where
+// `language_collection` was seeded by the installer and `language_code_field` already
+// matches — short-circuits to a no-op write that Vue's reactive setter ignores, so
+// `changesExist` stays false. (The on-mount seed itself happens in the installer; see
+// `localazy-installer-store.ts`.)
 watchEffect(() => {
   const lookupLanguageCodeField = possibleLanguageCodeFields.value.find((col) => col.value.toLocaleLowerCase() === 'code');
   if (lookupLanguageCodeField) {

--- a/extensions/module/src/stores/localazy-installer-store.ts
+++ b/extensions/module/src/stores/localazy-installer-store.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
-import type { DeepPartial, Field } from '@directus/types';
+import type { AppCollection, DeepPartial, Field } from '@directus/types';
 import { sleep } from '../../../common/utilities/sleep';
 import { getConfig } from '../../../common/config/get-config';
 import { useErrorsStore } from './errors-store';
@@ -14,6 +14,7 @@ import { createSyncStateFields } from '../data/fields/sync-state/create';
 import { createSyncLogFields } from '../data/fields/sync-log/create';
 import { computeFieldHealActions } from './utilities/heal-fields';
 import { LOCALAZY_COLLECTIONS } from '../../../common/models/collections-data/collection-names';
+import { detectLanguageDefaults } from './utilities/detect-language-defaults';
 
 // Re-exported for backward compatibility — many module files import this name from the
 // installer store. New code should import directly from `common/models/collections-data/collection-names`.
@@ -145,10 +146,22 @@ export const useLocalazyInstallerStore = defineStore('localazyInstaller', () => 
       installing.value = true;
       try {
         await ensureFolder();
+        // Seed the language fields from the user's existing Directus schema so the
+        // Project Setup page renders without a phantom "unsaved changes" warning. The
+        // form used to do this in a `watchEffect` that mutated `edits` while `store.data`
+        // stayed empty — that flipped `changesExist=true` on every fresh mount. Seeding
+        // the values up-front keeps form state and store state in lockstep on first
+        // visit. Only runs at install time; if the user adds a `languages` collection
+        // later, the Project Setup dropdowns let them pick manually.
         await ensureCollection({
           name: LOCALAZY_COLLECTIONS.settings,
           fields: createSettingsFields,
-          defaults: defaultConfiguration().settings,
+          defaults: {
+            ...defaultConfiguration().settings,
+            ...detectLanguageDefaults(collectionsStore.collections as AppCollection[], (collection) =>
+              fieldsStore.getFieldsForCollection(collection),
+            ),
+          },
         });
         await ensureCollection({
           name: LOCALAZY_COLLECTIONS.contentTransferSetup,

--- a/extensions/module/src/stores/utilities/detect-language-defaults.test.ts
+++ b/extensions/module/src/stores/utilities/detect-language-defaults.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import type { AppCollection, Field } from '@directus/types';
+import { detectLanguageDefaults } from './detect-language-defaults';
+
+const userCollection = (name: string): AppCollection => ({ collection: name }) as AppCollection;
+const systemCollection = (name: string): AppCollection => ({ collection: name }) as AppCollection;
+
+const stringField = (collection: string, field: string): Field => ({ collection, field, type: 'string' }) as Field;
+const integerField = (collection: string, field: string): Field => ({ collection, field, type: 'integer' }) as Field;
+
+function fieldsMapFactory(...fields: Field[]) {
+  return (collection: string) => fields.filter((f) => f.collection === collection);
+}
+
+describe('detectLanguageDefaults', () => {
+  it('returns the matched collection + code field when both exist', () => {
+    const collections = [userCollection('languages'), userCollection('articles')];
+    const getFields = fieldsMapFactory(stringField('languages', 'code'), stringField('languages', 'name'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({
+      language_collection: 'languages',
+      language_code_field: 'code',
+    });
+  });
+
+  it('matches case-insensitively on both collection and field name', () => {
+    const collections = [userCollection('Languages')];
+    const getFields = fieldsMapFactory(stringField('Languages', 'Code'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({
+      language_collection: 'Languages',
+      language_code_field: 'Code',
+    });
+  });
+
+  it('returns just the collection when no `code` field is present', () => {
+    const collections = [userCollection('languages')];
+    const getFields = fieldsMapFactory(stringField('languages', 'name'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({
+      language_collection: 'languages',
+    });
+  });
+
+  it('ignores a non-string `code` field', () => {
+    const collections = [userCollection('languages')];
+    const getFields = fieldsMapFactory(integerField('languages', 'code'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({
+      language_collection: 'languages',
+    });
+  });
+
+  it('returns an empty object when no user `languages` collection exists', () => {
+    const collections = [userCollection('articles'), userCollection('pages')];
+    const getFields = fieldsMapFactory();
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({});
+  });
+
+  it('ignores a `languages` collection in the `directus_` namespace', () => {
+    const collections = [systemCollection('directus_languages')];
+    const getFields = fieldsMapFactory(stringField('directus_languages', 'code'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({});
+  });
+
+  it('ignores a `languages` collection in the `localazy_` namespace', () => {
+    const collections = [systemCollection('localazy_languages')];
+    const getFields = fieldsMapFactory(stringField('localazy_languages', 'code'));
+
+    expect(detectLanguageDefaults(collections, getFields)).toEqual({});
+  });
+});

--- a/extensions/module/src/stores/utilities/detect-language-defaults.ts
+++ b/extensions/module/src/stores/utilities/detect-language-defaults.ts
@@ -1,0 +1,35 @@
+import type { AppCollection, Field } from '@directus/types';
+import type { Settings } from '../../../../common/models/collections-data/settings';
+
+/**
+ * Looks for the conventional Directus i18n layout and returns the matching seed values
+ * for `localazy_settings`. The Project Setup page used to compute this in a `watchEffect`
+ * that mutated `edits` directly, which flipped `changesExist=true` against the empty
+ * store-side defaults — see `localazy-installer-store.ts` for the call site.
+ *
+ * Conventions matched:
+ *   - a user (non-`directus_*`, non-`localazy_*`) collection named `languages`
+ *     (case-insensitive),
+ *   - a string field on that collection named `code` (case-insensitive).
+ *
+ * Returns the matched subset; either or both keys may be absent when nothing matches.
+ */
+export function detectLanguageDefaults(
+  collections: AppCollection[],
+  getFieldsForCollection: (collection: string) => Field[],
+): Partial<Settings> {
+  const updates: Partial<Settings> = {};
+  const languageCollection = collections.find(
+    (c) => !c.collection.startsWith('directus_') && !c.collection.startsWith('localazy_') && c.collection.toLowerCase() === 'languages',
+  );
+  if (!languageCollection) return updates;
+  updates.language_collection = languageCollection.collection;
+
+  const codeField = getFieldsForCollection(languageCollection.collection).find(
+    (f) => f.type === 'string' && f.field.toLowerCase() === 'code',
+  );
+  if (codeField) {
+    updates.language_code_field = codeField.field;
+  }
+  return updates;
+}

--- a/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.test.ts
@@ -70,6 +70,7 @@ const schemaWithLocalazyCollections = {
   collections: {
     localazy_settings: {},
     localazy_content_transfer_setup: {},
+    localazy_config_data: {},
   },
 } as unknown as SchemaOverview;
 
@@ -117,6 +118,23 @@ describe('makeBundleLocalazyContextLoader', () => {
 
   it('returns null when localazy_content_transfer_setup is missing but localazy_settings is present', async () => {
     const partialSchema = { collections: { localazy_settings: {} } } as unknown as SchemaOverview;
+    const ItemsService = makeItemsServiceCtor({});
+
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema })();
+
+    expect(result).toBeNull();
+    expect(ItemsService).not.toHaveBeenCalled();
+  });
+
+  // Closes the install-time race: the installer creates collections sequentially and seeds
+  // each singleton's row before moving on, so the `items.create` event for the
+  // content-transfer-setup seed fires with a schema that includes settings +
+  // contentTransferSetup but not yet config. Without this guard, `new ItemsService(config, …)`
+  // throws inside Directus' schema traversal.
+  it('returns null when localazy_config_data is missing but the other two are present', async () => {
+    const partialSchema = {
+      collections: { localazy_settings: {}, localazy_content_transfer_setup: {} },
+    } as unknown as SchemaOverview;
     const ItemsService = makeItemsServiceCtor({});
 
     const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema })();

--- a/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
@@ -26,6 +26,14 @@ import type { FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-s
  * permissions don't gate sync. Returns `null` when the Localazy collections aren't yet
  * provisioned in the schema, when the IO call fails, or when any of the three rows is
  * missing.
+ *
+ * The schema guard must cover every collection we then read. The installer creates the
+ * Localazy collections one at a time and seeds each singleton's row before moving on,
+ * so each PATCH fires an `items.create` event with a schema snapshot that only contains
+ * the collections created so far. Guarding only the first two would let the handler run
+ * between "contentTransferSetup seeded" and "config created", and `new ItemsService(config, …)`
+ * then throws `Cannot read properties of undefined (reading 'primary')` inside Directus'
+ * schema traversal.
  */
 export function makeBundleLocalazyContextLoader(deps: {
   ItemsService: ItemsServiceCtor;
@@ -33,7 +41,11 @@ export function makeBundleLocalazyContextLoader(deps: {
 }): AutomatedExportLocalazyContextLoader {
   return async () => {
     const { ItemsService, schema } = deps;
-    if (!schema.collections?.[LOCALAZY_COLLECTIONS.settings] || !schema.collections?.[LOCALAZY_COLLECTIONS.contentTransferSetup]) {
+    if (
+      !schema.collections?.[LOCALAZY_COLLECTIONS.settings] ||
+      !schema.collections?.[LOCALAZY_COLLECTIONS.contentTransferSetup] ||
+      !schema.collections?.[LOCALAZY_COLLECTIONS.config]
+    ) {
       return null;
     }
     try {


### PR DESCRIPTION
## Summary

Both bugs surface during the first time a new user runs the plugin against an empty Directus instance. Each is small; together they're the first two things a new user hits.

### 1. Sync-hook: install-time race in the loadContext guard

The installer creates the Localazy collections sequentially and seeds each singleton's row before moving on, so each `PATCH /items/localazy_…` fires an `items.create` event with a schema snapshot that only contains the collections created so far. The loadContext guard at `pipeline-adapters.ts:36` checked `settings` and `contentTransferSetup` but not `config`, so the event for the `contentTransferSetup` seed slipped through and hit `new ItemsService(localazy_config_data, …)`, which throws

```
loadBundleLocalazyContext TypeError: Cannot read properties of undefined (reading 'primary')
```

inside Directus' schema traversal. The `try/catch` swallowed it, but the line was noise on every fresh install. Guard now requires all three collections.

### 2. Module: Project Setup phantom "unsaved changes" warning

Three on-mount `watchEffect`s in `ProjectSetupForm.vue` (one was a literal duplicate of another) auto-filled `language_collection='languages'` and `language_code_field='code'` directly into `edits`. Against the empty store-side defaults, those writes flipped `changesExist=true` before the user touched anything — Save button enabled, leave-route guard fired on navigation.

Fix moves the auto-detect into the installer's seed defaults (`detectLanguageDefaults` helper) so the persisted row carries the matched values from the start. The form's `edits` clones from the store and stays in lockstep on first mount. The single remaining cascade `watchEffect` is kept so picking a new collection still auto-fills `code` if the new collection has one.

**Trade-off**: a user who installs Localazy *before* creating a `languages` collection and adds it later starts with empty dropdowns and picks once. Acceptable — the dropdowns are right there.

## Test plan

- [x] `npm run check` — 625/625 tests pass, typecheck clean, prettier clean
- [x] Fresh local-dev replay: wiped `development/{data,uploads,extensions}`, restarted `npm run dev`, logged in, visited Project Setup
  - [x] Save changes button starts **disabled**
  - [x] Both dropdowns pre-filled (`Languages`, `Code`) from the seeded row
  - [x] Navigating to Automation produces **no** warning
  - [x] API confirms `localazy_settings.language_collection="languages"` and `language_code_field="code"` were seeded by the installer
- [x] Dev server log has **no** more `loadBundleLocalazyContext TypeError` on fresh install
- [ ] CI green (`qa.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)