### PR TITLE
✨ feat: harden import sync and improve Directus error reporting

### DIFF
--- a/packages/common/src/models/collections-data/sync-state.ts
+++ b/packages/common/src/models/collections-data/sync-state.ts
@@ -1,15 +1,19 @@
 /**
- * Sync cursor data, indexed by (language, Localazy key id). The recorded number is the
- * `event` value of the most recently applied modification for that (language, key) pair.
+ * Download-sync cursor: a per-language high-water mark. The recorded number is the largest
+ * Localazy modification `event` we've confirmed-imported for that language.
  *
- * On the next download sync we skip any (language, key) whose stored event is `>=` the
- * one returned by the API — i.e. we only fetch translations modified since we last wrote
- * them. Cells with `undefined` storedEvent or `undefined` API event are always treated as
- * "needs sync" (safe mode), preserving correctness if the server ever omits the field.
+ * On the next download sync we fetch only keys whose `event` is greater than the language's
+ * watermark (Localazy's own `sinceEvent` / `maxEvent` incremental contract). A missing
+ * watermark, or a key with no `event`, is always treated as "needs sync" (safe mode).
+ *
+ * This replaced an earlier per-`(language, keyId)` map, which grew one entry per translated
+ * key × language and overflowed the `processed_keys` TEXT column on large projects. The
+ * watermark keeps the stored payload to a handful of numbers regardless of project size.
+ * See `utilities/sync-cursor.ts` for the failure-safe advance rule.
  */
 export type SyncCursor = {
-  /** `{ [lang]: { [localazyKeyId]: lastProcessedEventNumber } }` */
-  processed_keys: Record<string, Record<string, number>>;
+  /** `{ [lang]: highWaterEventNumber }` */
+  processed_keys: Record<string, number>;
 };
 
 /**
@@ -35,7 +39,7 @@ export type UploadCursor = {
  * upload cursor in `uploaded_hashes`.
  */
 export type SyncState = {
-  /** JSON-encoded `SyncCursor['processed_keys']`. Default `'{}'`. */
+  /** JSON-encoded `SyncCursor['processed_keys']` (per-language watermark map). Default `'{}'`. */
   processed_keys: string;
   /** JSON-encoded `UploadCursor['uploaded_hashes']`. Default `'{}'`. */
   uploaded_hashes: string;

--- a/packages/common/src/services/orchestrator/incremental-import-orchestrator.test.ts
+++ b/packages/common/src/services/orchestrator/incremental-import-orchestrator.test.ts
@@ -406,12 +406,12 @@ describe('runIncrementalImport — orchestrator', () => {
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0]!.collection).toBe('posts');
 
-    // Cursor persisted at end with all three (lang, keyId, event) cells.
+    // Cursor persisted at end as a per-language high-water mark (max event seen per language).
     expect(cursor.persistCalls.length).toBeGreaterThanOrEqual(1);
     const final = cursor.diskCursor.processed_keys;
-    expect(final.fr).toEqual({ 'fr-1': 10 });
-    expect(final.de).toEqual({ 'de-1': 20 });
-    expect(final.es).toEqual({ 'es-1': 30 });
+    expect(final.fr).toBe(10);
+    expect(final.de).toBe(20);
+    expect(final.es).toBe(30);
 
     // Progress messages — FETCHING_TRANSLATIONS → CHANGES_SUMMARY → UPDATING_DIRECTUS_COLLECTION → IMPORT_FINISHED.
     const ids = messages.map((m) => m.id);
@@ -449,7 +449,7 @@ describe('runIncrementalImport — orchestrator', () => {
     // away. The orchestrator should ignore the stored cursor because the project id no
     // longer matches.
     const cursor = makeInMemoryCursorStore({
-      cursor: { processed_keys: { fr: { 'fr-1': 999 } } },
+      cursor: { processed_keys: { fr: 999 } },
       projectId: 'PROJ-OLD',
     });
     const content = buildCollectionContent('posts', [{ language: 'fr', itemId: '1', event: 5 }]);
@@ -469,7 +469,7 @@ describe('runIncrementalImport — orchestrator', () => {
 
   it('full-sync mode: starts from an empty cursor even when the disk cursor matches the current project', async () => {
     const cursor = makeInMemoryCursorStore({
-      cursor: { processed_keys: { fr: { 'fr-1': 999 } } },
+      cursor: { processed_keys: { fr: 999 } },
       projectId: 'PROJ-A',
     });
     const content = buildCollectionContent('posts', [{ language: 'fr', itemId: '1', event: 5 }]);
@@ -504,11 +504,10 @@ describe('runIncrementalImport — orchestrator', () => {
     expect(cursor.persistCalls).toHaveLength(0); // no cursor touch when the fetch never succeeded
   });
 
-  it('throttled flush: many keys trigger one mid-flow persist + a final persist', async () => {
-    // Build a payload that exceeds the throttle threshold (minimum 50). Use 150 keys
-    // spread across 150 items so each upsertItemFromLocalazyContent emits one triple
-    // per PATCH — the throttle should fire ~3 times (every 50 written triples) plus
-    // the final flush in `finally`.
+  it('single end-of-run persist: many keys collapse into one per-language watermark', async () => {
+    // 150 keys across 150 items, events 1..150. The watermark cursor persists exactly once
+    // (in `finally` — no mid-run throttled flush, since the watermark can only be finalised
+    // after all failures are known), and records a single number per language (the max event).
     const perLang: Array<{ language: string; itemId: string; event?: number }> = [];
     for (let i = 1; i <= 150; i += 1) {
       perLang.push({ language: 'fr', itemId: String(i), event: i });
@@ -526,17 +525,16 @@ describe('runIncrementalImport — orchestrator', () => {
 
     expect(result.status).toBe('completed');
     expect(result.itemsProcessed).toBe(150);
-    // Throttle threshold for 150 keys is max(50, ceil(150/10)) = 50. We expect at least
-    // 2 mid-flow flushes (at 50 and 100 keys written) plus 1 final flush => >= 3 total.
-    expect(cursor.persistCalls.length).toBeGreaterThanOrEqual(3);
-
-    // Final persisted cursor records all 150 (fr, key) cells.
-    expect(Object.keys(cursor.diskCursor.processed_keys.fr ?? {}).length).toBe(150);
+    // Exactly one persist (the final flush). No mid-run throttling.
+    expect(cursor.persistCalls).toHaveLength(1);
+    // The 150 keys collapse to a single per-language watermark = the max event.
+    expect(cursor.diskCursor.processed_keys.fr).toBe(150);
   });
 
-  it('error in upsert: the `finally` block still persists what was written before the failure', async () => {
-    // Build content for 3 items; fail the second PATCH. Items 1 (and ONLY item 1, since
-    // PATCH-then-mark gates `onWritten` on success) should land in the persisted cursor.
+  it('error in upsert: the watermark is held below the failed event so it retries next run', async () => {
+    // 3 items; fail the second PATCH (event 20). Succeeded events {10, 30}, failed {20}.
+    // The failure-safe watermark advances only to 10 (just below the earliest failure), so
+    // the next run re-fetches event > 10 — retrying the failed key 2 (and redundantly 3).
     const content = buildCollectionContent('posts', [
       { language: 'fr', itemId: '1', event: 10 },
       { language: 'fr', itemId: '2', event: 20 },
@@ -567,11 +565,8 @@ describe('runIncrementalImport — orchestrator', () => {
     expect(errors).toHaveLength(1);
     // Items 1 and 3 succeeded → 2 PATCHes recorded in `updateCalls`.
     expect(updateCalls.map((c) => c.itemId).sort()).toEqual(['1', '3']);
-    // Cursor reflects only the successful writes.
-    const fr = cursor.diskCursor.processed_keys.fr ?? {};
-    expect(fr['fr-1']).toBe(10);
-    expect(fr['fr-3']).toBe(30);
-    expect(fr['fr-2']).toBeUndefined();
+    // Watermark held at 10 (just below the failed event 20) so key 2 is retried next run.
+    expect(cursor.diskCursor.processed_keys.fr).toBe(10);
     // The final persist always runs in `finally`.
     expect(cursor.persistCalls.length).toBeGreaterThanOrEqual(1);
   });

--- a/packages/common/src/services/orchestrator/incremental-import-orchestrator.ts
+++ b/packages/common/src/services/orchestrator/incremental-import-orchestrator.ts
@@ -1,5 +1,5 @@
 import { Project } from '@localazy/api-client';
-import { createEmptyCursor, cursorMatchesProject, filterKeysByEventCursor, recordCursorEntry } from '../../utilities/sync-cursor';
+import { buildWatermarkCursor, createEmptyCursor, cursorMatchesProject, filterKeysByEventCursor } from '../../utilities/sync-cursor';
 import { SyncCursor } from '../../models/collections-data/sync-state';
 import { DirectusLocalazyLanguage } from '../../models/directus-localazy-language';
 import { EnabledField } from '../../models/collections-data/content-transfer-setup';
@@ -154,9 +154,20 @@ async function runImportBody(
   const { cursor: storedCursor, projectId: storedProjectId } = await cursorStore.load();
   const baseCursor: SyncCursor =
     mode === 'full' || !cursorMatchesProject(storedProjectId, localazyProject.id || '') ? createEmptyCursor() : storedCursor;
-  // The in-memory cursor tracks only what we successfully wrote this run.
-  // `cursorStore.persist` merges it with whatever's on disk before each save.
-  const inMemoryCursor: SyncCursor = createEmptyCursor();
+  // Per-language events seen this run, split by outcome. The new per-language watermark is
+  // computed from these at persist time (`buildWatermarkCursor`): a language's watermark
+  // advances only up to just-below its earliest FAILED event, so failed keys are re-fetched
+  // next run. Tracking events (not keys) keeps the persisted cursor a handful of numbers.
+  const succeededEventsByLang = new Map<string, number[]>();
+  const failedEventsByLang = new Map<string, number[]>();
+  const recordEvents = (target: Map<string, number[]>, triples: WrittenTriple[]) => {
+    triples.forEach((t) => {
+      if (t.event === undefined) return;
+      const bucket = target.get(t.language) ?? [];
+      bucket.push(t.event);
+      target.set(t.language, bucket);
+    });
+  };
 
   // Milestone log: "started" line. The wording mirrors the design's section 11d so the
   // Activity page reads coherently regardless of whether the run came from UI or webhook.
@@ -203,8 +214,9 @@ async function runImportBody(
     });
     log.appendInfo('Already up to date — no changes since last sync');
     // Still touch `last_sync_at` so the UX / debug field reflects the most recent
-    // successful run; merge-on-persist keeps the cursor itself unchanged.
-    await cursorStore.persist(inMemoryCursor);
+    // successful run; persisting the unchanged base watermark leaves the cursor itself
+    // untouched.
+    await cursorStore.persist(baseCursor);
     return {
       status: 'up-to-date',
       itemsProcessed: 0,
@@ -219,11 +231,11 @@ async function runImportBody(
     mode: 'upsert',
   });
 
-  // Throttled flush: persist every `flushEvery` keys completed (capped at 10% of
-  // total work, minimum 50). Final flush happens unconditionally below.
-  const totalKeys = summary.changes;
-  const flushEvery = Math.max(50, Math.ceil(totalKeys / 10));
-  let sinceLastFlush = 0;
+  // The watermark can only be finalised once we know every failure for the run (advancing
+  // it past a key that fails later would skip that key forever). So unlike the old per-key
+  // cursor, we do NOT flush mid-run — we persist once in the `finally` below. A crash
+  // mid-run simply means the next run re-fetches from the last persisted watermark, which
+  // is correct (just redundant work).
   let writtenSinceStart = 0;
 
   // Per-collection / translation-string counters — only tally cursor-confirmed writes so
@@ -244,8 +256,8 @@ async function runImportBody(
   let writesForTranslationStrings = 0;
 
   const onWritten = (triples: WrittenTriple[]) => {
+    recordEvents(succeededEventsByLang, triples);
     triples.forEach((t) => {
-      recordCursorEntry(inMemoryCursor, t.language, t.keyId, t.event);
       const collection = keyIdToCollection.get(t.keyId);
       if (collection) {
         writesPerCollection.set(collection, (writesPerCollection.get(collection) ?? 0) + 1);
@@ -255,17 +267,16 @@ async function runImportBody(
         writesForTranslationStrings += 1;
       }
     });
-    sinceLastFlush += triples.length;
     writtenSinceStart += triples.length;
     // Surface the running total so the lock heartbeat closure can persist it without
     // reaching into the orchestrator's private state.
     onItemsProcessed(writtenSinceStart);
-    if (sinceLastFlush >= flushEvery) {
-      sinceLastFlush = 0;
-      // Fire-and-forget: the next persist will reload the disk cursor anyway, and we
-      // do not want write progress to stall on a slow Directus PATCH.
-      void cursorStore.persist(inMemoryCursor);
-    }
+  };
+
+  // Failed writes don't advance the cursor; we record their events so the watermark stays
+  // below them and the keys are retried next run.
+  const onFailed = (triples: WrittenTriple[]) => {
+    recordEvents(failedEventsByLang, triples);
   };
 
   // Wrap the caller's error sink so we get per-error log entries on the persisted
@@ -291,9 +302,12 @@ async function runImportBody(
       progress,
       onDirectusError: wrappedErrorSink,
       onWritten,
+      onFailed,
     });
   } finally {
-    await cursorStore.persist(inMemoryCursor);
+    // Single end-of-run persist: fold this run's per-language successes/failures into the
+    // base watermark. Failed events hold their language's watermark below them.
+    await cursorStore.persist(buildWatermarkCursor(baseCursor, succeededEventsByLang, failedEventsByLang));
   }
 
   // Milestone log: per-collection counts. Emitted after the upsert step so the numbers

--- a/packages/common/src/services/orchestrator/incremental-import-orchestrator.ts
+++ b/packages/common/src/services/orchestrator/incremental-import-orchestrator.ts
@@ -5,7 +5,7 @@ import { DirectusLocalazyLanguage } from '../../models/directus-localazy-languag
 import { EnabledField } from '../../models/collections-data/content-transfer-setup';
 import { LocalazyData } from '../../models/collections-data/localazy-data';
 import { Settings } from '../../models/collections-data/settings';
-import { LockState, OrchestratorAdapters } from './ports';
+import { ErrorSink, LockState, OrchestratorAdapters } from './ports';
 import { LocalazyContentSummary, summarizeLocalazyContent } from './summarize-localazy-content';
 import { upsertFromLocalazyContent } from './upsert-localazy-content';
 import { WrittenTriple } from './written-triple';
@@ -283,8 +283,8 @@ async function runImportBody(
   // session row in addition to the existing module-side error store. The wrap
   // intentionally calls the wrapped sink first so existing observers see errors with
   // identical timing — only the log entry is new.
-  const wrappedErrorSink = (err: unknown) => {
-    onDirectusError(err);
+  const wrappedErrorSink: ErrorSink = (err, context) => {
+    onDirectusError(err, context);
     const message = err instanceof Error ? err.message : String(err);
     log.appendError(`Upsert error: ${message}`);
   };

--- a/packages/common/src/services/orchestrator/lock-constants.ts
+++ b/packages/common/src/services/orchestrator/lock-constants.ts
@@ -35,3 +35,29 @@ export const SYNC_LOCK_HARD_CEILING_MS = 2 * 60 * 60 * 1000;
  * own staleness check would already let a contender steal.
  */
 export const SYNC_LOCK_STUCK_HINT_MS = SYNC_LOCK_STALE_HEARTBEAT_MS;
+
+/**
+ * Shared "is this lock dead?" predicate, evaluated against a `localazy_sync_state` row.
+ * Mirrors the orchestrator's private `isLockStale` (which reads the internal `LockState`
+ * shape) but operates on the persisted `sync_*` column names so the UI surfaces — the
+ * Import button's disabled affordance and the Activity-detail terminate flow — classify a
+ * lock identically to the orchestrator's own steal check. There is one staleness rule for
+ * all three callers.
+ *
+ * Stale = `sync_started_at` older than the 2 h hard ceiling (zombie that keeps
+ * heartbeating but never finishes) OR `sync_last_heartbeat_at` older than the 5 min
+ * heartbeat window (dead worker / Directus restart). A null timestamp is never stale on
+ * its own — a lock acquired microseconds ago hasn't heartbeated yet. Callers gate this
+ * behind `sync_in_progress === true`.
+ */
+export function isSyncLockStale(state: { sync_started_at: string | null; sync_last_heartbeat_at: string | null }, now: number): boolean {
+  if (state.sync_started_at) {
+    const startedMs = Date.parse(state.sync_started_at);
+    if (Number.isFinite(startedMs) && now - startedMs > SYNC_LOCK_HARD_CEILING_MS) return true;
+  }
+  if (state.sync_last_heartbeat_at) {
+    const heartbeatMs = Date.parse(state.sync_last_heartbeat_at);
+    if (Number.isFinite(heartbeatMs) && now - heartbeatMs > SYNC_LOCK_STALE_HEARTBEAT_MS) return true;
+  }
+  return false;
+}

--- a/packages/common/src/services/orchestrator/ports.ts
+++ b/packages/common/src/services/orchestrator/ports.ts
@@ -91,8 +91,21 @@ export type ResolveLanguageFkField = (parentCollection: string, translationField
  * existing code routed to `useErrorsStore()`; lifting splits that responsibility — the
  * orchestrator hands errors back through this port, the module adapter relays them to the
  * Pinia errors store.
+ *
+ * The optional `context` carries *where* the error happened so the UI can deep-link to the
+ * record (see `DirectusErrorContext`). Widening is backward-compatible: existing one-arg
+ * sinks remain assignable and callers may still invoke with a single argument.
  */
-export type ErrorSink = (error: unknown) => void;
+export type DirectusErrorContext = {
+  /** Parent collection the failing PATCH targeted — used for a Directus item deep-link. */
+  collection?: string;
+  /** Parent item id the failing PATCH targeted. */
+  itemId?: string | number;
+  /** Languages whose translations were in the failed batch (from the write triples). */
+  languages?: string[];
+};
+
+export type ErrorSink = (error: unknown, context?: DirectusErrorContext) => void;
 
 /**
  * Snapshot of the advisory sync lock. Mirrors the persisted `localazy_sync_state` row

--- a/packages/common/src/services/orchestrator/upsert-localazy-content.ts
+++ b/packages/common/src/services/orchestrator/upsert-localazy-content.ts
@@ -89,18 +89,33 @@ function madeUpdateChanges(updateTranslationFields: Set<string>, payload: Transl
   );
 }
 
-type UpsertItemFromLocalazyContentInput = {
-  collection: string;
+type BuildItemUpsertInput = {
   itemsInCollection: Item[];
   itemId: string | number;
   translations: LocalazyItemsInLanguage[];
   translationFieldFkMap: Map<string, string>;
   languageCodeField: string;
-  directusApi: DirectusApi;
 };
 
-async function upsertItemFromLocalazyContent(input: UpsertItemFromLocalazyContentInput): Promise<WrittenTriple[]> {
-  const { itemsInCollection, itemId, translations, collection, translationFieldFkMap, languageCodeField, directusApi } = input;
+type BuiltItemUpsert = {
+  /**
+   * Every `(lang, keyId, event)` triple this item's translations contribute. Reported to
+   * the caller's `onWritten` after the PATCH resolves, or `onFailed` if it throws — so the
+   * cursor can advance on success and hold (retry) on failure. PATCH-then-mark.
+   */
+  triples: WrittenTriple[];
+  payload: TranslationPayload;
+  /** False for an idempotent no-op (local row already matches) — skip the PATCH, still mark written. */
+  shouldWrite: boolean;
+};
+
+/**
+ * Pure builder — computes the translation payload + the contributing triples for one item.
+ * Deliberately does NO I/O so the caller owns the PATCH (and can route the triples to
+ * `onWritten` vs `onFailed` depending on the outcome).
+ */
+function buildItemUpsert(input: BuildItemUpsertInput): BuiltItemUpsert {
+  const { itemsInCollection, itemId, translations, translationFieldFkMap, languageCodeField } = input;
   // Stringify both sides — `+id` returns NaN for UUID primary keys, and NaN === NaN is
   // false, so the strict numeric equality used previously silently failed for any
   // installation with UUID-keyed collections.
@@ -108,13 +123,10 @@ async function upsertItemFromLocalazyContent(input: UpsertItemFromLocalazyConten
   let payload: TranslationPayload = {};
   const updateTranslationFields: Set<string> = new Set();
   let somethingToCreate = false;
-  // Track every `(lang, keyId, event)` triple that contributed to this PATCH. We only
-  // hand the list back to the caller after the PATCH resolves (PATCH-then-mark) — so a
-  // failed write never produces a cursor advance that would skip the same key next time.
   const triples: WrittenTriple[] = [];
 
   if (!collectionItem) {
-    return [];
+    return { triples, payload, shouldWrite: false };
   }
   translations.forEach((translation) => {
     translation.items.forEach((item) => {
@@ -141,14 +153,7 @@ async function upsertItemFromLocalazyContent(input: UpsertItemFromLocalazyConten
     });
   });
   const someUpdateChanges = madeUpdateChanges(updateTranslationFields, payload, collectionItem);
-  if (someUpdateChanges || somethingToCreate) {
-    await directusApi.updateDirectusItem(collection, itemId, payload);
-    return triples;
-  }
-  // Nothing was sent to Directus (idempotent no-op) — still advance the cursor since
-  // the local row already matches the remote translation, otherwise we'd refetch it
-  // again every sync.
-  return triples;
+  return { triples, payload, shouldWrite: someUpdateChanges || somethingToCreate };
 }
 
 type UpsertItemsFromSingleCollectionInput = {
@@ -160,10 +165,11 @@ type UpsertItemsFromSingleCollectionInput = {
   progress: ProgressSink;
   onDirectusError: ErrorSink;
   onWritten?: (triples: WrittenTriple[]) => void;
+  onFailed?: (triples: WrittenTriple[]) => void;
 };
 
 async function upsertItemsFromSingleCollection(input: UpsertItemsFromSingleCollectionInput) {
-  const { collection, content, settings, directusApi, resolveLanguageFkField, progress, onDirectusError, onWritten } = input;
+  const { collection, content, settings, directusApi, resolveLanguageFkField, progress, onDirectusError, onWritten, onFailed } = input;
 
   try {
     // Build a map of translation field -> FK column for the language relation, and ask
@@ -195,23 +201,28 @@ async function upsertItemsFromSingleCollection(input: UpsertItemsFromSingleColle
         mode: 'upsert',
       });
 
+      const built = buildItemUpsert({
+        itemsInCollection,
+        itemId,
+        translations,
+        translationFieldFkMap,
+        languageCodeField: settings.language_code_field,
+      });
       try {
-        const triples = await upsertItemFromLocalazyContent({
-          collection,
-          itemsInCollection,
-          itemId,
-          translations,
-          translationFieldFkMap,
-          languageCodeField: settings.language_code_field,
-          directusApi,
-        });
-        // PATCH-then-mark: only invoke the cursor sink after the write resolves. If the
-        // PATCH threw, we land in the catch below and `onWritten` is never called.
-        if (triples.length > 0 && onWritten) {
-          onWritten(triples);
+        if (built.shouldWrite) {
+          await directusApi.updateDirectusItem(collection, itemId, built.payload);
+        }
+        // PATCH-then-mark: only advance the cursor after the write resolves (or for an
+        // idempotent no-op, where the local row already matches). A thrown PATCH skips
+        // this and routes the same triples to `onFailed` so they're retried next run.
+        if (built.triples.length > 0 && onWritten) {
+          onWritten(built.triples);
         }
       } catch (e: unknown) {
         onDirectusError(e);
+        if (built.triples.length > 0 && onFailed) {
+          onFailed(built.triples);
+        }
         progress({
           id: UpsertProgressIds.UPDATING_DIRECTUS_COLLECTION_ERROR,
           message: `Error updating ${collection} collection (${index + 1}/${entries.length})`,
@@ -237,6 +248,7 @@ type UpsertTranslationStringsInput = {
   progress: ProgressSink;
   onDirectusError: ErrorSink;
   onWritten?: (triples: WrittenTriple[]) => void;
+  onFailed?: (triples: WrittenTriple[]) => void;
 };
 
 /**
@@ -245,7 +257,7 @@ type UpsertTranslationStringsInput = {
  * actual Directus side (legacy translations collection vs dedicated `localazy_translation_strings`).
  */
 async function upsertTranslationStrings(input: UpsertTranslationStringsInput): Promise<void> {
-  const { data, directusApi, progress, onDirectusError, onWritten } = input;
+  const { data, directusApi, progress, onDirectusError, onWritten, onFailed } = input;
   if (data.length === 0) {
     return;
   }
@@ -256,26 +268,26 @@ async function upsertTranslationStrings(input: UpsertTranslationStringsInput): P
     mode: 'upsert',
   });
 
+  // Build the triples up front so they're available on both branches: advance the cursor
+  // via `onWritten` on success, hold it via `onFailed` on failure (PATCH-then-mark).
+  const triples: WrittenTriple[] = [];
+  data.forEach((block) => {
+    Object.entries(block.localazyKeys).forEach(([language, localazyKey]) => {
+      triples.push({ language, keyId: localazyKey.id, event: localazyKey.event });
+    });
+  });
+
   try {
     const translationStringsService = new TranslationStringsService(directusApi);
     await translationStringsService.upsertTranslationStrings(data);
-    if (onWritten) {
-      const triples: WrittenTriple[] = [];
-      data.forEach((block) => {
-        Object.entries(block.localazyKeys).forEach(([language, localazyKey]) => {
-          triples.push({
-            language,
-            keyId: localazyKey.id,
-            event: localazyKey.event,
-          });
-        });
-      });
-      if (triples.length > 0) {
-        onWritten(triples);
-      }
+    if (triples.length > 0 && onWritten) {
+      onWritten(triples);
     }
   } catch (e: unknown) {
     onDirectusError(e);
+    if (triples.length > 0 && onFailed) {
+      onFailed(triples);
+    }
   }
 }
 
@@ -293,6 +305,12 @@ export type UpsertFromLocalazyContentInput = {
    * key, to keep the callback overhead off the hot loop.
    */
   onWritten?: (triples: WrittenTriple[]) => void;
+  /**
+   * Invoked once per item/translation-string batch whose write FAILED, with the same
+   * triples `onWritten` would have received on success. The orchestrator uses the failed
+   * events to hold the per-language watermark below them so the keys are retried next run.
+   */
+  onFailed?: (triples: WrittenTriple[]) => void;
 };
 
 /**
@@ -301,7 +319,7 @@ export type UpsertFromLocalazyContentInput = {
  * 150 ms delay between tasks (matches the original module-side behaviour).
  */
 export async function upsertFromLocalazyContent(input: UpsertFromLocalazyContentInput): Promise<void> {
-  const { contentItems, settings, directusApi, resolveLanguageFkField, progress, onDirectusError, onWritten } = input;
+  const { contentItems, settings, directusApi, resolveLanguageFkField, progress, onDirectusError, onWritten, onFailed } = input;
   const { add, execute } = createAsyncQueue();
   contentItems.collections.forEach((content, collection) => {
     add(async () =>
@@ -314,6 +332,7 @@ export async function upsertFromLocalazyContent(input: UpsertFromLocalazyContent
         progress,
         onDirectusError,
         onWritten,
+        onFailed,
       }),
     );
   });
@@ -324,6 +343,7 @@ export async function upsertFromLocalazyContent(input: UpsertFromLocalazyContent
       progress,
       onDirectusError,
       onWritten,
+      onFailed,
     }),
   );
 

--- a/packages/common/src/services/orchestrator/upsert-localazy-content.ts
+++ b/packages/common/src/services/orchestrator/upsert-localazy-content.ts
@@ -219,7 +219,10 @@ async function upsertItemsFromSingleCollection(input: UpsertItemsFromSingleColle
           onWritten(built.triples);
         }
       } catch (e: unknown) {
-        onDirectusError(e);
+        // Attach where it failed so the UI can deep-link: the PATCH targets the parent
+        // `collection` + `itemId`; languages come from the batch's write triples.
+        const languages = [...new Set(built.triples.map((t) => t.language))];
+        onDirectusError(e, { collection, itemId, languages });
         if (built.triples.length > 0 && onFailed) {
           onFailed(built.triples);
         }

--- a/packages/common/src/services/synchronization-languages-service.test.ts
+++ b/packages/common/src/services/synchronization-languages-service.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Project } from '@localazy/api-client';
+import { SynchronizationLanguagesService } from './synchronization-languages-service';
+import { DirectusApi } from '../interfaces/directus-api';
+import { CreateMissingLanguagesInDirectus } from '../enums/create-missing-languages-in-directus';
+import { Settings } from '../models/collections-data/settings';
+
+/**
+ * Regression coverage for the import language-resolution gate. A Localazy project language
+ * that has no backing row in the Directus languages collection must only end up in the
+ * import set when the `create_missing_languages_in_directus` setting actually creates it —
+ * otherwise the orchestrator would write `*_translations` rows whose `languages_code` has
+ * no parent row and Directus rejects them with `Invalid foreign key "ja" …`.
+ */
+describe('SynchronizationLanguagesService.resolveImportLanguages — missing-language gate', () => {
+  const LANGUAGE_COLLECTION = 'languages';
+  const LANGUAGE_CODE_FIELD = 'code';
+
+  // Directus has en + cs; the Localazy project additionally offers ja (missing from Directus).
+  function buildProject(): Project {
+    return {
+      languages: [
+        { code: 'en', name: 'English' },
+        { code: 'cs', name: 'Czech' },
+        { code: 'ja', name: 'Japanese' },
+      ],
+      sourceLanguage: 0,
+    } as unknown as Project;
+  }
+
+  function buildSettings(mode: CreateMissingLanguagesInDirectus): Settings {
+    return {
+      language_collection: LANGUAGE_COLLECTION,
+      language_code_field: LANGUAGE_CODE_FIELD,
+      language_mappings: '[]',
+      // `true` keeps every resolved language (the source-language remap branch) so the test
+      // asserts purely on the missing-language gate, not on source-language filtering.
+      import_source_language: true,
+      source_language: 'en',
+      create_missing_languages_in_directus: mode,
+    } as unknown as Settings;
+  }
+
+  function buildApi() {
+    const createDirectusItem = vi.fn().mockResolvedValue(undefined);
+    const api = {
+      fetchDirectusItems: vi.fn().mockResolvedValue([{ [LANGUAGE_CODE_FIELD]: 'en' }, { [LANGUAGE_CODE_FIELD]: 'cs' }]),
+      createDirectusItem,
+    } as unknown as DirectusApi;
+    return { api, createDirectusItem };
+  }
+
+  it('skips a missing language (does not import or create it) when the setting is NO', async () => {
+    const { api, createDirectusItem } = buildApi();
+    const service = new SynchronizationLanguagesService(api);
+
+    const result = await service.resolveImportLanguages(buildSettings(CreateMissingLanguagesInDirectus.NO), buildProject());
+
+    const directusForms = result.map((l) => l.directusForm).sort();
+    expect(directusForms).toEqual(['cs', 'en']);
+    expect(directusForms).not.toContain('ja');
+    expect(createDirectusItem).not.toHaveBeenCalled();
+  });
+
+  it('creates and imports a missing language when the setting is ALL', async () => {
+    const { api, createDirectusItem } = buildApi();
+    const service = new SynchronizationLanguagesService(api);
+
+    const result = await service.resolveImportLanguages(buildSettings(CreateMissingLanguagesInDirectus.ALL), buildProject());
+
+    expect(result.map((l) => l.directusForm).sort()).toEqual(['cs', 'en', 'ja']);
+    expect(createDirectusItem).toHaveBeenCalledTimes(1);
+    expect(createDirectusItem).toHaveBeenCalledWith(LANGUAGE_COLLECTION, expect.objectContaining({ [LANGUAGE_CODE_FIELD]: 'ja' }));
+  });
+
+  it('skips a missing language under ONLY_NON_HIDDEN (the create filter is inert, so nothing is created)', async () => {
+    const { api, createDirectusItem } = buildApi();
+    const service = new SynchronizationLanguagesService(api);
+
+    const result = await service.resolveImportLanguages(buildSettings(CreateMissingLanguagesInDirectus.ONLY_NON_HIDDEN), buildProject());
+
+    expect(result.map((l) => l.directusForm).sort()).toEqual(['cs', 'en']);
+    expect(createDirectusItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/common/src/services/synchronization-languages-service.ts
+++ b/packages/common/src/services/synchronization-languages-service.ts
@@ -72,33 +72,41 @@ export class SynchronizationLanguagesService {
       localazyForm: DirectusLocalazyAdapter.transformDirectusToLocalazyLanguage(directusLanguage),
     }));
 
-    const localazyExpandedLanguages = localazyLanguages.map((localazyLanguage) => ({
+    // Localazy project languages with no backing row in the Directus languages collection.
+    // Same comparison the create step uses below, so "missing" and "created" stay in lockstep.
+    const localazyLanguagesNotInDirectus = localazyLanguages.filter(
+      (l) => !directusExpandedLangauges.some((directusLanguage) => directusLanguage.localazyForm === l.code),
+    );
+
+    // Of the missing languages, the subset we'll actually create in Directus. `NO` creates
+    // nothing; `ALL` creates every missing language.
+    // Note: `enabled` isn't on @localazy/api-client's Language type. At runtime this access
+    // is always undefined, so the `ONLY_NON_HIDDEN` branch is effectively ALL-only today —
+    // preserving the existing (already-inert) "filter by enabled" behaviour.
+    const localazyLanguagesToCreate =
+      settings.create_missing_languages_in_directus === CreateMissingLanguagesInDirectus.NO
+        ? []
+        : localazyLanguagesNotInDirectus.filter(
+            (l) =>
+              settings.create_missing_languages_in_directus === CreateMissingLanguagesInDirectus.ALL ||
+              (l as { enabled?: boolean }).enabled,
+          );
+    if (localazyLanguagesToCreate.length > 0) {
+      await this.createLanguages(settings, localazyLanguagesToCreate);
+    }
+
+    // Import only languages that have a Directus row: the ones already present, plus the
+    // ones we just created. A Localazy language that's missing from Directus and was NOT
+    // created is intentionally skipped — writing its translation rows would fail the
+    // `languages_code` foreign key (`Invalid foreign key "ja" …`). This is the
+    // "when the import doesn't create the missing language, skip it" behaviour, gated by
+    // the `create_missing_languages_in_directus` setting.
+    const createdExpandedLanguages: DirectusLocalazyLanguage[] = localazyLanguagesToCreate.map((localazyLanguage) => ({
       originalForm: localazyLanguage.code,
       directusForm: DirectusLocalazyAdapter.transformLocalazyToDirectusPreferedFormLanguage(localazyLanguage.code),
       localazyForm: localazyLanguage.code,
     }));
-    let importLanguages: DirectusLocalazyLanguage[] = [...directusExpandedLangauges];
-    localazyExpandedLanguages.forEach((localazyLanguage) => {
-      const languageExistsInDirectus = importLanguages.find((l) => l.originalForm === localazyLanguage.originalForm);
-      const localazyFormInDirectusExists = importLanguages.find((l) => l.localazyForm === localazyLanguage.originalForm);
-      if (!languageExistsInDirectus && !localazyFormInDirectusExists) {
-        importLanguages.push(localazyLanguage);
-      }
-    });
-
-    if (settings.create_missing_languages_in_directus !== CreateMissingLanguagesInDirectus.NO) {
-      const localazyLanguagesNotInDirectus = localazyLanguages
-        .filter((l) => !directusExpandedLangauges.some((directusLanguage) => directusLanguage.localazyForm === l.code))
-        // Note: `enabled` isn't on @localazy/api-client's Language type. At runtime this
-        // access is always undefined, so the filter effectively only lets languages through
-        // when create_missing_languages_in_directus === ALL. Preserving existing behavior;
-        // the underlying "filter by enabled" logic was already inert.
-        .filter(
-          (l) =>
-            settings.create_missing_languages_in_directus === CreateMissingLanguagesInDirectus.ALL || (l as { enabled?: boolean }).enabled,
-        );
-      await this.createLanguages(settings, localazyLanguagesNotInDirectus);
-    }
+    let importLanguages: DirectusLocalazyLanguage[] = [...directusExpandedLangauges, ...createdExpandedLanguages];
 
     if (!import_source_language) {
       importLanguages = importLanguages.filter(

--- a/packages/common/src/utilities/sync-cursor.test.ts
+++ b/packages/common/src/utilities/sync-cursor.test.ts
@@ -6,7 +6,8 @@ import {
   serializeCursor,
   cursorMatchesProject,
   filterKeysByEventCursor,
-  recordCursorEntry,
+  advanceWatermark,
+  buildWatermarkCursor,
   mergeCursor,
   countCursorEntries,
 } from './sync-cursor';
@@ -26,192 +27,178 @@ describe('createEmptyCursor', () => {
 });
 
 describe('parseCursor', () => {
-  it('returns empty cursor for null / undefined / empty string', () => {
+  it('returns an empty cursor for null/undefined/empty input', () => {
     expect(parseCursor(null)).toEqual({ processed_keys: {} });
     expect(parseCursor(undefined)).toEqual({ processed_keys: {} });
     expect(parseCursor('')).toEqual({ processed_keys: {} });
   });
 
-  it('parses a well-formed JSON map', () => {
-    const raw = JSON.stringify({ en: { k1: 10, k2: 20 }, fr: { k1: 5 } });
-    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10, k2: 20 }, fr: { k1: 5 } } });
+  it('parses a per-language watermark map', () => {
+    expect(parseCursor('{"en":10,"fr":5}')).toEqual({ processed_keys: { en: 10, fr: 5 } });
   });
 
-  it('returns empty cursor for malformed JSON', () => {
+  it('parses negative watermarks (Localazy events are large negatives)', () => {
+    expect(parseCursor('{"ar":-6481606696963903000}')).toEqual({ processed_keys: { ar: -6481606696963903000 } });
+  });
+
+  it('returns empty on malformed JSON', () => {
     expect(parseCursor('{not-json')).toEqual({ processed_keys: {} });
   });
 
-  it('returns empty cursor for non-object JSON (array / string / number)', () => {
+  it('returns empty for non-object JSON', () => {
     expect(parseCursor('[1,2,3]')).toEqual({ processed_keys: {} });
     expect(parseCursor('"hello"')).toEqual({ processed_keys: {} });
     expect(parseCursor('42')).toEqual({ processed_keys: {} });
   });
 
-  it('drops non-numeric event values silently', () => {
-    const raw = JSON.stringify({ en: { k1: 10, k2: 'oops', k3: null, k4: 7 } });
-    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10, k4: 7 } } });
+  it('drops non-number values, keeping only valid numeric watermarks', () => {
+    expect(parseCursor('{"en":10,"fr":"oops","de":null}')).toEqual({ processed_keys: { en: 10 } });
   });
 
-  it('drops non-object per-language buckets', () => {
-    const raw = JSON.stringify({ en: { k1: 10 }, fr: 'broken', de: null });
-    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10 } } });
-  });
-
-  it('drops Infinity / NaN as non-finite numbers', () => {
-    // JSON.stringify would normally turn these to null, so build the object manually.
-    const raw = '{"en":{"k1":10,"k2":null}}';
-    expect(parseCursor(raw)).toEqual({ processed_keys: { en: { k1: 10 } } });
+  it('forward-migrates a legacy per-key map by dropping it (language re-syncs)', () => {
+    // Old shape: { lang: { keyId: event } }. The object value is not a number, so the
+    // language is dropped and will be re-synced once into a compact watermark.
+    expect(parseCursor('{"en":{"k1":10,"k2":20},"fr":7}')).toEqual({ processed_keys: { fr: 7 } });
   });
 });
 
 describe('serializeCursor', () => {
-  it('serializes the processed_keys map to JSON', () => {
-    expect(serializeCursor({ processed_keys: { en: { k1: 10 } } })).toBe('{"en":{"k1":10}}');
+  it('serializes the watermark map to JSON', () => {
+    expect(serializeCursor({ processed_keys: { en: 10, fr: 5 } })).toBe('{"en":10,"fr":5}');
   });
 
-  it('serializes empty cursor to empty object string', () => {
+  it('serializes an empty cursor to {}', () => {
     expect(serializeCursor(createEmptyCursor())).toBe('{}');
   });
 
   it('round-trips through parseCursor', () => {
-    const original = { processed_keys: { en: { k1: 10, k2: 20 }, fr: { k3: 5 } } };
+    const original = { processed_keys: { en: 20, fr: 5 } };
     expect(parseCursor(serializeCursor(original))).toEqual(original);
   });
 });
 
 describe('cursorMatchesProject', () => {
-  it('returns true when stored project id is empty (first sync)', () => {
-    expect(cursorMatchesProject('', 'abc')).toBe(true);
+  it('treats an empty stored project id as a match (first sync)', () => {
+    expect(cursorMatchesProject('', 'proj-1')).toBe(true);
   });
-
-  it('returns true when stored matches current', () => {
-    expect(cursorMatchesProject('abc', 'abc')).toBe(true);
-  });
-
-  it('returns false when stored differs from current', () => {
-    expect(cursorMatchesProject('abc', 'def')).toBe(false);
+  it('matches identical ids and rejects different ones', () => {
+    expect(cursorMatchesProject('proj-1', 'proj-1')).toBe(true);
+    expect(cursorMatchesProject('proj-1', 'proj-2')).toBe(false);
   });
 });
 
 describe('filterKeysByEventCursor', () => {
-  it('returns all keys when the cursor is undefined (no prior sync for this language)', () => {
+  it('includes all keys when there is no watermark for the language', () => {
     const keys = [makeKey('k1', 10), makeKey('k2', 20)];
     expect(filterKeysByEventCursor(keys, undefined)).toEqual(keys);
   });
 
-  it('returns all keys when the per-language cursor is empty', () => {
-    const keys = [makeKey('k1', 10), makeKey('k2', 20)];
-    expect(filterKeysByEventCursor(keys, {})).toEqual(keys);
-  });
-
-  it('skips keys whose event equals the stored event', () => {
+  it('includes only keys with event greater than the watermark', () => {
     const k1 = makeKey('k1', 10);
     const k2 = makeKey('k2', 20);
-    expect(filterKeysByEventCursor([k1, k2], { k1: 10, k2: 15 })).toEqual([k2]);
+    expect(filterKeysByEventCursor([k1, k2], 15)).toEqual([k2]);
   });
 
-  it('skips keys whose event is less than the stored event', () => {
-    const k1 = makeKey('k1', 5);
-    expect(filterKeysByEventCursor([k1], { k1: 10 })).toEqual([]);
-  });
-
-  it('includes keys whose event is greater than the stored event', () => {
-    const k1 = makeKey('k1', 11);
-    expect(filterKeysByEventCursor([k1], { k1: 10 })).toEqual([k1]);
-  });
-
-  it('includes keys with undefined event (safe mode for server without event support)', () => {
-    const k1 = makeKey('k1');
-    expect(filterKeysByEventCursor([k1], { k1: 999 })).toEqual([k1]);
-  });
-
-  it('includes keys not present in the cursor (first time we see them)', () => {
+  it('excludes a key whose event equals the watermark', () => {
     const k1 = makeKey('k1', 10);
-    const k2 = makeKey('k2', 20);
-    expect(filterKeysByEventCursor([k1, k2], { k1: 10 })).toEqual([k2]);
+    expect(filterKeysByEventCursor([k1], 10)).toEqual([]);
+  });
+
+  it('includes a key with no event (safe mode), even below the watermark', () => {
+    const k1 = makeKey('k1'); // no event
+    expect(filterKeysByEventCursor([k1], 999)).toEqual([k1]);
+  });
+
+  it('works with negative event/watermark values', () => {
+    const older = makeKey('o', -6481606864199203000);
+    const newer = makeKey('n', -6481606696963903000);
+    expect(filterKeysByEventCursor([older, newer], -6481606800000000000)).toEqual([newer]);
   });
 });
 
-describe('recordCursorEntry', () => {
-  it('creates a new per-language bucket if one does not exist', () => {
-    const cursor = createEmptyCursor();
-    recordCursorEntry(cursor, 'en', 'k1', 10);
-    expect(cursor.processed_keys).toEqual({ en: { k1: 10 } });
+describe('advanceWatermark', () => {
+  it('advances to the max succeeded event when nothing failed', () => {
+    expect(advanceWatermark(undefined, [10, 30, 20], [])).toBe(30);
+    expect(advanceWatermark(5, [10, 30, 20], [])).toBe(30);
   });
 
-  it('records into an existing bucket without disturbing other cells', () => {
-    const cursor = { processed_keys: { en: { k1: 5 } } };
-    recordCursorEntry(cursor, 'en', 'k2', 7);
-    expect(cursor.processed_keys).toEqual({ en: { k1: 5, k2: 7 } });
+  it('never moves backwards below the prior watermark', () => {
+    expect(advanceWatermark(100, [10, 20], [])).toBe(100);
   });
 
-  it('keeps the higher event when an entry already exists', () => {
-    const cursor = { processed_keys: { en: { k1: 10 } } };
-    recordCursorEntry(cursor, 'en', 'k1', 5);
-    expect(cursor.processed_keys.en).toEqual({ k1: 10 });
+  it('holds the watermark just below the earliest failed event so failures retry', () => {
+    // succeeded {10, 30}, failed {20}. Only events < 20 are safe → 10.
+    expect(advanceWatermark(undefined, [10, 30], [20])).toBe(10);
   });
 
-  it('upgrades the entry when called with a higher event', () => {
-    const cursor = { processed_keys: { en: { k1: 10 } } };
-    recordCursorEntry(cursor, 'en', 'k1', 20);
-    expect(cursor.processed_keys.en).toEqual({ k1: 20 });
+  it('keeps the prior watermark when every key this run failed', () => {
+    expect(advanceWatermark(40, [], [50, 60])).toBe(40);
   });
 
-  it('is a no-op when event is undefined', () => {
-    const cursor = { processed_keys: { en: { k1: 10 } } };
-    recordCursorEntry(cursor, 'en', 'k1', undefined);
-    expect(cursor.processed_keys.en).toEqual({ k1: 10 });
+  it('returns undefined when there is no prior watermark and nothing is confirmable', () => {
+    // The earliest fetched event failed; nothing below it succeeded.
+    expect(advanceWatermark(undefined, [30], [10, 20])).toBeUndefined();
+  });
+});
+
+describe('buildWatermarkCursor', () => {
+  it('advances per language from the base using successes and failures', () => {
+    const base = { processed_keys: { en: 5, fr: 100 } };
+    const succeeded = new Map<string, number[]>([
+      ['en', [10, 20]],
+      ['de', [7]],
+    ]);
+    const failed = new Map<string, number[]>([['fr', [110]]]);
+    expect(buildWatermarkCursor(base, succeeded, failed)).toEqual({
+      processed_keys: { en: 20, de: 7, fr: 100 },
+    });
   });
 
-  it('does not create a language bucket when event is undefined', () => {
-    const cursor = createEmptyCursor();
-    recordCursorEntry(cursor, 'fr', 'k1', undefined);
-    expect(cursor.processed_keys).toEqual({});
+  it('preserves base languages untouched this run', () => {
+    const base = { processed_keys: { en: 5, es: 9 } };
+    expect(buildWatermarkCursor(base, new Map([['en', [12]]]), new Map())).toEqual({
+      processed_keys: { en: 12, es: 9 },
+    });
+  });
+
+  it('omits a language with no prior watermark whose earliest key failed', () => {
+    const base = { processed_keys: {} };
+    const succeeded = new Map<string, number[]>([['fr', [30]]]);
+    const failed = new Map<string, number[]>([['fr', [10, 20]]]);
+    expect(buildWatermarkCursor(base, succeeded, failed)).toEqual({ processed_keys: {} });
   });
 });
 
 describe('mergeCursor', () => {
-  it('returns identity-equivalent of either cursor when the other is empty', () => {
-    const a = { processed_keys: { en: { k1: 10 } } };
-    const empty = createEmptyCursor();
-    expect(mergeCursor(a, empty)).toEqual(a);
-    expect(mergeCursor(empty, a)).toEqual(a);
+  it('keeps disk languages not touched by the in-memory cursor', () => {
+    const disk = { processed_keys: { en: 10, de: 3 } };
+    const inMemory = { processed_keys: { en: 20 } };
+    expect(mergeCursor(disk, inMemory)).toEqual({ processed_keys: { en: 20, de: 3 } });
   });
 
-  it('combines disjoint languages', () => {
-    const a = { processed_keys: { en: { k1: 10 } } };
-    const b = { processed_keys: { fr: { k2: 20 } } };
-    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 10 }, fr: { k2: 20 } } });
+  it('lets the in-memory value win even when lower than disk (failure-safe)', () => {
+    // A run that hit a failure holds its watermark below disk's pre-failure value; the
+    // merge must not restore the higher disk value.
+    const disk = { processed_keys: { en: 100 } };
+    const inMemory = { processed_keys: { en: 49 } };
+    expect(mergeCursor(disk, inMemory)).toEqual({ processed_keys: { en: 49 } });
   });
 
-  it('combines disjoint keys within the same language', () => {
-    const a = { processed_keys: { en: { k1: 10 } } };
-    const b = { processed_keys: { en: { k2: 20 } } };
-    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 10, k2: 20 } } });
-  });
-
-  it('takes max for overlapping cells', () => {
-    const a = { processed_keys: { en: { k1: 10, k2: 30 } } };
-    const b = { processed_keys: { en: { k1: 20, k2: 25 } } };
-    expect(mergeCursor(a, b)).toEqual({ processed_keys: { en: { k1: 20, k2: 30 } } });
-  });
-
-  it('does not mutate the inputs', () => {
-    const a = { processed_keys: { en: { k1: 10 } } };
-    const b = { processed_keys: { en: { k1: 20 } } };
-    mergeCursor(a, b);
-    expect(a).toEqual({ processed_keys: { en: { k1: 10 } } });
-    expect(b).toEqual({ processed_keys: { en: { k1: 20 } } });
+  it('does not mutate its inputs', () => {
+    const disk = { processed_keys: { en: 10 } };
+    const inMemory = { processed_keys: { en: 20 } };
+    mergeCursor(disk, inMemory);
+    expect(disk).toEqual({ processed_keys: { en: 10 } });
+    expect(inMemory).toEqual({ processed_keys: { en: 20 } });
   });
 });
 
 describe('countCursorEntries', () => {
-  it('returns 0 for empty cursor', () => {
+  it('returns 0 for an empty cursor', () => {
     expect(countCursorEntries(createEmptyCursor())).toBe(0);
   });
 
-  it('sums per-language map sizes', () => {
-    const cursor = { processed_keys: { en: { k1: 1, k2: 2 }, fr: { k3: 3 } } };
-    expect(countCursorEntries(cursor)).toBe(3);
+  it('counts the number of languages with a watermark', () => {
+    expect(countCursorEntries({ processed_keys: { en: 1, fr: 2, de: 3 } })).toBe(3);
   });
 });

--- a/packages/common/src/utilities/sync-cursor.ts
+++ b/packages/common/src/utilities/sync-cursor.ts
@@ -2,12 +2,19 @@ import { Key } from '@localazy/api-client';
 import { SyncCursor } from '../models/collections-data/sync-state';
 
 /**
- * Pure helpers around the download-sync cursor. The cursor is a per-(language, key id)
- * map storing the last `event` number we successfully wrote for that cell. Everything
- * here is intentionally side-effect-free and synchronous — the orchestration (loading
- * the singleton, persisting back) lives in the call site so this stays testable.
+ * Helpers around the download-sync cursor. The cursor is a per-language high-water mark:
+ * `{ [lang]: maxEvent }`, where `maxEvent` is the largest Localazy modification `event`
+ * we've confirmed-imported for that language. On the next sync we fetch only keys whose
+ * `event` is greater than the watermark.
  *
- * The shape mirrors the Strapi-plugin implementation: `{ [lang]: { [keyId]: event } }`.
+ * This mirrors Localazy's own incremental-sync contract (`listKeysSinceEvent` /
+ * `sinceEvent` / `maxEvent`): a single scalar per request, not a per-key map. The previous
+ * per-`(lang, keyId)` representation grew unbounded (one entry per translated key × every
+ * language) and overflowed the `processed_keys` TEXT column on large projects — the column
+ * stays `text`, but the watermark keeps its contents to a handful of numbers.
+ *
+ * Everything here is pure and synchronous; orchestration (loading the singleton, persisting
+ * back) lives at the call site.
  */
 
 export function createEmptyCursor(): SyncCursor {
@@ -15,27 +22,27 @@ export function createEmptyCursor(): SyncCursor {
 }
 
 /**
- * Parse a JSON-serialized `processed_keys` blob (the on-disk format used by the
- * `localazy_sync_state` singleton). Returns an empty cursor for any malformed input —
- * the cursor is best-effort cache, not authoritative state, so we never throw and
- * never let a corrupt row block sync. The worst case of an empty parse is "re-download
- * everything once", which is the desired fallback.
+ * Parse the JSON-encoded watermark map stored in `localazy_sync_state.processed_keys`.
+ * Returns an empty cursor for any malformed input — the cursor is best-effort cache, not
+ * authoritative state, so we never throw and never let a corrupt row block sync.
+ *
+ * Forward-migration: older installs stored a per-key map (`{ [lang]: { [keyId]: event } }`).
+ * Such a language's value is an object, not a number, so it's dropped here — that language
+ * simply re-syncs in full once, after which the compact watermark is written back. The
+ * worst case is "re-download that language's keys once", which is the safe fallback.
  */
 export function parseCursor(raw: string | null | undefined): SyncCursor {
   if (!raw) return createEmptyCursor();
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') return createEmptyCursor();
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return createEmptyCursor();
     const processed: SyncCursor['processed_keys'] = {};
-    for (const [lang, perLang] of Object.entries(parsed as Record<string, unknown>)) {
-      if (!perLang || typeof perLang !== 'object') continue;
-      const cleaned: Record<string, number> = {};
-      for (const [keyId, event] of Object.entries(perLang as Record<string, unknown>)) {
-        if (typeof event === 'number' && Number.isFinite(event)) {
-          cleaned[keyId] = event;
-        }
+    for (const [lang, value] of Object.entries(parsed as Record<string, unknown>)) {
+      // Only a finite number is a valid watermark. Legacy per-key objects (or any other
+      // shape) are skipped, forcing a clean re-sync for that language.
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        processed[lang] = value;
       }
-      processed[lang] = cleaned;
     }
     return { processed_keys: processed };
   } catch {
@@ -49,9 +56,8 @@ export function serializeCursor(cursor: SyncCursor): string {
 
 /**
  * Returns true iff the cursor was last written against the same Localazy project we're
- * about to sync. Used at sync start to decide whether to treat the on-disk cursor as
- * authoritative or wipe it in memory. Empty `storedProjectId` is treated as "no recorded
- * project" — i.e. first sync — so the cursor is acceptable.
+ * about to sync. Empty `storedProjectId` is treated as "no recorded project" (first sync),
+ * so the cursor is acceptable.
  */
 export function cursorMatchesProject(storedProjectId: string, currentProjectId: string): boolean {
   if (!storedProjectId) return true;
@@ -59,79 +65,88 @@ export function cursorMatchesProject(storedProjectId: string, currentProjectId: 
 }
 
 /**
- * Filter keys for a single language down to those that need (re-)downloading according
- * to the cursor.
+ * Filter keys for a single language down to those that need (re-)downloading according to
+ * the per-language watermark.
  *
- * Rule (must match the Strapi plugin exactly):
- *   - If we have no cursor entry for `(lang, key.id)` → include.
- *   - If the server didn't return an `event` for the key → include (safe mode).
- *   - Otherwise include iff `key.event > storedEvent`.
+ * Rule:
+ *   - No watermark for the language (`undefined`) → include everything (first sync).
+ *   - Key has no `event` (server omitted it) → include (safe mode).
+ *   - Otherwise include iff `key.event > watermark`.
  *
- * The "include on undefined" rules protect us against either side of the sync getting
- * confused: if Localazy ever rolls out a backend that doesn't echo `event`, we degrade to
- * "always download" rather than "always skip".
+ * The "include on undefined" rules degrade to "always download" rather than "always skip"
+ * if either side ever stops echoing `event`.
  */
-export function filterKeysByEventCursor(keys: Key[], perLanguageCursor: Record<string, number> | undefined): Key[] {
-  if (!perLanguageCursor) return keys;
+export function filterKeysByEventCursor(keys: Key[], watermark: number | undefined): Key[] {
+  if (watermark === undefined) return keys;
   return keys.filter((k) => {
-    const stored = perLanguageCursor[k.id];
-    if (stored === undefined) return true;
     if (k.event === undefined) return true;
-    return k.event > stored;
+    return k.event > watermark;
   });
 }
 
 /**
- * Record one successfully-applied `(lang, keyId, event)` triple in the in-memory cursor.
- * Mutates `cursor` for performance — sync writes happen in a hot loop. If the cell
- * already holds a higher event (rare, but possible if a concurrent sync raced ahead),
- * keep the higher value.
+ * Failure-safe watermark advance for one language. Returns the largest event `E` such that
+ * every key with `event <= E` has been successfully imported — in a prior run (`prev`) or
+ * among this run's `succeededEvents` — while never reaching or passing the earliest
+ * `failedEvents`. Keeping the watermark below the first failure guarantees failed keys (and
+ * the few succeeded keys after them) are re-fetched next run, preserving exact retry without
+ * a per-key map.
+ *
+ * Returns `undefined` only when there was no prior watermark and nothing could be confirmed
+ * below the first failure — the caller then leaves that language uncursored (full re-sync).
  */
-export function recordCursorEntry(cursor: SyncCursor, lang: string, keyId: string, event: number | undefined): void {
-  if (event === undefined) return;
-  const bucket = cursor.processed_keys[lang] || (cursor.processed_keys[lang] = {});
-  const existing = bucket[keyId];
-  bucket[keyId] = existing === undefined ? event : Math.max(existing, event);
-}
-
-/**
- * Merge two cursors cell-by-cell, taking `max(event)` per `(lang, keyId)`. Used when
- * persisting the in-memory cursor: we re-read the on-disk cursor, merge so we don't
- * clobber concurrent writers, and write the result back. Pure — neither input is
- * mutated, the result is a fresh object.
- */
-export function mergeCursor(a: SyncCursor, b: SyncCursor): SyncCursor {
-  const result: SyncCursor['processed_keys'] = {};
-  const allLangs = new Set([...Object.keys(a.processed_keys), ...Object.keys(b.processed_keys)]);
-  for (const lang of allLangs) {
-    const left = a.processed_keys[lang] || {};
-    const right = b.processed_keys[lang] || {};
-    const allKeys = new Set([...Object.keys(left), ...Object.keys(right)]);
-    const merged: Record<string, number> = {};
-    for (const keyId of allKeys) {
-      const lv = left[keyId];
-      const rv = right[keyId];
-      if (lv === undefined) {
-        merged[keyId] = rv!;
-      } else if (rv === undefined) {
-        merged[keyId] = lv;
-      } else {
-        merged[keyId] = Math.max(lv, rv);
-      }
-    }
-    result[lang] = merged;
+export function advanceWatermark(prev: number | undefined, succeededEvents: number[], failedEvents: number[]): number | undefined {
+  let minFailed = Number.POSITIVE_INFINITY;
+  for (const e of failedEvents) {
+    if (e < minFailed) minFailed = e;
   }
-  return { processed_keys: result };
+  let result = prev;
+  for (const e of succeededEvents) {
+    if (e < minFailed && (result === undefined || e > result)) {
+      result = e;
+    }
+  }
+  return result;
 }
 
 /**
- * Count the total cells in a cursor (sum of per-language map sizes). Useful for
- * debugging / progress reporting, not for correctness.
+ * Build the new cursor from the base (loaded) watermark plus this run's per-language
+ * success/failure events. A language where nothing could be confirmed and that had no prior
+ * watermark is omitted entirely, so it re-syncs in full next time rather than silently
+ * advancing past unconfirmed keys.
+ */
+export function buildWatermarkCursor(
+  base: SyncCursor,
+  succeededByLang: Map<string, number[]>,
+  failedByLang: Map<string, number[]>,
+): SyncCursor {
+  const processed: SyncCursor['processed_keys'] = {};
+  const langs = new Set<string>([...Object.keys(base.processed_keys), ...succeededByLang.keys(), ...failedByLang.keys()]);
+  for (const lang of langs) {
+    const w = advanceWatermark(base.processed_keys[lang], succeededByLang.get(lang) ?? [], failedByLang.get(lang) ?? []);
+    if (w !== undefined) processed[lang] = w;
+  }
+  return { processed_keys: processed };
+}
+
+/**
+ * Per-language right-biased merge used by the persist adapters. The just-computed cursor
+ * (`inMemory`) wins; languages present only on disk (not touched this run) are preserved.
+ *
+ * We deliberately do NOT take `max(event)`: a run that hit a failure intentionally holds its
+ * watermark below the failing event, and a higher pre-failure value still on disk must not
+ * override it (that would skip the failed key forever). The advisory sync lock serialises
+ * runs, so `disk` is what the orchestrator loaded as its base and `inMemory` already folded
+ * it in via `advanceWatermark`. Pure — neither input is mutated.
+ */
+export function mergeCursor(disk: SyncCursor, inMemory: SyncCursor): SyncCursor {
+  return { processed_keys: { ...disk.processed_keys, ...inMemory.processed_keys } };
+}
+
+/**
+ * Number of languages carrying a watermark. Debug / inspection only — not used for
+ * correctness.
  */
 export function countCursorEntries(cursor: SyncCursor): number {
-  let total = 0;
-  for (const perLang of Object.values(cursor.processed_keys)) {
-    total += Object.keys(perLang).length;
-  }
-  return total;
+  return Object.keys(cursor.processed_keys).length;
 }

--- a/packages/module/src/ActivityDetail.vue
+++ b/packages/module/src/ActivityDetail.vue
@@ -8,6 +8,32 @@
       <Navigation />
     </template>
 
+    <template v-if="canTerminate" #actions>
+      <v-button
+        v-tooltip.bottom="'Abort this run and release the sync lock so the next Import can proceed'"
+        kind="warning"
+        :loading="terminating"
+        :disabled="terminating"
+        @click="showTerminateDialog = true"
+      >
+        Terminate session
+      </v-button>
+      <v-dialog v-model="showTerminateDialog" @esc="showTerminateDialog = false">
+        <v-card>
+          <v-card-title>Terminate this sync session?</v-card-title>
+          <v-card-text>
+            This marks the session as aborted, and releases the sync lock if it's stuck so the next Import can proceed. Any work still in
+            flight (server-side or in another browser tab) is abandoned but not undone — partially-imported translations stay in place. Use
+            this when a run is stuck and won't finish on its own.
+          </v-card-text>
+          <v-card-actions>
+            <v-button secondary @click="showTerminateDialog = false">Cancel</v-button>
+            <v-button kind="warning" :disabled="terminating" :loading="terminating" @click="confirmTerminate">Terminate</v-button>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </template>
+
     <div class="panel">
       <div v-if="loading" class="loading">
         <v-progress-circular indeterminate />
@@ -49,10 +75,14 @@ import { computed, onBeforeMount, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import Navigation from './components/Navigation.vue';
 import SessionMetadata from './components/Activity/SessionMetadata.vue';
+import { storeToRefs } from 'pinia';
 import { useLocalazySyncLogStore } from './stores/localazy-sync-log-store';
+import { useLocalazySyncStateStore } from './stores/localazy-sync-state-store';
 import { useLocalazyBoot } from './composables/use-localazy-boot';
 import { useSyncLogEntries } from './composables/use-sync-log-entries';
 import { useSyncLogUserNames } from './composables/use-sync-log-user-names';
+import { useDirectusUserStore, useDirectusNotificationsStore } from './composables/use-directus-stores';
+import { isSyncLockStale } from '@localazy/directus-common';
 import type { SyncLogEntry, SyncLogSession } from '@localazy/directus-common';
 
 const route = useRoute();
@@ -63,6 +93,56 @@ const loading = ref(true);
 
 const { boot } = useLocalazyBoot();
 const syncLogStore = useLocalazySyncLogStore();
+const syncStateStore = useLocalazySyncStateStore();
+const { data: syncStateData } = storeToRefs(syncStateStore);
+const notificationsStore = useDirectusNotificationsStore();
+const directusUserStore = useDirectusUserStore();
+
+const showTerminateDialog = ref(false);
+const terminating = ref(false);
+
+// Only an unfinished run can be terminated. A session that already reached a terminal
+// status (completed / failed / aborted / …) has nothing to abort and holds no lock.
+const canTerminate = computed(() => session.value?.status === 'in_progress');
+
+/**
+ * Mark the session aborted, then release the advisory sync lock — but only if it's held
+ * and the orchestrator would already consider it stale (dead worker / past the 2 h
+ * ceiling). The lock isn't id-linked to a log row, so a held-but-live lock may belong to a
+ * different, healthy run; clearing that would abort real in-flight work. Gating on
+ * staleness means terminating an old stuck session never disturbs a concurrent live run,
+ * while a genuinely-stuck lock (the case that motivated this button) still gets cleared so
+ * the AdvancedSettings "stuck" banner clears and the row is left clean.
+ *
+ * We reload the sync-state singleton first: this page doesn't otherwise read it, so its
+ * cached `data` would still hold the pre-fetch defaults and misreport the lock as free.
+ */
+async function confirmTerminate() {
+  if (!session.value) return;
+  terminating.value = true;
+  try {
+    await syncLogStore.terminate(session.value, directusUserStore.currentUser?.id ?? null);
+    await syncStateStore.reload();
+    const lock = syncStateData.value;
+    if (lock.sync_in_progress && isSyncLockStale(lock, Date.now())) {
+      await syncStateStore.save({
+        sync_in_progress: false,
+        sync_started_at: null,
+        sync_initiator: '',
+        sync_pending: false,
+        sync_items_processed: 0,
+        sync_last_heartbeat_at: null,
+        acquired_token: '',
+      });
+    }
+    // Re-fetch so the metadata block reflects the aborted status + the new log entry.
+    session.value = await syncLogStore.getById(sessionId.value);
+    notificationsStore.add({ title: 'Session terminated', type: 'success' });
+    showTerminateDialog.value = false;
+  } finally {
+    terminating.value = false;
+  }
+}
 
 const breadcrumb = computed(() => [
   { name: 'Localazy', to: '/localazy' },

--- a/packages/module/src/AdvancedSettings.vue
+++ b/packages/module/src/AdvancedSettings.vue
@@ -6,7 +6,7 @@
 
     <template #actions>
       <v-button
-        v-tooltip="!mappingsValid ? 'Fix invalid custom language mappings before saving' : null"
+        v-tooltip.bottom="!mappingsValid ? 'Fix invalid custom language mappings before saving' : null"
         class="panel-button"
         :disabled="!changesExist || !mappingsValid"
         :loading="hydrating || saving"

--- a/packages/module/src/components/ErrorsNotice.vue
+++ b/packages/module/src/components/ErrorsNotice.vue
@@ -12,11 +12,42 @@
     </v-notice>
     <v-notice v-if="hasDirectusErrors" type="danger">
       <div class="messages">
-        <div v-for="(directusError, index) in directusErrors" :key="index" class="message">
-          <div>
-            {{ directusError }}
+        <div v-for="(directusError, index) in directusErrors" :key="index" class="error-row">
+          <div class="error-header">
+            <button type="button" class="error-summary" :aria-expanded="isExpanded(index)" @click="toggleExpanded(index)">
+              <v-icon :name="isExpanded(index) ? 'expand_more' : 'chevron_right'" small class="expand-icon" />
+              <span class="message-text" :title="directusError.message">{{ directusError.message }}</span>
+              <span v-if="directusError.count > 1" class="message-count">×{{ directusError.count }}</span>
+            </button>
+            <v-icon name="clear" clickable class="clear-icon" @click="clearDirectusError(index)" />
           </div>
-          <v-icon name="clear" clickable @click="clearDirectusError(index)" />
+
+          <div v-if="isExpanded(index)" class="error-detail">
+            <p class="detail-hint">Records the import could not write. Open one to fix the value (e.g. shorten it or widen the field).</p>
+            <ul v-if="directusError.occurrences.length > 0" class="occurrence-list">
+              <li v-for="(occ, oIndex) in directusError.occurrences" :key="oIndex" class="occurrence">
+                <span class="occurrence-where">
+                  <code>{{ occ.collection }}</code> · <code>{{ occ.itemId }}</code>
+                  <span v-if="occ.languages.length" class="occurrence-langs">({{ occ.languages.join(', ') }})</span>
+                </span>
+                <router-link class="occurrence-link" :to="`/content/${occ.collection}/${occ.itemId}`">
+                  <v-icon name="open_in_new" x-small /> Open in Directus
+                </router-link>
+              </li>
+            </ul>
+            <p v-else class="detail-empty">No record-level details captured for this error.</p>
+
+            <div class="detail-footer">
+              <a v-if="localazyProjectUrl" class="localazy-link" :href="localazyProjectUrl" target="_blank" rel="noopener noreferrer">
+                <v-icon name="open_in_new" x-small /> Open project in Localazy
+              </a>
+              <span v-if="directusError.count > directusError.occurrences.length" class="detail-note">
+                Showing {{ directusError.occurrences.length }} of {{ directusError.count }} occurrence{{
+                  directusError.count === 1 ? '' : 's'
+                }}.
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </v-notice>
@@ -25,7 +56,7 @@
 
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia';
-import { computed, PropType } from 'vue';
+import { computed, PropType, ref } from 'vue';
 import { useErrorsStore } from '../stores/errors-store';
 import { useLocalazyStore } from '../stores/localazy-store';
 import { LocalazyData } from '@localazy/directus-common';
@@ -39,6 +70,19 @@ const props = defineProps({
 
 const { localazyErrors, directusErrors, hasLocalazyErrors, hasDirectusErrors } = storeToRefs(useErrorsStore());
 const { clearDirectusError } = useErrorsStore();
+
+// Which grouped Directus errors are expanded to show their per-record occurrences. Keyed by
+// list index — transient page state, fine to reset on navigation.
+const expandedDirectus = ref<Set<number>>(new Set());
+const isExpanded = (index: number) => expandedDirectus.value.has(index);
+function toggleExpanded(index: number) {
+  const next = new Set(expandedDirectus.value);
+  if (next.has(index)) next.delete(index);
+  else next.add(index);
+  expandedDirectus.value = next;
+}
+
+const localazyProjectUrl = computed(() => props.localazyData?.project_url || null);
 const { hydrateLocalazyData } = useLocalazyStore();
 const { hydrating } = storeToRefs(useLocalazyStore());
 
@@ -112,10 +156,128 @@ async function onReconnect() {
   gap: 8px;
 }
 
-.message {
+.error-row {
+  width: 100%;
+}
+
+.error-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 8px;
   width: 100%;
+}
+
+/* The summary is a button so the whole preview row toggles the detail (keyboard-accessible),
+   but it must look like inline text, not a form control. */
+.error-summary {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.expand-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* Directus value errors can embed a multi-KB JSON blob. The store masks the worst of it,
+   but clamp here too so a single long message can't blow out the notice height — the full
+   text stays available via the element's `title` tooltip and the expandable detail. */
+.message-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+  min-width: 0;
+}
+
+.message-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+
+.clear-icon {
+  flex-shrink: 0;
+}
+
+.error-detail {
+  margin: 6px 0 4px 22px;
+  padding: 10px 12px;
+  border-radius: var(--theme--border-radius);
+  background: var(--theme--background-subdued, rgba(0, 0, 0, 0.1));
+  font-size: 13px;
+}
+
+.detail-hint {
+  margin: 0 0 8px 0;
+  opacity: 0.85;
+}
+
+.occurrence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.occurrence {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.occurrence-where code {
+  font-family: var(--theme--fonts--monospace--font-family, monospace);
+}
+
+.occurrence-langs {
+  opacity: 0.75;
+  margin-left: 4px;
+}
+
+.occurrence-link,
+.localazy-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  text-decoration: underline;
+  color: inherit;
+}
+
+.detail-empty {
+  margin: 0;
+  opacity: 0.85;
+}
+
+.detail-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--theme--border-color-subdued, rgba(0, 0, 0, 0.1));
+}
+
+.detail-note {
+  opacity: 0.75;
 }
 </style>

--- a/packages/module/src/components/Sync/SyncActionButtons.vue
+++ b/packages/module/src/components/Sync/SyncActionButtons.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="sync-group">
         <v-button
-          v-tooltip="syncInProgress ? 'Localazy is syncing — try again in a moment' : null"
+          v-tooltip.bottom="syncInProgress ? 'Localazy is syncing — try again in a moment' : null"
           :disabled="disableDownloadButtons"
           secondary
           @click="$emit('download')"

--- a/packages/module/src/composables/use-sync-container-actions.ts
+++ b/packages/module/src/composables/use-sync-container-actions.ts
@@ -11,6 +11,7 @@ import { useLocalazyConfigStore } from '../stores/localazy-config-store';
 import { useLocalazyTransferSetupStore } from '../stores/localazy-transfer-setup-store';
 import { useLocalazySyncLogStore } from '../stores/localazy-sync-log-store';
 import { useProgressTrackerStore } from '../stores/progress-tracker-store';
+import { useErrorsStore } from '../stores/errors-store';
 import { useDirectusLanguages } from './use-directus-languages';
 import { useCollectionsOrganizer } from './use-collections-organizer';
 import { useTranslatableCollections } from './use-translatable-collections';
@@ -47,6 +48,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
   const directusUserId = computed(() => userStore.currentUser?.id ?? '');
 
   const { addProgressMessage, resetProgressTracker } = useProgressTrackerStore();
+  const { resetDirectusErrors } = useErrorsStore();
   const localazyStore = useLocalazyStore();
   const { localazyUser, localazyProject } = storeToRefs(localazyStore);
 
@@ -111,6 +113,9 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     // ran when the user explicitly closed the modal via the Done button, and any other
     // dismissal path (re-clicking Export, switching pages) left stale messages behind.
     resetProgressTracker();
+    // Same rationale for the Directus error notice — start each run with a clean slate so
+    // counts reflect this run, not an accumulation across every prior attempt.
+    resetDirectusErrors();
 
     // Pre-orchestrator progress lines. The orchestrator's first message is
     // `UPLOAD_CHANGES_SUMMARY` (or `UPLOAD_UP_TO_DATE`), which only lands once the cursor
@@ -171,6 +176,7 @@ export const useSyncContainerActions = (data: UseSyncContainerActions) => {
     // See the matching call in `onExport` — without this the tracker accumulates
     // messages across runs whenever the user dismisses the modal without clicking Done.
     resetProgressTracker();
+    resetDirectusErrors();
 
     // SYNC_MODE_HEADER and RETRIEVING_LANGUAGES go to the modal *before* the orchestrator
     // runs — same order users have always seen. The orchestrator (called once languages

--- a/packages/module/src/services/orchestrator-adapters.ts
+++ b/packages/module/src/services/orchestrator-adapters.ts
@@ -383,7 +383,7 @@ type BuildAdaptersInput = {
 export function buildOrchestratorAdapters(input: BuildAdaptersInput): OrchestratorAdapters {
   const directusApi = new DirectusModuleApi(input.api, input.collectionsStore);
   const { addDirectusError } = useErrorsStore();
-  const onDirectusError: ErrorSink = (e) => addDirectusError(e);
+  const onDirectusError: ErrorSink = (e, context) => addDirectusError(e, context);
 
   return {
     cursorStore: buildCursorStore(),

--- a/packages/module/src/stores/errors-store.test.ts
+++ b/packages/module/src/stores/errors-store.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useErrorsStore, normalizeDirectusMessage } from './errors-store';
+
+// AnalyticsService is only touched by the Localazy-error path; stub it so importing the
+// store doesn't try to reach the network.
+vi.mock('@localazy/directus-common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@localazy/directus-common')>();
+  return { ...actual, AnalyticsService: { trackError: vi.fn().mockResolvedValue(undefined) } };
+});
+
+/** Build a Directus-shaped axios error carrying a single API error message. */
+function directusError(message: string) {
+  return { response: { data: { errors: [{ message }] } } };
+}
+
+const TOO_LONG = (value: string) => `Value "${value}" for field "content" in collection "community_actions_translations" is too long.`;
+
+describe('errors-store — Directus error aggregation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('collapses per-row "value too long" errors that differ only by the (long) value into one counted row', () => {
+    const store = useErrorsStore();
+    const longA = 'A'.repeat(500);
+    const longB = '{"ar":{"_a6481607220144618512":-6481606700118020000}}'.repeat(20);
+
+    store.addDirectusError(directusError(TOO_LONG(longA)));
+    store.addDirectusError(directusError(TOO_LONG(longB)));
+    store.addDirectusError(directusError(TOO_LONG(longA)));
+
+    expect(store.directusErrors).toHaveLength(1);
+    expect(store.directusErrors[0]!.count).toBe(3);
+    // The masked message keeps the actionable parts and drops the blob.
+    expect(store.directusErrors[0]!.message).toContain('field "content"');
+    expect(store.directusErrors[0]!.message).toContain('"…"');
+    expect(store.directusErrors[0]!.message).not.toContain('6481606700118020000');
+  });
+
+  it('keeps short quoted tokens (e.g. language codes) so distinct FK errors stay distinct', () => {
+    const store = useErrorsStore();
+    store.addDirectusError(directusError('Invalid foreign key "ja" for field "languages_code" in collection "x".'));
+    store.addDirectusError(directusError('Invalid foreign key "ja" for field "languages_code" in collection "x".'));
+    store.addDirectusError(directusError('Invalid foreign key "zh-CN" for field "languages_code" in collection "x".'));
+
+    expect(store.directusErrors).toHaveLength(2);
+    expect(store.directusErrors.find((e) => e.message.includes('"ja"'))!.count).toBe(2);
+    expect(store.directusErrors.find((e) => e.message.includes('"zh-CN"'))!.count).toBe(1);
+  });
+
+  it('caps distinct errors at 50 but still counts repeats of already-tracked ones', () => {
+    const store = useErrorsStore();
+    for (let i = 0; i < 60; i += 1) {
+      store.addDirectusError(directusError(`Distinct error number ${i} with a unique tail ${'x'.repeat(50)}-${i}`));
+    }
+    expect(store.directusErrors).toHaveLength(50);
+
+    const before = store.directusErrors[0]!.count;
+    store.addDirectusError(directusError(`Distinct error number 0 with a unique tail ${'x'.repeat(50)}-0`));
+    expect(store.directusErrors[0]!.count).toBe(before + 1);
+  });
+
+  it('records deduped, capped per-record occurrences from the error context', () => {
+    const store = useErrorsStore();
+    const msg = TOO_LONG('x'.repeat(60));
+    store.addDirectusError(directusError(msg), { collection: 'community_actions', itemId: 39, languages: ['es'] });
+    store.addDirectusError(directusError(msg), { collection: 'community_actions', itemId: 39, languages: ['es'] }); // dup → not re-added
+    store.addDirectusError(directusError(msg), { collection: 'community_actions', itemId: 40, languages: ['es', 'de'] });
+    store.addDirectusError(directusError(msg)); // no context → counts but no occurrence
+
+    expect(store.directusErrors).toHaveLength(1);
+    const entry = store.directusErrors[0]!;
+    expect(entry.count).toBe(4);
+    expect(entry.occurrences).toEqual([
+      { collection: 'community_actions', itemId: '39', languages: ['es'] },
+      { collection: 'community_actions', itemId: '40', languages: ['es', 'de'] },
+    ]);
+  });
+
+  it('resetDirectusErrors clears the list', () => {
+    const store = useErrorsStore();
+    store.addDirectusError(directusError('boom'));
+    expect(store.hasDirectusErrors).toBe(true);
+    store.resetDirectusErrors();
+    expect(store.hasDirectusErrors).toBe(false);
+    expect(store.directusErrors).toHaveLength(0);
+  });
+
+  it('normalizeDirectusMessage masks only quoted runs of 40+ chars', () => {
+    expect(normalizeDirectusMessage('keep "ja" short')).toBe('keep "ja" short');
+    expect(normalizeDirectusMessage(`mask "${'y'.repeat(40)}" here`)).toBe('mask "…" here');
+  });
+});

--- a/packages/module/src/stores/errors-store.ts
+++ b/packages/module/src/stores/errors-store.ts
@@ -2,6 +2,26 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { LocalazyError } from '@localazy/directus-common';
 import { AnalyticsService } from '@localazy/directus-common';
+import type { DirectusErrorContext } from '@localazy/directus-common';
+
+/**
+ * One place a grouped Directus error happened: the parent record the failing PATCH targeted
+ * (for a Directus deep-link) plus the languages in that batch. Surfaced in the expandable
+ * detail of an error row so the operator can jump straight to the offending item.
+ */
+export type DirectusErrorOccurrence = { collection: string; itemId: string; languages: string[] };
+
+/**
+ * One distinct Directus error plus a `count` of how many times it (in its value-masked
+ * form) occurred this run, and the individual `occurrences` (capped) for the expandable
+ * detail. Bulk imports fail one row at a time, so without aggregation a single column-length
+ * or FK problem produces hundreds of near-identical rows — each carrying the full offending
+ * value (often a multi-KB JSON blob). See `normalizeDirectusMessage`.
+ */
+export type DirectusErrorEntry = { message: string; count: number; occurrences: DirectusErrorOccurrence[] };
+
+/** Max per-error occurrences retained for the expandable detail — bounds memory + DOM. */
+const MAX_OCCURRENCES_PER_ERROR = 25;
 
 type Errors = {
   localazy: {
@@ -10,7 +30,7 @@ type Errors = {
     import: LocalazyError[];
     export: LocalazyError[];
   };
-  directus: string[];
+  directus: DirectusErrorEntry[];
 };
 
 type CommonParams = {
@@ -19,6 +39,38 @@ type CommonParams = {
 };
 
 type AddLocalazyError = CommonParams & { type: keyof Errors['localazy'] };
+
+/**
+ * Upper bound on distinct Directus error rows kept. A pathological run could otherwise
+ * surface thousands of unique messages; past this cap new distinct errors are dropped
+ * (existing ones still increment their count), keeping the notice bounded.
+ */
+const MAX_DISTINCT_DIRECTUS_ERRORS = 50;
+
+/** Hard cap on a normalized message length — bounds both the dedupe key and the rendered row. */
+const MAX_DIRECTUS_MESSAGE_LENGTH = 240;
+
+/**
+ * Collapse the variable part of a Directus error so otherwise-identical failures group into
+ * one counted row. Directus phrases value errors as `Value "<value>" for field "x" in
+ * collection "y" is too long.` — the `<value>` differs per row (and is often a huge JSON
+ * blob that itself contains quotes), but the actionable part (field, collection, error
+ * kind) is identical.
+ *
+ * Three passes: (1) greedily mask the value in the `Value "…" for field` phrasing — greedy
+ * so it spans values containing their own quotes; (2) mask any remaining quoted run of 40+
+ * chars (other message shapes); (3) hard-cap the length so a single message can't dominate
+ * the dedupe key or blow out the notice. Short quoted tokens (language codes like `"ja"`,
+ * field/collection names) survive — they carry the useful signal.
+ */
+export function normalizeDirectusMessage(message: string): string {
+  let normalized = message.replace(/^(Value )".*"( for field )/s, '$1"…"$2');
+  normalized = normalized.replace(/"[^"]{40,}"/g, '"…"');
+  if (normalized.length > MAX_DIRECTUS_MESSAGE_LENGTH) {
+    normalized = `${normalized.slice(0, MAX_DIRECTUS_MESSAGE_LENGTH)}…`;
+  }
+  return normalized;
+}
 
 export const useErrorsStore = defineStore('errorsStore', () => {
   const errors = ref<Errors>({
@@ -55,16 +107,36 @@ export const useErrorsStore = defineStore('errorsStore', () => {
     message?: string;
   };
 
-  function addDirectusError(error: unknown) {
+  function extractDirectusMessage(error: unknown): string {
     const e = error as DirectusErrorPayload;
     const firstApiError = e.response?.data?.errors?.[0];
-    if (firstApiError?.message) {
-      errors.value.directus.push(firstApiError.message);
-    } else if (e.message) {
-      errors.value.directus.push(e.message);
-    } else {
-      errors.value.directus.push('Unknown error');
+    if (firstApiError?.message) return firstApiError.message;
+    if (e.message) return e.message;
+    return 'Unknown error';
+  }
+
+  /** Append an occurrence to an entry, deduped by collection+itemId and capped. */
+  function recordOccurrence(entry: DirectusErrorEntry, context?: DirectusErrorContext) {
+    if (!context?.collection || context.itemId === undefined || context.itemId === null) return;
+    const itemId = String(context.itemId);
+    const collection = context.collection;
+    if (entry.occurrences.some((o) => o.collection === collection && o.itemId === itemId)) return;
+    if (entry.occurrences.length >= MAX_OCCURRENCES_PER_ERROR) return;
+    entry.occurrences.push({ collection, itemId, languages: context.languages ?? [] });
+  }
+
+  function addDirectusError(error: unknown, context?: DirectusErrorContext) {
+    const message = normalizeDirectusMessage(extractDirectusMessage(error));
+    const existing = errors.value.directus.find((entry) => entry.message === message);
+    if (existing) {
+      existing.count += 1;
+      recordOccurrence(existing, context);
+      return;
     }
+    if (errors.value.directus.length >= MAX_DISTINCT_DIRECTUS_ERRORS) return;
+    const entry: DirectusErrorEntry = { message, count: 1, occurrences: [] };
+    recordOccurrence(entry, context);
+    errors.value.directus.push(entry);
   }
 
   function resetLocalazyErrors() {
@@ -74,6 +146,10 @@ export const useErrorsStore = defineStore('errorsStore', () => {
       import: [],
       export: [],
     };
+  }
+
+  function resetDirectusErrors() {
+    errors.value.directus = [];
   }
 
   function clearDirectusError(index: number) {
@@ -98,6 +174,7 @@ export const useErrorsStore = defineStore('errorsStore', () => {
     addLocalazyError,
     addDirectusError,
     resetLocalazyErrors,
+    resetDirectusErrors,
     clearDirectusError,
   };
 });

--- a/packages/module/src/stores/localazy-sync-log-store.ts
+++ b/packages/module/src/stores/localazy-sync-log-store.ts
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
 import { useLocalazyInstallerStore, LOCALAZY_COLLECTIONS } from './localazy-installer-store';
 import { useErrorsStore } from './errors-store';
+import { createSyncLogWriter, type SyncLogHttpClient } from '../services/sync-log-writer';
 import type { SyncLogSession } from '@localazy/directus-common';
 
 /**
@@ -78,6 +79,35 @@ export const useLocalazySyncLogStore = defineStore('localazySyncLog', () => {
     }
   }
 
+  /**
+   * Force a stuck `in_progress` session into the terminal `aborted` state. Appends a
+   * milestone entry recording the manual termination, then writes the terminal columns
+   * (`status` / `finished_at` / `summary` / `items_processed`) through the same deep
+   * writer the orchestrator uses on a natural finish — so retention trimming and the
+   * row's terminal shape stay identical to an organically-finished run.
+   *
+   * Deliberately does NOT touch the advisory sync lock in `localazy_sync_state`: the lock
+   * isn't id-linked to a log row, so releasing it is the caller's decision (see
+   * `ActivityDetail.vue`, which clears it only when a lock is actually held).
+   */
+  async function terminate(session: SyncLogSession, terminatedByUserId: string | null): Promise<void> {
+    // Same `api`→`SyncLogHttpClient` narrowing the orchestrator adapters use — `useApi()`'s
+    // axios shape is structurally compatible but not assignable without the bridge cast.
+    const writer = createSyncLogWriter({ api: api as unknown as SyncLogHttpClient, collectionName: LOCALAZY_COLLECTIONS.syncLog });
+    await writer.appendEntry(session.id, {
+      timestamp: new Date().toISOString(),
+      level: 'warn',
+      message: 'Session manually terminated by operator.',
+      ...(terminatedByUserId ? { data: { user: terminatedByUserId } } : {}),
+    });
+    await writer.finish(session.id, {
+      status: 'aborted',
+      summary: session.summary || 'Manually terminated by operator.',
+      itemsProcessed: session.items_processed,
+    });
+    await reload();
+  }
+
   // Mirror the singleton stores' pattern: first reload fires once the installer flips
   // `installed` to true. `immediate: true` covers the case where the installer was
   // already done by the time this store is first used.
@@ -89,5 +119,5 @@ export const useLocalazySyncLogStore = defineStore('localazySyncLog', () => {
     { immediate: true },
   );
 
-  return { sessions, loading, error, reload, clearAll, getById };
+  return { sessions, loading, error, reload, clearAll, getById, terminate };
 });

--- a/packages/sync-hook/src/endpoint/orchestrator-adapters.test.ts
+++ b/packages/sync-hook/src/endpoint/orchestrator-adapters.test.ts
@@ -200,7 +200,7 @@ describe('CursorStore adapter', () => {
 
   beforeEach(() => {
     fake = makeFakeItemsService({
-      localazy_sync_state: [{ id: 1, processed_keys: '{"en":{"k1":5}}', cursor_project_id: 'proj-1' }],
+      localazy_sync_state: [{ id: 1, processed_keys: '{"en":5}', cursor_project_id: 'proj-1' }],
     });
     logger = makeLogger();
   });
@@ -217,10 +217,10 @@ describe('CursorStore adapter', () => {
     const result = await adapters.cursorStore.load();
 
     expect(result.projectId).toBe('proj-1');
-    expect(result.cursor.processed_keys.en?.k1).toBe(5);
+    expect(result.cursor.processed_keys.en).toBe(5);
   });
 
-  it('persist() merges with on-disk cursor via max(event) and writes the project id', async () => {
+  it('persist() lets the in-memory watermark win per language, preserving untouched disk languages', async () => {
     const adapters = buildServerOrchestratorAdapters({
       ItemsService: fake.FakeService as ItemsServiceCtor,
       schema: { collections: {}, relations: [] },
@@ -229,13 +229,14 @@ describe('CursorStore adapter', () => {
       localazyProject: project,
     });
 
-    await adapters.cursorStore.persist({ processed_keys: { en: { k2: 7 }, de: { k1: 3 } } });
+    await adapters.cursorStore.persist({ processed_keys: { en: 7, de: 3 } });
 
     const row = fake.tables.get('localazy_sync_state')?.[0];
     const persisted = JSON.parse(row?.processed_keys as string);
-    // Merge: on-disk en.k1=5 preserved, in-memory en.k2=7 added, de.k1=3 added.
-    expect(persisted.en).toEqual({ k1: 5, k2: 7 });
-    expect(persisted.de).toEqual({ k1: 3 });
+    // Right-biased merge: in-memory en=7 overrides disk en=5, de=3 added. (No max() —
+    // a failure-held watermark below disk must not be restored.)
+    expect(persisted.en).toBe(7);
+    expect(persisted.de).toBe(3);
     expect(row?.cursor_project_id).toBe('proj-1');
   });
 


### PR DESCRIPTION
Five grouped commits (see individual commits for detail). All surfaced while testing 2.0.0 against a production-replica Directus.

## Commits

1. **🐛 fix: render action-button tooltips below the page header** — the Import/Save buttons sit in the `#actions` header at the top of the viewport, where the default top-placed `v-tooltip` rendered off-screen. `v-tooltip.bottom`.
2. **🐛 fix: skip Localazy languages missing from Directus on import** — `resolveImportLanguages` imported project languages that don't exist in Directus (the create-missing setting only governed *creation*, not *inclusion*), so the upsert failed with `Invalid foreign key "ja" for field "languages_code"`. Now imports only languages backed by a Directus row (existing + just-created).
3. **✨ feat: terminate a stuck sync session from the Activity detail page** — a zombied run left its session stuck at `in_progress` with no UI escape. Adds a Terminate button that marks the session `aborted` and releases the advisory lock *only when it's stale* (shared `isSyncLockStale`), so it can't disturb a healthy concurrent run.
4. **🐛 fix: stop the download cursor overflowing its column** — `processed_keys` stored a per-`(language, key)` map that grew unbounded and overflowed the 64 KB `text` column on large projects, so the cursor never persisted and every import re-fetched everything. Replaced with a per-language `event` high-water mark (Localazy's `sinceEvent`/`maxEvent` model), advanced *failure-safely* so failed keys still retry. Column stays `text`; legacy blobs self-heal on next sync.
5. **✨ feat: aggregate Directus import errors into expandable rows with deep-links** — group identical (value-masked) errors with a count, capped/truncated and reset per run. Each row expands to the records that failed (`collection · itemId (languages)`) with a deep-link to the Directus item and a link to the Localazy project, so it's clear *where* a "valid" error like "value is too long" occurs.

## Verification

Built and run live against a prod-replica Directus (MySQL + the local extension `dist`):
- Import no longer FK-fails on `ja` (6 → 4 target languages).
- Terminate flips a stuck session to **Aborted** and clears a stale lock.
- Full sync: the `processed_keys too long` error is gone; the persisted cursor went **54,979 B → 79 B** and a follow-up incremental dropped 2,728 → 2,343 changes (cursor now actually filters).
- Error notice collapses hundreds of failures into one `×N` row; expanding it and clicking **Open in Directus** lands on the offending item editor.

`pnpm check` green (lint, format, typecheck, 631 tests across the three packages). No schema migration — the cursor column stays `text`.