### PR TITLE
🐛 fix: allow sqlite3 native build so pnpm dev boots Directus

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ allowBuilds:
   oracledb: false
   protobufjs: false
   sharp: true
-  sqlite3: false
+  sqlite3: true
   unrs-resolver: true
   vue-demi: true
 

--- a/scripts/seed-dev-data.mjs
+++ b/scripts/seed-dev-data.mjs
@@ -236,6 +236,28 @@ async function main() {
     },
   ]);
 
+  // Pre-configure the articles collection's title + body as translatable so a
+  // fresh dev environment can drive Export / Import end-to-end without a manual
+  // Project Setup pass. Without this, the Articles checkbox on Import & Export
+  // is selectable but the Save action stays at 0 items, because the sync
+  // pipeline only walks fields listed in localazy_content_transfer_setup.
+  //
+  // The singleton row is created lazily by the module's installer-store on
+  // first boot. If we beat the module to it (race condition on a fresh start),
+  // log a warning and continue — the user can configure it manually via
+  // Project Setup. Either way the seed itself should not fail.
+  console.log('[seed] configuring articles fields as translatable');
+  try {
+    await api(token, '/items/localazy_content_transfer_setup', 'PATCH', {
+      enabled_fields: JSON.stringify([{ collection: 'articles', fields: ['title', 'body'] }]),
+    });
+  } catch (e) {
+    console.warn(
+      '[seed] could not configure translatable fields automatically — open the Localazy → Project Setup page once to initialise, then re-run the seed.',
+    );
+    console.warn('[seed] error:', e.message);
+  }
+
   console.log('[seed] done');
 }
 

--- a/scripts/seed-dev-data.mjs
+++ b/scripts/seed-dev-data.mjs
@@ -141,7 +141,12 @@ async function main() {
   await api(token, '/fields/articles_translations', 'POST', {
     field: 'languages_code',
     type: 'string',
-    meta: { interface: 'input' },
+    // Hidden from the per-translation form. Directus' translations interface
+    // determines the language by the row's position in the parent's
+    // translation list — the FK is not user-editable inline. Without
+    // hidden:true, the field tries to render the resolved language object
+    // as the value of a plain text input, surfacing "[object Object]".
+    meta: { interface: 'input', hidden: true },
     schema: { length: 16 },
   });
   await api(token, '/fields/articles_translations', 'POST', {

--- a/scripts/seed-dev-data.mjs
+++ b/scripts/seed-dev-data.mjs
@@ -38,7 +38,10 @@ async function main() {
   console.log('[seed] creating languages collection');
   await api(token, '/collections', 'POST', {
     collection: 'languages',
-    meta: { icon: 'translate' },
+    // display_template controls how a language relation renders in lists and
+    // in the translations interface. Without it, Directus falls back to the
+    // primary-key object and renders "[object Object]" for the language pill.
+    meta: { icon: 'translate', display_template: '{{name}} ({{code}})' },
     schema: {},
     fields: [
       {


### PR DESCRIPTION
## Summary

\`scripts/dev.mjs\` sets \`DB_CLIENT=sqlite3\`, which routes Directus to the legacy \`sqlite3\` npm package. PR #102 (pnpm migration) marked \`sqlite3: false\` in \`pnpm-workspace.yaml\`'s \`allowBuilds\` on the wrong assumption that \`better-sqlite3\` (which IS in devDeps) was the runtime driver. It isn't — Directus' source has a literal \`case "sqlite3"\` branch in its DB_CLIENT switch and doesn't recognise \`better-sqlite3\` as a value.

Under npm flat node_modules the sqlite3 native binary was always built on install. Under pnpm strict, the gate blocked it, so \`knex/Client_SQLite3.initializeDriver()\` walked through ten filesystem paths trying to find \`node_sqlite3.node\` and crashed.

## Fix

Flip \`sqlite3: false\` → \`sqlite3: true\` in \`pnpm-workspace.yaml\`. After this PR, contributors will need a one-time \`pnpm rebuild sqlite3\` (or fresh \`pnpm install\`) to get the native binary; subsequent installs are fine.

## Verified locally

\`pnpm dev\` now boots: 
- Initial turbo build (all cached) ✓
- Watch builds start for both extensions ✓
- Directus starts at http://localhost:8055 ✓
- Loaded extensions: \`@localazy/directus-extension-localazy\`, \`@localazy/directus-extension-localazy-automation\` ✓
- \"Watching extensions for changes...\" ✓

## Post-merge

Job A will refresh the existing release PR (#106) to include this commit in the CHANGELOG. The release itself ships as 2.0.0 — the prior \`localazy/release@v2\` bot left main at version 2.0.0 without pushing the tag, so workflow-scripts correctly detects \"manually bumped\" and uses 2.0.0 verbatim. Once Job B publishes and tags 2.0.0, future releases will bump normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)