### PR TITLE
ci: bump deprecated v4 actions to v6 + lint cleanup

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: [self-hosted, Linux]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ This is an npm-workspaces monorepo with three packages under `extensions/`:
 ## Prerequisites
 
 - Node 22 (see `.nvmrc`). With nvm: `nvm use`.
-- No Docker required — the dev loop uses a local Directus instance against SQLite.
 
 ## Install
 

--- a/extensions/common/services/translation-strings-service.ts
+++ b/extensions/common/services/translation-strings-service.ts
@@ -63,25 +63,21 @@ export class TranslationStringsService {
     return Array.isArray(translationStrings) ? translationStrings : [];
   }
 
-  async resolveTranslationStrings() {
-    let translationStrings: TranslationString[] = [];
-    if (this.hasDedicatedTranslationsCollection()) {
-      try {
-        const result = await this.directusApi.fetchTranslationStrings();
-        translationStrings = this.normalizeDirectus10TranslationStrings(result as Directus10TranslationApiResult[]);
-      } catch (_e: unknown) {
-        try {
-          translationStrings = await this.fetchTranslationStringsFromSettings();
-          return translationStrings;
-        } catch (_e2: unknown) {
-          return [];
-        }
-      }
-    } else {
-      translationStrings = await this.fetchTranslationStringsFromSettings();
+  async resolveTranslationStrings(): Promise<TranslationString[]> {
+    if (!this.hasDedicatedTranslationsCollection()) {
+      return this.fetchTranslationStringsFromSettings();
     }
 
-    return Array.isArray(translationStrings) ? translationStrings : [];
+    try {
+      const result = await this.directusApi.fetchTranslationStrings();
+      return this.normalizeDirectus10TranslationStrings(result as Directus10TranslationApiResult[]);
+    } catch (_e: unknown) {
+      try {
+        return await this.fetchTranslationStringsFromSettings();
+      } catch (_e2: unknown) {
+        return [];
+      }
+    }
   }
 
   async upsertLegacyTranslationStrings(data: LocalazyTranslationStringBlock[]) {


### PR DESCRIPTION
## Summary

- Bump `actions/checkout@v4` → `@v6` and `actions/setup-node@v4` → `@v6` in `qa.yml`. Both v6 releases run on Node 24, silencing the GitHub Actions Node-20 deprecation warning (the `release.yml` job only invokes `localazy/release/*@v2` — its inner Node-20 dependencies will need to be bumped upstream in `localazy/release` itself).
- Refactor `TranslationStringsService.resolveTranslationStrings` to early returns, removing the dead `let translationStrings: TranslationString[] = []` initializer that ESLint's `no-useless-assignment` was flagging — and the redundant trailing `Array.isArray` check, since both downstream helpers already return `TranslationString[]`.
- Drop the stale "No Docker required" prerequisite line from `CONTRIBUTING.md`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no `no-useless-assignment` finding)
- [ ] CI QA workflow runs on the new action versions without the Node-20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)