### PR TITLE
chore(deps): bump sync-hook axios to ^1.15.2 (covers 9 CVEs)

### DIFF
--- a/extensions/sync-hook/package.json
+++ b/extensions/sync-hook/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@localazy/api-client": "^2.1.5",
-    "axios": "^1.13.0",
+    "axios": "^1.15.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@localazy/api-client": "^2.1.5",
-        "axios": "^1.13.0",
+        "axios": "^1.15.2",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -84,6 +84,43 @@
         "@types/lodash": "^4.17.1",
         "@types/node": "^22.0.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "extensions/sync-hook/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "extensions/sync-hook/node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "extensions/sync-hook/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -10953,6 +10990,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -13437,7 +13475,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -18408,7 +18445,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {


### PR DESCRIPTION
## Summary

`extensions/sync-hook/package.json` has `axios` as a direct dependency, and Rollup inlines it into the published `dist/api.js`. So unlike the other Dependabot alerts on this repo (which are all transitive through the `directus` dev server / `@directus/extensions-sdk` build tool), **axios actually ships to users**.

Bumping the range from `^1.13.0` → `^1.15.2`. The lock file now resolves `axios@1.16.1`, comfortably above the required patch floor across all 9 open Dependabot alerts:

| Severity | GHSA | Issue |
|---|---|---|
| high | GHSA-pf86-5x62-jrwf | Prototype pollution — response tampering, data exfiltration, request hijacking |
| high | GHSA-6chq-wfr3-2hj9 | Header injection via prototype pollution |
| high | GHSA-pmwg-cvhr-8vh7 | NO_PROXY bypass via 127.0.0.0/8 loopback subnet |
| high | GHSA-q8qp-cvcw-x6jj | Prototype pollution read-side gadgets in HTTP adapter (credential injection / request hijacking) |
| medium | GHSA-445q-vr5w-6q77 | CRLF injection in multipart/form-data via unsanitized `blob.type` |
| medium | GHSA-m7pr-hjqh-92cm | `no_proxy` bypass via IP alias allowing SSRF |
| medium | GHSA-3w6x-2g7m-8v23 | Invisible JSON tampering via prototype pollution gadget in `parseReviver` |
| medium | GHSA-5c9x-8gcm-mpgx | Streamed uploads bypass `maxBodyLength` when `maxRedirects: 0` |
| low | GHSA-xhjh-pmcv-23jw | Null byte injection via reverse-encoding in `AxiosURLSearchParams` |

…plus 6 more axios alerts (62hf-57xw-28j9, vf2m-468p-8v99, xx6v-rp6x-q39c, w9j2-pvgh-6h63, 3p68-rc4w-qgx5, fvcv-3m26-pcqx) all patched at ≤ 1.15.2.

### Out of scope

The remaining 27 Dependabot alerts (`tar`, `fast-xml-parser`, `unhead`, `srvx`, `qs`, `uuid`, `sanitize-html`, `@tootallnate/once`) are transitive through `directus` and `@directus/extensions-sdk`. They affect the local dev server and build environment, not the published extensions. They'll clear when those upstreams next release.

## Test plan

- [x] `npm install` succeeds; lock file resolves `axios@1.16.1` for the sync-hook tree.
- [x] `npm run build` on `@localazy/directus-extension-localazy-automation` succeeds; `dist/api.js` still inlines axios.
- [x] `npm run check` (lint + format + typecheck + test) — 625 tests pass.
- [ ] After merge, Dependabot drops all 15 axios alerts on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)