### PR TITLE
📚 docs: backfill 2.0.0 release section in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 2.0.0 (2026-05-20)
+
+Top-to-bottom modernization of the repo and a large feature push around server-driven sync, plus the UX work to drive it. Bundles 75 PRs landed on `next` since v1.0.10 / v1.1.0 ([#93](https://github.com/localazy/directus-extension-localazy/pull/93)), plus three follow-ups merged directly to `main`.
+
+### 🚀 Headline Changes
+
+- **Toolchain to 2.0** — Node 22, npm workspaces, ESLint 10 flat config, Prettier 3, TypeScript 5.9, Vitest, Directus SDK 17, host range `^11`, husky pre-commit, knip, v8 coverage. CI gates lint + format + typecheck + tests plus a production build on every PR.
+- **`sync-hook` is now a Directus bundle** — `defineHook` + `defineEndpoint` packaged together. The endpoint exposes `GET /localazy-automation/status` so the module can detect bundle presence; the hook keeps the `ItemsService`/`FieldsService` callbacks (non-sandboxable by design, `MARKETPLACE_TRUST=all` required for marketplace installs).
+- **Server-driven sync** — inbound webhook handler with HMAC verification + admin gating + orchestrator dispatch; incremental download + upload pipelines; advisory sync lock + heartbeat + dirty-bit re-fire; burst coordinator coalescing related events into sessions.
+- **Activity page** — new `localazy_sync_log` collection, Export / Import tabs (direction), `Triggered by` filter (Automation / User) with initiator-name resolution, detail page powered by `useSyncLogEntries`. Coalesced `upload-automated` burst sessions render inline in the Export tab.
+- **Automation page** — single home for the sync master toggles (per ADR-0001 — previously split across Advanced Settings as `automated_upload` + `automated_deprecation`, with deprecation now a sub-toggle of the Export master). Includes the `WebhookSetup` UI, a README link when the bundle is missing, and bundle errors routed through the Directus logger.
+- **UX refresh** — Overview redesign, About rewrite + nav reorder, Import / Export tree search with whole-subtree reveal under a name match, dark-mode pass across module pages, fresh-install bug fixes, language-display utility + v-select language mappings editor (community PR #21 integrated).
+- **Architecture deepening** — async queue, deep sync-log writer, and incremental-import orchestrator lifted into `extensions/common/`; module-side incremental-export orchestrator extracted as a foundation; typed Directus service constructors; `DirectusModuleApi` class implementing a slim `DirectusApi` interface; `useSingletonForm`, `useLocalazyBoot`, `useUnsavedChangesGuard`, reactivity pattern standardization.
+- **Hardening** — eliminate the `no-explicit-any` baseline (68 → 0, rule promoted to error), triage floating promises (rule promoted to error), fix the webhook hang + Directus 11 admin gate (`admin_access` moved to `directus_policies`), UUID PK comparison fix, dynamic language FK resolution, SHA-256 fallback for non-secure-context browsers (`crypto.subtle` is undefined off HTTPS / `localhost`), `heal-fields` utility + `meta.special` drift PATCH.
+- **Docs & dev env** — `CLAUDE.md`, `CONTEXT.md` glossary, `docs/adr/` (incl. ADR-0001 for the master-toggle move), `scripts/dev.mjs` symlinks workspaces under `development/extensions/` to keep `EXTENSIONS_PATH` clean of `extensions/common/`, SQLite + seed script for local data.
+
+**Scope**: 261 files changed, +49,629 / −17,217.
+
+### 🧰 Post-Release Follow-ups
+
+- ⬆️ Bump sync-hook `axios` to ^1.15.2, covering 9 CVEs ([#98](https://github.com/localazy/directus-extension-localazy/pull/98))
+- 🔧 Make `.husky/pre-commit` executable ([#97](https://github.com/localazy/directus-extension-localazy/pull/97))
+- 🔧 Bump deprecated v4 GitHub Actions to v6 + lint cleanup ([#95](https://github.com/localazy/directus-extension-localazy/pull/95))
+
 ## 1.0.10 (2024-12-10)
 ### 🔀 Pull Requests
 


### PR DESCRIPTION
## Summary

- Adds a `2.0.0 (2026-05-20)` section to `CHANGELOG.md` covering the 75-PR `next` → `main` release that was squash-merged in #93, organized as a curated headline summary across nine topical bullets (toolchain, bundle conversion, server-driven sync, Activity/Automation pages, UX, architecture, hardening, docs/dev env).
- Lists the three post-release follow-ups merged directly to `main` (#95 CI bumps, #97 husky executable, #98 axios CVE bump) under a separate sub-section.
- Hand-written entry — the existing sections are auto-generated by `@localazy/conventional-changelog-preset`. When `localazy/release@v2` next runs against `main` it may rewrite or duplicate this section, so the release workflow run should be reviewed before merging the next release PR.

## Test plan

- [ ] Render `CHANGELOG.md` on GitHub and confirm headings, links, and emoji render correctly
- [ ] Confirm PR links resolve (#93, #95, #97, #98)
- [ ] Decide whether to let the next release-prep run overwrite this section or merge it into a follow-up commit