### PR TITLE
PR 74/N: route bundle error tracking through the Directus logger

### DIFF
--- a/extensions/sync-hook/src/hook/functions/track-error.ts
+++ b/extensions/sync-hook/src/hook/functions/track-error.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import type { DirectusLogger } from '../types/directus-services';
 
 /**
  * Normalise an `unknown` thrown value into an Error instance so downstream
@@ -11,10 +12,21 @@ function normaliseError(error: unknown): AxiosError | Error {
   return new Error(typeof error === 'string' ? error : JSON.stringify(error));
 }
 
-export function trackDirectusError(error: unknown, type: string) {
-  console.log(type, normaliseError(error));
+/**
+ * Surface a Directus-side error at `error` severity on the Pino logger Directus injects
+ * into the bundle context. Structured fields (`errorType`, `source`) make the entry
+ * filterable in log aggregators; pino's built-in `err` serializer renders the
+ * stack/message/code. The `type` doubles as the human-readable log message so a tail of
+ * `directus_log` still reads naturally.
+ */
+export function trackDirectusError(logger: DirectusLogger, error: unknown, type: string) {
+  logger.error({ err: normaliseError(error), errorType: type, source: 'directus' }, type);
 }
 
-export function trackLocalazyError(error: unknown, type: string) {
-  console.log(type, normaliseError(error));
+/**
+ * Localazy-side counterpart to `trackDirectusError`. Same shape; the `source` field
+ * separates the two so operators can filter by origin.
+ */
+export function trackLocalazyError(logger: DirectusLogger, error: unknown, type: string) {
+  logger.error({ err: normaliseError(error), errorType: type, source: 'localazy' }, type);
 }

--- a/extensions/sync-hook/src/hook/index.test.ts
+++ b/extensions/sync-hook/src/hook/index.test.ts
@@ -14,7 +14,7 @@ const adapterMocks = vi.hoisted(() => ({
   collectionContentFetcherFactory: vi.fn(),
   translationStringsFetcherFactory: vi.fn(),
   sourceLanguageImportContentFetcherFactory: vi.fn(),
-  dispatchToLocalazy: vi.fn(),
+  dispatchFactory: vi.fn(),
 }));
 
 const reporterMocks = vi.hoisted(() => ({
@@ -40,7 +40,7 @@ vi.mock('./services/content-synchronization/pipeline-adapters', () => ({
   makeTranslationStringsFetcher: adapterMocks.translationStringsFetcherFactory.mockReturnValue('translationStringsFetcherSentinel'),
   makeSourceLanguageImportContentFetcher:
     adapterMocks.sourceLanguageImportContentFetcherFactory.mockReturnValue('sourceLanguageFetcherSentinel'),
-  dispatchToLocalazy: adapterMocks.dispatchToLocalazy,
+  makeDispatchToLocalazy: adapterMocks.dispatchFactory.mockReturnValue('dispatchSentinel'),
 }));
 
 vi.mock('./services/content-synchronization/deprecation-key-projectors', () => ({
@@ -79,6 +79,7 @@ describe('sync-hook entry point', () => {
     adapterMocks.collectionContentFetcherFactory.mockReturnValue('collectionContentFetcherSentinel');
     adapterMocks.translationStringsFetcherFactory.mockReturnValue('translationStringsFetcherSentinel');
     adapterMocks.sourceLanguageImportContentFetcherFactory.mockReturnValue('sourceLanguageFetcherSentinel');
+    adapterMocks.dispatchFactory.mockReturnValue('dispatchSentinel');
     pipelineMocks.runAutomatedExportPipeline.mockResolvedValue({ kind: 'exported' });
     pipelineMocks.runAutomatedDeprecationPipeline.mockResolvedValue({ kind: 'deprecated', keysCount: 0 });
     registrations = new Map();
@@ -120,13 +121,22 @@ describe('sync-hook entry point', () => {
       it(`${event} composes the export pipeline with the translation-strings fetcher`, async () => {
         await registrations.get(event)!({ keys: ['k1'] }, { schema: fakeSchema });
 
-        expect(adapterMocks.loadContextFactory).toHaveBeenCalledWith({ ItemsService: fakeItemsService, schema: fakeSchema });
-        expect(adapterMocks.translationStringsFetcherFactory).toHaveBeenCalledWith({ ItemsService: fakeItemsService, schema: fakeSchema });
+        expect(adapterMocks.loadContextFactory).toHaveBeenCalledWith({
+          ItemsService: fakeItemsService,
+          schema: fakeSchema,
+          logger: fakeLogger,
+        });
+        expect(adapterMocks.translationStringsFetcherFactory).toHaveBeenCalledWith({
+          ItemsService: fakeItemsService,
+          schema: fakeSchema,
+          logger: fakeLogger,
+        });
+        expect(adapterMocks.dispatchFactory).toHaveBeenCalledWith(fakeLogger);
         expect(pipelineMocks.runAutomatedExportPipeline).toHaveBeenCalledExactlyOnceWith({
           loadContext: 'loadContextSentinel',
           directusApi: { tag: 'directus-api-service-sentinel' },
           fetchContent: 'translationStringsFetcherSentinel',
-          dispatchContent: adapterMocks.dispatchToLocalazy,
+          dispatchContent: 'dispatchSentinel',
         });
         expect(reporterMocks.reportAutomatedExportOutcome).toHaveBeenCalledExactlyOnceWith({
           outcome: { kind: 'exported' },
@@ -169,12 +179,13 @@ describe('sync-hook entry point', () => {
         schema: fakeSchema,
         keys: ['a', 'b'],
         collection: 'articles',
+        logger: fakeLogger,
       });
       expect(pipelineMocks.runAutomatedExportPipeline).toHaveBeenCalledExactlyOnceWith({
         loadContext: 'loadContextSentinel',
         directusApi: { tag: 'directus-api-service-sentinel' },
         fetchContent: 'collectionContentFetcherSentinel',
-        dispatchContent: adapterMocks.dispatchToLocalazy,
+        dispatchContent: 'dispatchSentinel',
       });
       expect(reporterMocks.reportAutomatedExportOutcome).toHaveBeenCalledExactlyOnceWith({
         outcome: { kind: 'exported' },

--- a/extensions/sync-hook/src/hook/index.ts
+++ b/extensions/sync-hook/src/hook/index.ts
@@ -3,9 +3,9 @@ import { defineHook } from '@directus/extensions-sdk';
 import { runAutomatedExportPipeline } from '../../../common/services/orchestrator/automated-export-pipeline';
 import { runAutomatedDeprecationPipeline } from '../../../common/services/orchestrator/automated-deprecation-pipeline';
 import {
-  dispatchToLocalazy,
   makeBundleLocalazyContextLoader,
   makeCollectionContentFetcher,
+  makeDispatchToLocalazy,
   makeSourceLanguageImportContentFetcher,
   makeTranslationStringsFetcher,
 } from './services/content-synchronization/pipeline-adapters';
@@ -41,10 +41,10 @@ export default defineHook(({ action }, { services, logger }) => {
     action(event, async (_, { schema, accountability }) => {
       if (!schema) return;
       const outcome = await runAutomatedExportPipeline({
-        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema }),
+        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema, logger }),
         directusApi: new DirectusApiService(ItemsService, schema),
-        fetchContent: makeTranslationStringsFetcher({ ItemsService, schema }),
-        dispatchContent: dispatchToLocalazy,
+        fetchContent: makeTranslationStringsFetcher({ ItemsService, schema, logger }),
+        dispatchContent: makeDispatchToLocalazy(logger),
       });
       reportAutomatedExportOutcome({ outcome, logger, label: 'translation strings', trackingLabel: 'exportTranslationString' });
       await burstCoordinator.recordExportOutcome({
@@ -64,8 +64,8 @@ export default defineHook(({ action }, { services, logger }) => {
       if (!schema) return;
       const outcome = await runAutomatedDeprecationPipeline({
         itemIds: keys,
-        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema }),
-        fetchSourceLanguageImportContent: makeSourceLanguageImportContentFetcher(),
+        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema, logger }),
+        fetchSourceLanguageImportContent: makeSourceLanguageImportContentFetcher(logger),
         projectDeprecationKeys: projectTranslationStringsDeprecationKeys,
       });
       reportAutomatedDeprecationOutcome({
@@ -92,10 +92,10 @@ export default defineHook(({ action }, { services, logger }) => {
       if (!schema) return;
       const keys: string[] = 'keys' in payload ? payload.keys : [payload.key];
       const outcome = await runAutomatedExportPipeline({
-        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema }),
+        loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema, logger }),
         directusApi: new DirectusApiService(ItemsService, schema),
-        fetchContent: makeCollectionContentFetcher({ ItemsService, FieldsService, schema, keys, collection: payload.collection }),
-        dispatchContent: dispatchToLocalazy,
+        fetchContent: makeCollectionContentFetcher({ ItemsService, FieldsService, schema, keys, collection: payload.collection, logger }),
+        dispatchContent: makeDispatchToLocalazy(logger),
       });
       reportAutomatedExportOutcome({
         outcome,
@@ -119,8 +119,8 @@ export default defineHook(({ action }, { services, logger }) => {
     if (!schema) return;
     const outcome = await runAutomatedDeprecationPipeline({
       itemIds: keys,
-      loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema }),
-      fetchSourceLanguageImportContent: makeSourceLanguageImportContentFetcher(),
+      loadContext: makeBundleLocalazyContextLoader({ ItemsService, schema, logger }),
+      fetchSourceLanguageImportContent: makeSourceLanguageImportContentFetcher(logger),
       projectDeprecationKeys: projectCollectionDeprecationKeys(collection),
     });
     reportAutomatedDeprecationOutcome({

--- a/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.test.ts
@@ -125,7 +125,7 @@ describe('reportAutomatedExportOutcome', () => {
 
     expect(logger.info).toHaveBeenCalledWith('Localazy: Exporting translation strings failed');
     expect(logger.error).toHaveBeenCalledWith(error);
-    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(error, 'exportTranslationString');
+    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(logger, error, 'exportTranslationString');
   });
 });
 
@@ -220,6 +220,6 @@ describe('reportAutomatedDeprecationOutcome', () => {
 
     expect(logger.error).toHaveBeenCalledWith('Localazy: Deprecating deleted collection articles failed');
     expect(logger.error).toHaveBeenCalledWith(error);
-    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(error, 'deprecateDeletedCollectionItems');
+    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(logger, error, 'deprecateDeletedCollectionItems');
   });
 });

--- a/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/outcome-reporters.ts
@@ -48,7 +48,7 @@ export function reportAutomatedExportOutcome(input: {
     case 'failed':
       logger.info(`Localazy: Exporting ${label} failed`);
       logger.error(outcome.error);
-      trackDirectusError(outcome.error, trackingLabel);
+      trackDirectusError(logger, outcome.error, trackingLabel);
       return;
     default:
       assertNever(outcome);
@@ -92,7 +92,7 @@ export function reportAutomatedDeprecationOutcome(input: {
     case 'failed':
       logger.error(`Localazy: Deprecating deleted ${label} failed`);
       logger.error(outcome.error);
-      trackDirectusError(outcome.error, trackingLabel);
+      trackDirectusError(logger, outcome.error, trackingLabel);
       return;
     default:
       assertNever(outcome);

--- a/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.test.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.test.ts
@@ -6,7 +6,9 @@ import { ContentTransferSetupDatabase } from '../../../../../common/models/colle
 import { LocalazyData } from '../../../../../common/models/collections-data/localazy-data';
 import { LocalazyContent } from '../../../../../common/models/localazy-content';
 import { TranslatableContent } from '../../../../../common/models/translatable-content';
-import type { FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
+import type { DirectusLogger, FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
+
+const fakeLogger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as DirectusLogger;
 
 const trackMocks = vi.hoisted(() => ({
   trackLocalazyError: vi.fn(),
@@ -53,9 +55,9 @@ vi.mock('../directus-service', () => ({
 }));
 
 import {
-  dispatchToLocalazy,
   makeBundleLocalazyContextLoader,
   makeCollectionContentFetcher,
+  makeDispatchToLocalazy,
   makeSourceLanguageImportContentFetcher,
   makeTranslationStringsFetcher,
 } from './pipeline-adapters';
@@ -107,7 +109,7 @@ describe('makeBundleLocalazyContextLoader', () => {
 
   it('returns null when localazy_settings collection is missing from the schema', async () => {
     const ItemsService = makeItemsServiceCtor({});
-    const loader = makeBundleLocalazyContextLoader({ ItemsService, schema: emptySchema });
+    const loader = makeBundleLocalazyContextLoader({ ItemsService, schema: emptySchema, logger: fakeLogger });
 
     const result = await loader();
 
@@ -120,7 +122,7 @@ describe('makeBundleLocalazyContextLoader', () => {
     const partialSchema = { collections: { localazy_settings: {} } } as unknown as SchemaOverview;
     const ItemsService = makeItemsServiceCtor({});
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema, logger: fakeLogger })();
 
     expect(result).toBeNull();
     expect(ItemsService).not.toHaveBeenCalled();
@@ -137,7 +139,7 @@ describe('makeBundleLocalazyContextLoader', () => {
     } as unknown as SchemaOverview;
     const ItemsService = makeItemsServiceCtor({});
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: partialSchema, logger: fakeLogger })();
 
     expect(result).toBeNull();
     expect(ItemsService).not.toHaveBeenCalled();
@@ -149,7 +151,7 @@ describe('makeBundleLocalazyContextLoader', () => {
       localazy_config_data: sampleLocalazyData,
     });
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections, logger: fakeLogger })();
 
     expect(result).toBeNull();
   });
@@ -160,7 +162,7 @@ describe('makeBundleLocalazyContextLoader', () => {
       localazy_config_data: sampleLocalazyData,
     });
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections, logger: fakeLogger })();
 
     expect(result).toBeNull();
   });
@@ -171,7 +173,7 @@ describe('makeBundleLocalazyContextLoader', () => {
       localazy_content_transfer_setup: sampleTransferSetup,
     });
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections, logger: fakeLogger })();
 
     expect(result).toBeNull();
   });
@@ -186,11 +188,12 @@ describe('makeBundleLocalazyContextLoader', () => {
       { throwOnCollection: 'localazy_config_data' },
     );
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections, logger: fakeLogger })();
 
     expect(result).toBeNull();
     expect(trackMocks.trackLocalazyError).toHaveBeenCalledOnce();
-    expect(trackMocks.trackLocalazyError.mock.calls[0]![1]).toBe('loadBundleLocalazyContext');
+    expect(trackMocks.trackLocalazyError.mock.calls[0]![0]).toBe(fakeLogger);
+    expect(trackMocks.trackLocalazyError.mock.calls[0]![2]).toBe('loadBundleLocalazyContext');
   });
 
   it('reads all three Localazy collections with accountability=null and returns the resolved context', async () => {
@@ -200,7 +203,7 @@ describe('makeBundleLocalazyContextLoader', () => {
       localazy_config_data: sampleLocalazyData,
     });
 
-    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections })();
+    const result = await makeBundleLocalazyContextLoader({ ItemsService, schema: schemaWithLocalazyCollections, logger: fakeLogger })();
 
     expect(result).toEqual({
       settings: sampleSettings,
@@ -236,6 +239,7 @@ describe('makeCollectionContentFetcher', () => {
       schema: schemaWithLocalazyCollections,
       keys: ['a1', 'a2'],
       collection: 'articles',
+      logger: fakeLogger,
     });
     const result = await fetcher({ context: ctx, localazyProject: sampleProject, exportLanguages: ['en', 'de'] });
 
@@ -260,6 +264,7 @@ describe('makeTranslationStringsFetcher', () => {
     const fetcher = makeTranslationStringsFetcher({
       ItemsService: vi.fn() as unknown as ItemsServiceCtor,
       schema: schemaWithLocalazyCollections,
+      logger: fakeLogger,
     });
     const ctx = { settings: sampleSettings, contentTransferSetup: sampleTransferSetup, localazyData: sampleLocalazyData };
     const result = await fetcher({ context: ctx, localazyProject: sampleProject, exportLanguages: ['en'] });
@@ -281,16 +286,17 @@ describe('makeTranslationStringsFetcher', () => {
     const fetcher = makeTranslationStringsFetcher({
       ItemsService: vi.fn() as unknown as ItemsServiceCtor,
       schema: schemaWithLocalazyCollections,
+      logger: fakeLogger,
     });
     const ctx = { settings: sampleSettings, contentTransferSetup: sampleTransferSetup, localazyData: sampleLocalazyData };
     const result = await fetcher({ context: ctx, localazyProject: sampleProject, exportLanguages: ['en'] });
 
     expect(result).toEqual({ sourceLanguage: {}, otherLanguages: {} });
-    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(fetchError, 'fetchTranslationStrings');
+    expect(trackMocks.trackDirectusError).toHaveBeenCalledExactlyOnceWith(fakeLogger, fetchError, 'fetchTranslationStrings');
   });
 });
 
-describe('dispatchToLocalazy', () => {
+describe('makeDispatchToLocalazy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -298,7 +304,7 @@ describe('dispatchToLocalazy', () => {
   it('unpacks context into settings + localazyData and forwards content + localazyProject', async () => {
     const ctx = { settings: sampleSettings, contentTransferSetup: sampleTransferSetup, localazyData: sampleLocalazyData };
 
-    await dispatchToLocalazy({ content: okContent, context: ctx, localazyProject: sampleProject });
+    await makeDispatchToLocalazy(fakeLogger)({ content: okContent, context: ctx, localazyProject: sampleProject });
 
     expect(serviceMocks.exportContentToLocalazy).toHaveBeenCalledExactlyOnceWith({
       content: okContent,
@@ -327,11 +333,12 @@ describe('makeSourceLanguageImportContentFetcher', () => {
       } as ContentTransferSetupDatabase,
       localazyData: sampleLocalazyData,
     };
-    const result = await makeSourceLanguageImportContentFetcher()({ context: ctx, localazyProject: sampleProject });
+    const result = await makeSourceLanguageImportContentFetcher(fakeLogger)({ context: ctx, localazyProject: sampleProject });
 
     expect(result).toEqual({ success: true, content: importContent });
     expect(serviceMocks.resolveLocalazyLanguageId).toHaveBeenCalledWith(sampleProject.sourceLanguage);
     expect(serviceMocks.importContentFromLocalazy).toHaveBeenCalledExactlyOnceWith({
+      logger: fakeLogger,
       languages: [{ originalForm: 'en', localazyForm: 'en', directusForm: '' }],
       localazyData: sampleLocalazyData,
       localazyProject: sampleProject,
@@ -345,7 +352,7 @@ describe('makeSourceLanguageImportContentFetcher', () => {
     serviceMocks.importContentFromLocalazy.mockResolvedValue({ success: false });
 
     const ctx = { settings: sampleSettings, contentTransferSetup: sampleTransferSetup, localazyData: sampleLocalazyData };
-    await makeSourceLanguageImportContentFetcher()({ context: ctx, localazyProject: sampleProject });
+    await makeSourceLanguageImportContentFetcher(fakeLogger)({ context: ctx, localazyProject: sampleProject });
 
     expect(serviceMocks.importContentFromLocalazy.mock.calls[0]![0].languages).toEqual([
       { originalForm: '', localazyForm: '', directusForm: '' },

--- a/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
+++ b/extensions/sync-hook/src/hook/services/content-synchronization/pipeline-adapters.ts
@@ -17,7 +17,7 @@ import { importFromLocalazyService } from '../import-from-localazy-service';
 import { TranslationStringsService } from '../../../../../common/services/translation-strings-service';
 import { DirectusApiService } from '../directus-service';
 import { LOCALAZY_COLLECTIONS } from '../../../../../common/models/collections-data/collection-names';
-import type { FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
+import type { DirectusLogger, FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-services';
 
 /**
  * Builds the `loadContext` adapter for the Automated export / deprecation pipelines.
@@ -38,9 +38,10 @@ import type { FieldsServiceCtor, ItemsServiceCtor } from '../../types/directus-s
 export function makeBundleLocalazyContextLoader(deps: {
   ItemsService: ItemsServiceCtor;
   schema: SchemaOverview;
+  logger: DirectusLogger;
 }): AutomatedExportLocalazyContextLoader {
   return async () => {
-    const { ItemsService, schema } = deps;
+    const { ItemsService, schema, logger } = deps;
     if (
       !schema.collections?.[LOCALAZY_COLLECTIONS.settings] ||
       !schema.collections?.[LOCALAZY_COLLECTIONS.contentTransferSetup] ||
@@ -65,7 +66,7 @@ export function makeBundleLocalazyContextLoader(deps: {
       }
       return { settings, contentTransferSetup, localazyData };
     } catch (e: unknown) {
-      trackLocalazyError(e, 'loadBundleLocalazyContext');
+      trackLocalazyError(logger, e, 'loadBundleLocalazyContext');
       return null;
     }
   };
@@ -85,9 +86,10 @@ export function makeCollectionContentFetcher(deps: {
   schema: SchemaOverview;
   keys: string[];
   collection: string;
+  logger: DirectusLogger;
 }): AutomatedExportContentFetcher {
   return async ({ context, exportLanguages }) => {
-    const service = new ApiTranslatableCollectionsService(deps.ItemsService, deps.schema, deps.FieldsService);
+    const service = new ApiTranslatableCollectionsService(deps.ItemsService, deps.schema, deps.FieldsService, deps.logger);
     return service.fetchContentFromTranslatableCollections({
       translatableCollections: [{ collection: deps.collection, itemIds: deps.keys }],
       languages: exportLanguages,
@@ -106,6 +108,7 @@ export function makeCollectionContentFetcher(deps: {
 export function makeTranslationStringsFetcher(deps: {
   ItemsService: ItemsServiceCtor;
   schema: SchemaOverview;
+  logger: DirectusLogger;
 }): AutomatedExportContentFetcher {
   return async ({ context, exportLanguages }) => {
     const translationStringsService = new TranslationStringsService(new DirectusApiService(deps.ItemsService, deps.schema));
@@ -116,26 +119,29 @@ export function makeTranslationStringsFetcher(deps: {
         synchronizeTranslationStrings: context.contentTransferSetup.translation_strings,
       });
     } catch (e: unknown) {
-      trackDirectusError(e, 'fetchTranslationStrings');
+      trackDirectusError(deps.logger, e, 'fetchTranslationStrings');
       return { sourceLanguage: {}, otherLanguages: {} };
     }
   };
 }
 
 /**
- * Dispatch adapter for the Automated export pipeline. Wraps the existing
+ * Builds the dispatch adapter for the Automated export pipeline. Wraps the existing
  * `ExportToLocalazyService` so the pipeline doesn't need to know its constructor or
- * payload shape.
+ * payload shape. Closes over the bundle's logger so dispatch-time failures surface at
+ * `error` severity via Directus' Pino logger.
  */
-export const dispatchToLocalazy: AutomatedExportContentDispatcher = async ({ content, context, localazyProject }) => {
-  const exportToLocalazyService = new ExportToLocalazyService();
-  await exportToLocalazyService.exportContentToLocalazy({
-    content,
-    settings: context.settings,
-    localazyData: context.localazyData,
-    localazyProject,
-  });
-};
+export function makeDispatchToLocalazy(logger: DirectusLogger): AutomatedExportContentDispatcher {
+  return async ({ content, context, localazyProject }) => {
+    const exportToLocalazyService = new ExportToLocalazyService(logger);
+    await exportToLocalazyService.exportContentToLocalazy({
+      content,
+      settings: context.settings,
+      localazyData: context.localazyData,
+      localazyProject,
+    });
+  };
+}
 
 /**
  * Builds the deprecation-pipeline `fetchSourceLanguageImportContent` adapter. Requests
@@ -143,19 +149,20 @@ export const dispatchToLocalazy: AutomatedExportContentDispatcher = async ({ con
  * deleted Directus item ids to per-language key ids using `translationString.localazyKeys`
  * / `collectionItem.localazyKey`, so we don't need to fetch other languages here.
  */
-export function makeSourceLanguageImportContentFetcher(): SourceLanguageImportContentFetcher {
+export function makeSourceLanguageImportContentFetcher(logger: DirectusLogger): SourceLanguageImportContentFetcher {
   return async ({ context, localazyProject }) => {
     const sourceLocale = DirectusLocalazyAdapter.resolveLocalazyLanguageId(localazyProject.sourceLanguage);
     const sourceLanguageCode = sourceLocale?.locale || '';
     return importFromLocalazyService.importContentFromLocalazy({
+      logger,
       languages: [{ originalForm: sourceLanguageCode, localazyForm: sourceLanguageCode, directusForm: '' }],
       localazyData: context.localazyData,
       localazyProject,
       enabledFields: EnabledFieldsService.parseFromDatabase(context.contentTransferSetup.enabled_fields),
       progressCallbacks: {
-        nothingToImport: () => trackLocalazyError(new Error('Nothing to import'), 'fetchSourceLanguageImportContent'),
+        nothingToImport: () => trackLocalazyError(logger, new Error('Nothing to import'), 'fetchSourceLanguageImportContent'),
         couldNotFetchContent: (language) =>
-          trackLocalazyError(new Error(`Couldn't fetch content for ${language}`), 'fetchSourceLanguageImportContent'),
+          trackLocalazyError(logger, new Error(`Couldn't fetch content for ${language}`), 'fetchSourceLanguageImportContent'),
       },
     });
   };

--- a/extensions/sync-hook/src/hook/services/export-to-localazy-service.ts
+++ b/extensions/sync-hook/src/hook/services/export-to-localazy-service.ts
@@ -8,6 +8,7 @@ import { DirectusLocalazyAdapter } from '../../../../common/services/directus-lo
 import { trackLocalazyError } from '../functions/track-error';
 import { ExportToLocalazyCommonService } from '../../../../common/services/export-to-localazy-common-service';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
+import type { DirectusLogger } from '../types/directus-services';
 
 type ExportContentToLocalazy = {
   content: TranslatableContent;
@@ -36,6 +37,8 @@ type CreateExportPromisesForLanguage = {
  * The original defensive early-return covering these has been removed; trust the pipeline.
  */
 export class ExportToLocalazyService {
+  constructor(private readonly logger: DirectusLogger) {}
+
   private createExportPromisesForLanguage(options: CreateExportPromisesForLanguage) {
     const { content, language, access_token, projectId } = options;
     const contentChunks = ContentFromCollections.splitContentIntoChunks(content);
@@ -79,7 +82,7 @@ export class ExportToLocalazyService {
 
       await execute({ delayBetween: 150 });
     } catch (e: unknown) {
-      trackLocalazyError(e, 'export');
+      trackLocalazyError(this.logger, e, 'export');
     }
   }
 }

--- a/extensions/sync-hook/src/hook/services/import-from-localazy-service.ts
+++ b/extensions/sync-hook/src/hook/services/import-from-localazy-service.ts
@@ -6,6 +6,7 @@ import { DirectusLocalazyLanguage } from '../../../../common/models/directus-loc
 import { ContentFromLocalazyService } from '../../../../common/services/content-from-localazy-service';
 import { EnabledField } from '../../../../common/models/collections-data/content-transfer-setup';
 import { LocalazyData } from '../../../../common/models/collections-data/localazy-data';
+import type { DirectusLogger } from '../types/directus-services';
 
 type FetchContentInLanguage = {
   lang: DirectusLocalazyLanguage;
@@ -19,6 +20,7 @@ type ImportContentFromLocalazy = {
   enabledFields: EnabledField[];
   localazyData: LocalazyData;
   localazyProject: Project;
+  logger: DirectusLogger;
 
   progressCallbacks: {
     nothingToImport: () => void;
@@ -39,10 +41,10 @@ type ImportContentFromLocalazyReturn = ImportContentFromLocalazySuccessReturn | 
 
 class ImportFromLocalazyService {
   async importContentFromLocalazy(data: ImportContentFromLocalazy): Promise<ImportContentFromLocalazyReturn> {
-    const { languages, enabledFields, progressCallbacks, localazyProject, localazyData } = data;
+    const { languages, enabledFields, progressCallbacks, localazyProject, localazyData, logger } = data;
 
     const uniqueLocalazyFormLanguages = uniqWith(languages, (a, b) => a.localazyForm === b.localazyForm);
-    const directusFile = await this.loadFile(localazyData.access_token, localazyProject?.id || '');
+    const directusFile = await this.loadFile(logger, localazyData.access_token, localazyProject?.id || '');
 
     if (!directusFile) {
       progressCallbacks.nothingToImport();
@@ -74,7 +76,7 @@ class ImportFromLocalazyService {
     return { success: false };
   }
 
-  private async loadFile(token: string, projectId: string) {
+  private async loadFile(logger: DirectusLogger, token: string, projectId: string) {
     if (!token) {
       return null;
     }
@@ -86,7 +88,7 @@ class ImportFromLocalazyService {
         });
         return files.find((file) => file.name === 'directus.json') || null;
       } catch (e: unknown) {
-        trackLocalazyError(e, 'loadFile');
+        trackLocalazyError(logger, e, 'loadFile');
         return null;
       }
     } else {

--- a/extensions/sync-hook/src/hook/services/translatable-collections-service.ts
+++ b/extensions/sync-hook/src/hook/services/translatable-collections-service.ts
@@ -6,23 +6,25 @@ import {
   TranslatableCollectionsService,
   TranslatableCollectionsServiceOptions,
 } from '../../../../common/services/translatable-collections-service';
-import type { FieldsServiceCtor, ItemsServiceCtor } from '../types/directus-services';
+import type { DirectusLogger, FieldsServiceCtor, ItemsServiceCtor } from '../types/directus-services';
 
 export class ApiTranslatableCollectionsService {
   private translatableCollectionsService: TranslatableCollectionsService;
+  private logger: DirectusLogger;
 
-  constructor(ItemsService: ItemsServiceCtor, schema: SchemaOverview, FieldsService: FieldsServiceCtor) {
+  constructor(ItemsService: ItemsServiceCtor, schema: SchemaOverview, FieldsService: FieldsServiceCtor, logger: DirectusLogger) {
     this.translatableCollectionsService = new TranslatableCollectionsService({
       directusApi: new DirectusApiService(ItemsService, schema),
       translatableCollectionsContent: new ApiDirectusDataModelService(schema, FieldsService),
     });
+    this.logger = logger;
   }
 
   async fetchContentFromTranslatableCollections(options: TranslatableCollectionsServiceOptions) {
     try {
       return this.translatableCollectionsService.fetchContentFromTranslatableCollections(options);
     } catch (e: unknown) {
-      trackDirectusError(e, 'fetchContentFromTranslatableCollection');
+      trackDirectusError(this.logger, e, 'fetchContentFromTranslatableCollection');
       return {
         sourceLanguage: {},
         otherLanguages: {},


### PR DESCRIPTION
## Summary
- Replace `console.log(type, error)` in `trackDirectusError` / `trackLocalazyError` with structured pino calls (`logger.error({ err, errorType, source }, type)`) so bundle-side failures surface at **error** severity in Directus' configured logger.
- Thread the bundle's `DirectusLogger` (pino) through the call chain: outcome reporters → pipeline-adapter factories → `ApiTranslatableCollectionsService` / `ExportToLocalazyService` constructors → `importFromLocalazyService.importContentFromLocalazy`. `dispatchToLocalazy` becomes the factory `makeDispatchToLocalazy(logger)`.
- The hook entry passes its context `logger` into every factory.

## Why
Pre-existing `track-error.ts` was a printf stub (`console.log`), inherited from main. Eight call-sites across export/deprecation pipelines, content fetchers, and import/export services routed through it, so any failure deep inside the bundle landed at **info** severity with no structured fields — invisible to log aggregators filtering on `level >= error`.

Pino's `err` serializer now renders the stack/message/code; `errorType` + `source: 'directus' | 'localazy'` give operators filterable fields per side of the integration.

## Test plan
- [x] `npm run typecheck` — green (`vue-tsc --noEmit`)
- [x] `npm run test` — 625/625 passing (50 files)
- [x] `npm run format` — clean
- [x] `npm run lint` — clean (one warning unrelated to this change, pre-existing on `next`)
- [ ] Verify in a local Directus instance that a forced failure (e.g. invalid Localazy token) now prints at `error` severity with structured `err` / `errorType` / `source` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)