### PR TITLE
🔧 chore(ci): adopt lockstep release flow via @localazy/workflow-scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,53 +5,123 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
 
+env:
+  # Set the "NODE_AUTH_TOKEN" environmental variable that "actions/setup-node" uses as the "_authToken"
+  # in the generated ".npmrc" file to authenticate to NPM registry.
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_PUBLIC }}
+  FORCE_COLOR: '3'
+  HUSKY: '0'
+
 jobs:
-  ci:
-    name: CI Init
+  create-release-pr:
+    name: Create Release PR
     runs-on: [self-hosted, Linux]
-    outputs:
-      action: ${{ steps.init.outputs.action }}
+    if: "!startsWith(github.event.head_commit.message, '🚀 release:')"
+    timeout-minutes: 30
     steps:
-      - id: init
-        uses: localazy/release/init@v2
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-  prepare:
-    name: Prepare Release PR
-    needs: ci
-    if: needs.ci.outputs.action == 'prepare'
-    runs-on: [self-hosted, Linux]
-    steps:
-      - uses: localazy/release/prepare@v2
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          app-id: ${{ secrets.AUTH_APP_ID }}
-          app-key: ${{ secrets.AUTH_APP_KEY }}
-          monorepo-bump: |
-            ''
-            'extensions/common'
-            'extensions/module'
-            'extensions/sync-hook'
+          registry-url: https://registry.npmjs.org
 
-  publish:
+      - name: Generate token
+        id: auth
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_KEY }}
+
+      - name: Setup GitHub CLI
+        uses: sersoft-gmbh/setup-gh-cli-action@v3
+        with:
+          version: stable
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create Release PR
+        run: npx @localazy/workflow-scripts@latest create-release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+
+  publish-release:
     name: Publish Release
-    needs: ci
-    if: needs.ci.outputs.action == 'publish'
     runs-on: [self-hosted, Linux]
+    if: "startsWith(github.event.head_commit.message, '🚀 release:')"
+    timeout-minutes: 30
     steps:
-      - uses: localazy/release/publish@v2
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          app-id: ${{ secrets.AUTH_APP_ID }}
-          app-key: ${{ secrets.AUTH_APP_KEY }}
-          run-after-install: npm run set-production-config
-          monorepo-npm-build: |
-            'extensions/module'
-            'extensions/sync-hook'
-          monorepo-public-npm-token: ${{ secrets.NPM_AUTH_TOKEN_PUBLIC }}
-          monorepo-public-npm-publish: |
-            'extensions/module'
-            'extensions/sync-hook'
+          registry-url: https://registry.npmjs.org
+
+      - name: Read root version
+        id: package
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync extension versions to root
+        run: |
+          VERSION="${{ steps.package.outputs.version }}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version --workspace=@localazy/directus-extension-localazy
+          npm version "$VERSION" --no-git-tag-version --allow-same-version --workspace=@localazy/directus-extension-localazy-automation
+
+      - name: Build extensions
+        run: npm run build
+
+      - name: Publish @localazy/directus-extension-localazy
+        run: npm publish --access public --workspace=@localazy/directus-extension-localazy
+
+      - name: Publish @localazy/directus-extension-localazy-automation
+        run: npm publish --access public --workspace=@localazy/directus-extension-localazy-automation
+
+      - name: Generate token
+        id: auth
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_KEY }}
+
+      - name: Setup GitHub CLI
+        uses: sersoft-gmbh/setup-gh-cli-action@v3
+        with:
+          version: stable
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Create and push git tag
+        id: git-tag
+        run: npx @localazy/workflow-scripts@latest create-git-tag
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Create GitHub Release
+        run: npx @localazy/workflow-scripts@latest create-github-release "${{ steps.git-tag.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ A monorepo of two published Directus extensions plus one internal shared package
 ## Stack
 
 - **Node 22** (`.nvmrc`).
-- **npm workspaces** at the repo root. (Stay on npm — `localazy/release@v2` is npm-hardcoded; pnpm/Yarn would require forking that action.)
+- **npm workspaces** at the repo root.
 - **ESLint 10** flat config (`eslint.config.js`) + `typescript-eslint@8` + `eslint-plugin-vue@10` flat presets + `eslint-config-prettier`. Per-workspace globals: browser for `module/` and `common/`, node for `sync-hook/`.
 - **Prettier 3** (`.prettierrc.json`). Single quotes, semicolons, trailing commas, `printWidth: 140` (matches the `vue/max-len` lint rule — don't change one without changing the other).
 - **TypeScript** `^5.9`. Typechecking uses `vue-tsc --noEmit` so `<script lang="ts">` inside `.vue` files is covered.
@@ -78,7 +78,12 @@ rm -rf development/data development/uploads development/extensions
 | `npm run build`             | Minified production build of both extensions. This is what release publishes.       |
 | `npm run build:development` | Unminified build (faster, used by `dev`).                                           |
 
-CI (`.github/workflows/qa.yml`) runs `npm run check` then a production build on every PR. Release (`.github/workflows/release.yml`) is triggered by pushes to `main` and uses `localazy/release@v2` to bump versions, generate the changelog, build, and publish to npm.
+CI (`.github/workflows/qa.yml`) runs `npm run check` then a production build on every PR. Release (`.github/workflows/release.yml`) is triggered by pushes to `main` and uses `npx @localazy/workflow-scripts@latest` to drive a **lockstep release flow**: the root `package.json` version is the single source of truth, and both extensions publish together at that version. Two jobs gated by commit-message prefix:
+
+- Commit doesn't start with `🚀 release:` → `create-release-pr` opens a single PR bumping root version + updating root `CHANGELOG.md` based on conventional commits.
+- Commit starts with `🚀 release:` → sync both extensions' `version` field to root, build, `npm publish` both, then `create-git-tag` + `create-github-release`.
+
+The two extensions' `package.json` versions on `main` will lag behind root between releases — they are synced at publish time, so the value end users see on npm always matches root. Cosmetic mismatch only.
 
 ## Coding conventions
 


### PR DESCRIPTION
## Summary

Replaces `localazy/release@v2` with two CI jobs that invoke `npx @localazy/workflow-scripts@latest` directly, modeled on the shape used by `localazy-mt` and sibling repos.

- **Job A** — commit doesn't start with `🚀 release:` → `create-release-pr` opens a single PR bumping root version + root CHANGELOG from conventional commits.
- **Job B** — commit starts with `🚀 release:` → sync both extensions' `package.json` versions to root, build, `npm publish` both, then `create-git-tag` + `create-github-release`.

The two extensions stay lockstepped at the root version (matching today's behavior). Their `package.json` versions on `main` will lag behind root between releases — the sync step at publish time guarantees end users see the right version on npm; committed values are an artifact.

## Why this PR is first

This is PR #1 of the npm → pnpm + apps/packages restructure. The release flow rewrite is the highest-risk change, so it ships on the familiar (npm, current directory layout) stack first. Subsequent PRs will swap the package manager and then restructure the directory tree, both depending on this release flow already being in place.

## Test plan

- [ ] Verify `NPM_AUTH_TOKEN_PUBLIC`, `AUTH_APP_ID`, `AUTH_APP_KEY` org secrets reach this repo (they're already in use by current `release.yml`, so this should be a no-op confirmation).
- [ ] After merge, push a non-release commit to `main` and confirm Job A creates a release PR with proper version bump + CHANGELOG entry.
- [ ] Merge that release PR and confirm Job B publishes both extensions to npm at the same version, creates the git tag, and creates a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)