### PR TITLE
✨ feat: support Directus 12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ A monorepo of two published Directus extensions plus one internal shared package
 
 ## Stack
 
+- **Directus 12** target. Both extensions declare `host: ^11.0.0 || ^12.0.0` and build against `@directus/extensions-sdk@^18` + `@directus/types@^16`; local dev runs `directus@^12` (root devDependency). These were on the v11 line (`sdk@^17` / `types@^15`) before the v12 upgrade — keep the `extensions-sdk` and `types` versions in lockstep across `module`, `sync-hook`, and `common`, matched to the host major. A local dev DB bootstrapped on an older major needs `directus database migrate:latest` before `pnpm dev` will boot.
 - **Node 22** (`.nvmrc`).
 - **pnpm workspaces** (`pnpm-workspace.yaml`), pnpm `11.4.0` pinned via root `packageManager`. Strict isolation (no `shamefullyHoist`). `autoInstallPeers: true`. CVE overrides and a `vue` + `axios` version pin live in `pnpm-workspace.yaml`.
 - **ESLint 10** flat config (`eslint.config.js`) + `typescript-eslint@8` + `eslint-plugin-vue@10` flat presets + `eslint-config-prettier`. Per-workspace globals: browser for `module/` and `common/`, node for `sync-hook/`.
@@ -98,9 +99,9 @@ The two extensions' `package.json` versions on `main` will lag behind root betwe
 
   A duplicated local `LOCALAZY_COLLECTIONS` block in `endpoint/index.ts` once mislabeled the folder as the data collection and silently hung the webhook handler for every delivery. Don't reintroduce a per-file copy of these names.
 
-## Directus 10 shapes redefined in Directus 11
+## Directus version gotchas (shapes & APIs restructured across majors)
 
-We support Directus 11, so the shapes below are the current truth. They are listed here because the Directus 10 shapes still live in older guides, blog posts, and the SDK's training-data fingerprint — code-completion and AI assistants will happily reach for them. When you touch system-collection fields, verify the relocation first.
+We support Directus 11 and 12, so the shapes below are the current truth. They are listed here because the older shapes still live in guides, blog posts, and the SDK's training-data fingerprint — code-completion and AI assistants will happily reach for them. When you touch system-collection fields or private-view slots, verify the current shape first.
 
 - **`admin_access` and `app_access` moved from `directus_roles` to `directus_policies`.** Directus 11 added a policy layer between users/roles and permissions. There is no `directus_users.admin_access` column. The traversal is:
 
@@ -115,4 +116,6 @@ We support Directus 11, so the shapes below are the current truth. They are list
 
   Reading `directus_users` with `fields: ['admin_access']` makes `ItemsService.readOne()` throw — when the caller's `catch` clause maps that to "user missing" you get the symptom "webhook fails on every delivery because the configured user no longer exists" even though the user is still right there. The webhook gate hit exactly this trap (see `endpoint/index.ts` `lookupWebhookUser`).
 
-Add new entries here when you find another Directus 10 shape that Directus 11 has restructured.
+- **`private-view`'s `#headline` slot renders inline in Directus 12.** In v11 the `#headline` breadcrumb sat on its own line above the title. Directus 12 rewrote `header-bar` and forwards `#headline` into the title's `title:prepend` slot — a gapless flex row — so `<v-breadcrumb>` ends up directly abutting the page title ("LocalazyProject setup"), and `#actions` is now vertically centred (which exposed stale top margins on header buttons). Every module page uses `#headline`; the fix is the shared `styles/mixins/private-view.scss` mixin (`@include private-view-header`), included in each page's **scoped** style so it only targets our own slot content, never core Directus screens. The slot still works and emits no deprecation warning in 12.1.1, but Directus is clearly phasing the old slot system — prefer `title:prepend` / `title-outer:prepend` for new headers.
+
+Add new entries here when you find another shape or API that a newer Directus major has restructured.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.6",
     "better-sqlite3": "^12.0.0",
-    "directus": "^11.17.4",
+    "directus": "^12.1.1",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-vue": "^10.9.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@directus/types": "^15.0.0",
+    "@directus/types": "^16.0.0",
     "@types/lodash": "^4.17.7"
   }
 }

--- a/packages/module/README.md
+++ b/packages/module/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://localazy.com">
-    <img src="./assets/logo.svg" width="285" height="50" alt="Localazy" >
+    <img src="https://raw.githubusercontent.com/localazy/directus-extension-localazy/main/packages/module/assets/logo.svg" width="285" height="50" alt="Localazy" >
   </a>
 </p>
 <p align="center">
@@ -14,7 +14,7 @@
 
 > Turn translation of your Directus project into a seamless experience.
 
-![](./assets/banner.png)
+![Directus Extension Localazy](https://raw.githubusercontent.com/localazy/directus-extension-localazy/main/packages/module/assets/banner.png)
 
 ## 🌐 About
 
@@ -22,15 +22,15 @@ The Directus localization extension by Localazy allows you to synchronize your c
 
 ## 📄 Prerequisites
 
-- Directus 11+ (see compatibility table below).
+- Directus 11 or 12 (see compatibility table below).
 - [Your project is set up for translations](https://docs.directus.io/guides/headless-cms/content-translations.html)
 
 ## 🧭 Compatibility
 
-| Extension version | Directus   | Notes                                                                                                      |
-| ----------------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| `2.x`             | `^11.0.0`  | Current.                                                                                                   |
-| `1.x`             | `^10.10.0` | Frozen. Pin with `npm install @localazy/directus-extension-localazy@^1` if you can't upgrade Directus yet. |
+| Extension version | Directus               | Notes                                                                                                      |
+| ----------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `2.x`             | `^11.0.0 \|\| ^12.0.0` | Current. Supports Directus 11 and 12.                                                                      |
+| `1.x`             | `^10.10.0`             | Frozen. Pin with `npm install @localazy/directus-extension-localazy@^1` if you can't upgrade Directus yet. |
 
 ## 🔧 Install
 
@@ -58,7 +58,7 @@ npm install @localazy/directus-extension-localazy
 
 ## Automatically Upload Content
 
-To automatically synchronize your content from Directus to Localazy, see [Directus Extension Localazy Automation](https://github.com/localazy/directus-extension-localazy/blob/main/extensions/sync-hook)
+To automatically synchronize your content from Directus to Localazy, see [Directus Extension Localazy Automation](https://github.com/localazy/directus-extension-localazy/blob/main/packages/sync-hook)
 
 ## 🛟 Support
 

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "path": "dist/index.js",
     "source": "src/index.ts",
-    "host": "^11.0.0"
+    "host": "^11.0.0 || ^12.0.0"
   },
   "scripts": {
     "build": "directus-extension build",
@@ -52,8 +52,8 @@
     "pinia": "^2.3.1"
   },
   "devDependencies": {
-    "@directus/extensions-sdk": "^17.1.4",
-    "@directus/types": "^15.0.0",
+    "@directus/extensions-sdk": "^18.0.1",
+    "@directus/types": "^16.0.0",
     "@localazy/directus-common": "workspace:*",
     "@types/lodash": "^4.14.195",
     "sass": "^1.63.6",

--- a/packages/module/src/About.vue
+++ b/packages/module/src/About.vue
@@ -67,7 +67,7 @@
       </p>
       <p>
         Learn more in the
-        <a href="https://github.com/localazy/directus-extension-localazy/blob/main/extensions/sync-hook/README.md" target="_blank"
+        <a href="https://github.com/localazy/directus-extension-localazy/blob/main/packages/sync-hook/README.md" target="_blank"
           >automation bundle README</a
         >.
       </p>
@@ -120,6 +120,9 @@ import Navigation from './components/Navigation.vue';
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
 
 .page {
   @include page;

--- a/packages/module/src/Activity.vue
+++ b/packages/module/src/Activity.vue
@@ -275,9 +275,17 @@ onBeforeMount(() => {
 </script>
 
 <style lang="scss" scoped>
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
+
 .panel {
+  /*
+   * Unlike the other pages, Activity's first child (the retention note) has no top
+   * margin of its own, so it would sit flush against the header bar. Keep the panel's
+   * top padding here to give the content the same breathing room as the side padding.
+   */
   padding: var(--content-padding);
-  padding-top: 0;
   padding-bottom: var(--content-padding-bottom);
 }
 

--- a/packages/module/src/ActivityDetail.vue
+++ b/packages/module/src/ActivityDetail.vue
@@ -176,6 +176,10 @@ onBeforeMount(async () => {
 </script>
 
 <style lang="scss" scoped>
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
+
 .panel {
   padding: var(--content-padding);
   padding-top: 0;

--- a/packages/module/src/AdvancedSettings.vue
+++ b/packages/module/src/AdvancedSettings.vue
@@ -189,6 +189,9 @@ async function onSaveChanges() {
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
 
 .page {
   @include page;
@@ -198,10 +201,6 @@ async function onSaveChanges() {
   padding: var(--content-padding);
   padding-top: 0;
   padding-bottom: var(--content-padding-bottom);
-}
-
-.panel-button {
-  margin-top: 20px;
 }
 
 .errors-notice {

--- a/packages/module/src/Automation.vue
+++ b/packages/module/src/Automation.vue
@@ -104,6 +104,9 @@ onBeforeMount(() => {
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
 
 .page {
   @include page;
@@ -113,10 +116,6 @@ onBeforeMount(() => {
   padding: var(--content-padding);
   padding-top: 0;
   padding-bottom: var(--content-padding-bottom);
-}
-
-.panel-button {
-  margin-top: 20px;
 }
 
 .errors-notice {

--- a/packages/module/src/Overview.vue
+++ b/packages/module/src/Overview.vue
@@ -45,6 +45,9 @@ onBeforeMount(() => {
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
 
 .page {
   @include page;
@@ -54,10 +57,6 @@ onBeforeMount(() => {
   padding: var(--content-padding);
   padding-top: 0;
   padding-bottom: var(--content-padding-bottom);
-}
-
-.panel-button {
-  margin-top: 20px;
 }
 
 .errors-notice {

--- a/packages/module/src/ProjectSetup.vue
+++ b/packages/module/src/ProjectSetup.vue
@@ -55,6 +55,9 @@ async function onSaveChanges() {
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
 
 .page {
   @include page;
@@ -64,10 +67,6 @@ async function onSaveChanges() {
   padding: var(--content-padding);
   padding-top: 0;
   padding-bottom: var(--content-padding-bottom);
-}
-
-.panel-button {
-  margin-top: 20px;
 }
 
 .errors-notice {

--- a/packages/module/src/Sync.vue
+++ b/packages/module/src/Sync.vue
@@ -323,6 +323,10 @@ function deselectAll() {
 
 <style lang="scss" scoped>
 @use './styles/mixins/page' as *;
+@use './styles/mixins/private-view' as *;
+
+@include private-view-header;
+
 .page {
   @include page;
 }

--- a/packages/module/src/data/constants.ts
+++ b/packages/module/src/data/constants.ts
@@ -9,9 +9,9 @@
  * GitHub-hosted README for the server-side bundle. The Automation page surfaces this link
  * when the bundle isn't installed in the host Directus instance so the operator has a
  * clear next step. Update this when the README path moves (a bundling refactor could
- * relocate it under `extensions/sync-hook/src/...`).
+ * relocate it under `packages/sync-hook/src/...`).
  */
-export const BUNDLE_README_URL = 'https://github.com/localazy/directus-extension-localazy/blob/main/extensions/sync-hook/README.md';
+export const BUNDLE_README_URL = 'https://github.com/localazy/directus-extension-localazy/blob/main/packages/sync-hook/README.md';
 
 /**
  * Endpoint child name on the server-side bundle. Directus mounts endpoint children under

--- a/packages/module/src/styles/mixins/private-view.scss
+++ b/packages/module/src/styles/mixins/private-view.scss
@@ -1,0 +1,13 @@
+// Directus 12's `header-bar` renders the private-view `#headline` slot inline as the
+// first child of the `.title` flex row — a gapless row — so our "Localazy" breadcrumb
+// ends up directly abutting the page title ("LocalazyProject setup"). Under Directus 11
+// the same slot rendered on its own line above the title, so no gap was needed.
+//
+// This lives in each page's *scoped* <style>, so the selector only matches our own slot
+// content (which carries the page's scope id) and never leaks onto core Directus screens.
+@mixin private-view-header {
+  // Restore the space between the breadcrumb and the page title.
+  .v-breadcrumb {
+    margin-inline-end: 0.5rem;
+  }
+}

--- a/packages/sync-hook/README.md
+++ b/packages/sync-hook/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://localazy.com">
-    <img src="./assets/logo.svg" width="285" height="50" alt="Localazy" >
+    <img src="https://raw.githubusercontent.com/localazy/directus-extension-localazy/main/packages/sync-hook/assets/logo.svg" width="285" height="50" alt="Localazy" >
   </a>
 </p>
 <p align="center">
@@ -34,15 +34,15 @@ If you prefer to install manually (via `npm install`), this flag is **not** requ
 
 ## 📄 Prerequisites
 
-- Installed & enabled [Directus Extension Localazy](https://github.com/localazy/directus-extension-localazy/tree/main/extensions/module).
-- Directus 11+ (see compatibility table below).
+- Installed & enabled [Directus Extension Localazy](https://github.com/localazy/directus-extension-localazy/tree/main/packages/module).
+- Directus 11 or 12 (see compatibility table below).
 
 ## 🧭 Compatibility
 
-| Extension version | Directus   | Notes                                                                                                                 |
-| ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| `2.x`             | `^11.0.0`  | Current.                                                                                                              |
-| `1.x`             | `^10.10.0` | Frozen. Pin with `npm install @localazy/directus-extension-localazy-automation@^1` if you can't upgrade Directus yet. |
+| Extension version | Directus               | Notes                                                                                                                 |
+| ----------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `2.x`             | `^11.0.0 \|\| ^12.0.0` | Current. Supports Directus 11 and 12.                                                                                 |
+| `1.x`             | `^10.10.0`             | Frozen. Pin with `npm install @localazy/directus-extension-localazy-automation@^1` if you can't upgrade Directus yet. |
 
 ## 🔧 Install
 

--- a/packages/sync-hook/package.json
+++ b/packages/sync-hook/package.json
@@ -40,7 +40,7 @@
         "source": "src/endpoint/index.ts"
       }
     ],
-    "host": "^11.0.0"
+    "host": "^11.0.0 || ^12.0.0"
   },
   "scripts": {
     "build": "directus-extension build",
@@ -63,8 +63,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@directus/extensions-sdk": "^17.1.4",
-    "@directus/types": "^15.0.0",
+    "@directus/extensions-sdk": "^18.0.1",
+    "@directus/types": "^16.0.0",
     "@localazy/directus-common": "workspace:*",
     "@types/lodash": "^4.17.1",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^12.0.0
         version: 12.10.0
       directus:
-        specifier: ^11.17.4
-        version: 11.17.4(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
+        specifier: ^12.1.1
+        version: 12.1.1(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
       eslint:
         specifier: ^10.3.0
         version: 10.4.1(jiti@2.7.0)
@@ -64,7 +64,7 @@ importers:
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-eslint-parser:
         specifier: ^10.4.0
         version: 10.4.1(eslint@10.4.1(jiti@2.7.0))
@@ -88,8 +88,8 @@ importers:
         version: 4.18.1
     devDependencies:
       '@directus/types':
-        specifier: ^15.0.0
-        version: 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+        specifier: ^16.0.0
+        version: 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.24
@@ -116,11 +116,11 @@ importers:
         version: 2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3))
     devDependencies:
       '@directus/extensions-sdk':
-        specifier: ^17.1.4
-        version: 17.1.4(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(ws@8.21.0)(yaml@2.9.0)
+        specifier: ^18.0.1
+        version: 18.0.1(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(ws@8.21.0)(yaml@2.9.0)
       '@directus/types':
-        specifier: ^15.0.0
-        version: 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+        specifier: ^16.0.0
+        version: 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
       '@localazy/directus-common':
         specifier: workspace:*
         version: link:../common
@@ -153,11 +153,11 @@ importers:
         version: 4.18.1
     devDependencies:
       '@directus/extensions-sdk':
-        specifier: ^17.1.4
-        version: 17.1.4(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)
+        specifier: ^18.0.1
+        version: 18.0.1(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(ws@8.21.0)(yaml@2.9.0)
       '@directus/types':
-        specifier: ^15.0.0
-        version: 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+        specifier: ^16.0.0
+        version: 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
       '@localazy/directus-common':
         specifier: workspace:*
         version: link:../common
@@ -624,40 +624,43 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@directus/ai@1.3.1':
-    resolution: {integrity: sha512-OuQwQtx6wDQp7rAvF/pIV6jo1svPu3mZ769tJLC/nqO2dMZxfyYcFQ4Gr1ip4SoVfPLbyEpWTMHvgafvVsAmLA==}
+  '@directus/ai@1.3.2':
+    resolution: {integrity: sha512-HUCU24/MGcUP25T1O72IQM21vUqsA4/SjG83CmdpVfz9MJJGfq61qdi0ImLFMNsYSKE10lHhGwlRGsE+NejKUA==}
 
-  '@directus/api@35.2.0':
-    resolution: {integrity: sha512-4hrFny6lcWKISVz27pNzlqKzBo+vMPC0X/nUdZuvlWkYC7+TNNooIqlSO6Bx0FNmqr0XAYcf61MzJKbFsdwjsg==}
+  '@directus/api@37.0.1':
+    resolution: {integrity: sha512-RIdS8tDdy7oEmMf7uGTMlhY432PqAm7/VHDF6EDXe81W+xSQJJAIiHV7zcMulIYRyczPJPyxgKTXbQos6nzrzQ==}
     engines: {node: '>=22'}
 
-  '@directus/app@15.10.0':
-    resolution: {integrity: sha512-mB5jZiwXgdDyV2HOWDXYxNDiT7dK10W/9bgz9vfU3gxPI36LCQJiLtOa904z2ICzNTLMuuAk8veeTrOBkCVrCg==}
+  '@directus/app@16.2.1':
+    resolution: {integrity: sha512-DVBzoDFUxxUVTfUfozqrV2cijkNV57p+KMCenrglCkEYrbhK253qwnberCm0mvZe5oKV/v26djhgTXcPjqNZ1A==}
 
-  '@directus/composables@11.4.1':
-    resolution: {integrity: sha512-FN9YCVXVfvH19+xoSiKoyTH2jZweYjUmaoW6H1pHgS7GhgsLB9W4GxQEDHHCBhdTA4lANCc7FXCwpPNZe+LBkw==}
+  '@directus/composables@11.5.1':
+    resolution: {integrity: sha512-TOwevAEFtqU6DPmh3tmbkQV7tO0LTXkKE0leyzjxpWa8rJ/oL7NxE11MVlG6c1cJAXgsFj+AFVSgrSmyIHisUw==}
     peerDependencies:
       vue: 3.5.24
 
-  '@directus/constants@14.3.0':
-    resolution: {integrity: sha512-mf4CEm0q/pVlfbkvFc2JuCpas4BJS6ldLtYqLUA1uqzBJg1eP7OWxp6DF27kZmNeDUgN1Wbzbt9TI3qTJMd8FA==}
+  '@directus/constants@14.4.0':
+    resolution: {integrity: sha512-5/B6XccEc8ml3UZoKpihitrEk7XY1Rwx0QSoAOuvxBzwbTtBahKhY9OnTTIWt8h47Pc5j2djn85S6W+xhzAOXg==}
 
-  '@directus/env@5.8.0':
-    resolution: {integrity: sha512-WMOG8YgIUwhM7PnlJ68Z8JyvG6PHmZjicXEF6UtY9HuFUA9xWR1HtF5J9D64GTYvNSLBbgrPPgtCAtZHq0mXZA==}
+  '@directus/env@6.1.0':
+    resolution: {integrity: sha512-DLTfygyk+wXsMp1U/O2aa/fhxtfKsEvmIBPtEgNFR5pQeeaqyo1HQ+yGUHzi/nOe1sT1TTH4j9HL1nKA6MgbXA==}
 
   '@directus/errors@2.3.1':
     resolution: {integrity: sha512-lTFCIBRirQa7gH1Nr6EpNiM0cFeIUMfBMrRzGDmgCqe56MnQ6+ZG0f7czY35+5uCKeIsLcrOVVv7NM3XGBQZ9w==}
 
-  '@directus/extensions-registry@3.0.26':
-    resolution: {integrity: sha512-79bRP4RFTtctO0WOCJfP+sPpJHC6JguLYBxYxi99NgJX1Jeps+P4RkhzYWmK0O6H/7MDCqklNfu7sjeJWPH/bQ==}
+  '@directus/errors@2.4.0':
+    resolution: {integrity: sha512-XyRE86Nly8QmZKySfQct2ehhhHTkAADHu3HuZFeMh9C9ICX5Fa3D0b4v/3e3ZosCdTktbP4if+IeAlXcVtJpqA==}
 
-  '@directus/extensions-sdk@17.1.4':
-    resolution: {integrity: sha512-nu2B1eGkmMSCruhg2QpUSD8rTpKVY7lXLomzrOixlNXz3uEM71VOxQ1oNZneGMVPiF3qb6gRgq3A5b2skkD4Pg==}
+  '@directus/extensions-registry@4.0.1':
+    resolution: {integrity: sha512-5c/3rgyeY3L+/HwDcvp2bOyaPMZTSzJqi8HAoILy9TaJkwv1airZxFSwFCjNpJlL0gpBqkqdvxt5R6PBR2kqpw==}
+
+  '@directus/extensions-sdk@18.0.1':
+    resolution: {integrity: sha512-REAvA8mhq7Ok8+QKpmBSEAKTX+KjjzUGQXn8akaWqZoC4FgZHEv+2ZuICmlWoyHBkJmYs5NYs6SMylx70+MtjA==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
-  '@directus/extensions@3.0.25':
-    resolution: {integrity: sha512-52kUPwBRuCPWm/MpFQAicwCAQlGPKpyfWIRt9O/VL/6IbBYqAsnsIQ7keg7oBlzjFgejKT+WTQjjcmUM/5L59A==}
+  '@directus/extensions@4.0.1':
+    resolution: {integrity: sha512-zIeHP7/oz2E90TduWtfdagzCvm+c957V+5XI95k8nReERYKqCyxPvcWMRsYAUBtWmw5hWZAAc1xP60YFykJiWw==}
     peerDependencies:
       knex: 3.1.0
       pino: 9.7.0
@@ -673,54 +676,64 @@ packages:
       vue-router:
         optional: true
 
-  '@directus/format-title@12.1.2':
-    resolution: {integrity: sha512-L7uzayoZNU2SjBu7MaJziub+QyRgDQKV/723fDjASsu2d4N+Z5vN5D2c2aCrP6TsC/v4gTBn2lfy4znm8t2KiQ==}
+  '@directus/format-title@13.0.0':
+    resolution: {integrity: sha512-jQYWlfCgDPZ1xcfS5wQUJd9hMFjFil/Isx7M3sy0fU5/km/DMeX+KxPTR0FgOWm3YY/YOw2omvZD2E2wQf9KHQ==}
 
-  '@directus/memory@3.1.8':
-    resolution: {integrity: sha512-2CdotMFtT7gTnol6kyOFFUlLjL2VLOelClbP61VqpKSYq94pxeF9AjveCdyzlXp1uB67slSVNowo4QB240vRRA==}
+  '@directus/license@0.3.0':
+    resolution: {integrity: sha512-WNbzyDJ2qPWZQ1u/A4K+tOGYCZ43EPRo+Ym7Z09ZpFP8jiEasR1MgpGg5JW+QiQJqHe9uPfQVDP6GFjKER1bvw==}
 
-  '@directus/pressure@3.0.22':
-    resolution: {integrity: sha512-y6dKxzRA1qmgnZNhrGYPgs1bwGKhJMy1KBRIJMz7jyaTNznzQACT15UK0mumwwm6XiR63WUHP3a0VDhYPeMR2w==}
+  '@directus/memory@4.0.1':
+    resolution: {integrity: sha512-nbiSka2yfVxbK7JdtYasQOqvLz4u7y4MmOZGK84oQAJ/MIWA85Ki8ZPOeImu5Jnkg8+175zFpZ4cvPSH6KOBgQ==}
 
-  '@directus/schema@13.0.8':
-    resolution: {integrity: sha512-L6SXT83GlLyoxZF16EIXy0TPW/l/YvGvUuuJHHvpwo3CaL+NXLfXXG9lrnYQD4m7IvZquUbXi3orrrTFon/eJg==}
+  '@directus/pressure@4.0.1':
+    resolution: {integrity: sha512-QTHVXwN2s+n3jFe6nDP8l2n6K/IGQRUmV22g5TB21Swhr2NqtirIKaLhTTaxe6RhkLm2HXSoDWlvEp1co2GjsA==}
 
-  '@directus/specs@13.0.0':
-    resolution: {integrity: sha512-8X6DjflTwKs76jZ4CKiDgZvHoMc9RFK1jUWOy69m4jJeW0mGAgwLBw2rGRdENMMD8HxxaGQxHWJLWeaJ86v/9Q==}
+  '@directus/schema@14.0.0':
+    resolution: {integrity: sha512-b0QiePeIxHeAa9gZxv7rxC+YpiL41SldR18xtasKw3xiHjsAhgLIXudjvg15xF7bBFv136mv5r7mNslaTe/lDA==}
 
-  '@directus/storage-driver-azure@12.0.22':
-    resolution: {integrity: sha512-1t5hcZVBMpvmAhIxrRVopZiXmNG0aH0Ol8ObkH3fnePb48mR4nW6VCSjN0wge5R3HMWDVrLPk/l+W6b1DjVjzQ==}
+  '@directus/sdk@21.3.0':
+    resolution: {integrity: sha512-ozK2OmlaBiCuP5RuL046CaGGqEnlOdl4Rg690qaOgbC0C45XnDZVeBlb+NDLTUqEj88iSX8Cv74G3qh0L2i7Yw==}
+    engines: {node: '>=22'}
 
-  '@directus/storage-driver-cloudinary@12.0.22':
-    resolution: {integrity: sha512-knx8tiET1QCRIWoWaKW/fslia7mdh44rCB59Dg3lBhKqJTyGKAJuuHsGjD93AkblJ/mFMNaS4bg63g/MGexk2A==}
+  '@directus/specs@15.0.0':
+    resolution: {integrity: sha512-7MUj7+544hkKL9Wf9q4w2pGIPaoUpK8JcyQmrhWElwrF0CXLhtYcHAZr75CRWesLJxFWP6HfqSv9q+EBe05Xrw==}
 
-  '@directus/storage-driver-gcs@12.0.22':
-    resolution: {integrity: sha512-3myXTTt7L8NqAMPQ+NYl3EcPQcKVtZiTD8naEUy+BX7azWxDWx/r2D+v/fJQEd13QhfK8bbfvMcci9W5/8/93A==}
+  '@directus/storage-driver-azure@13.0.1':
+    resolution: {integrity: sha512-pqUEmz9xi498+KM0MMvcCIVCo5zPUorkoxDAHaz0Baw0zJ+4TSpHvi59367LvSBA2DmT/YutXXqaC+FDBvloZg==}
 
-  '@directus/storage-driver-local@12.0.4':
-    resolution: {integrity: sha512-hKBY+BB7ODHJPYlpCULnzudTkdlHQzrUUjJQmuP7Id2e8Sz5WYNMXHtvJUrJoQ0uJlYowZyeHvoEYaJQdxB0xg==}
+  '@directus/storage-driver-cloudinary@13.0.1':
+    resolution: {integrity: sha512-N/k6uwXWYtRqIvC3mhw9irmArX6yeRp3p0pwzM5lai07Q2/7w0pVVm3w391SmOqkuYiQTVVWt3JUvBnOvALDmg==}
 
-  '@directus/storage-driver-s3@12.1.8':
-    resolution: {integrity: sha512-AYD8mxN0p1AOuh4+v3L0fgAz/oOW0+ADiShiGwb+Y/A3x6YwCLEIV3ozKaOh8Aow3QXphQIwM9FtLkqU5EEhlw==}
+  '@directus/storage-driver-gcs@13.0.1':
+    resolution: {integrity: sha512-MLXQdrsAllz0zirXrYiJfNc6oJqvETzGEwaK6wSLEY4a+OlWqJQ4dXZzfwnW8QQKn3w2jLHTyU+4ZaS2lh8ZJA==}
 
-  '@directus/storage-driver-supabase@3.0.22':
-    resolution: {integrity: sha512-aIzBxgw9kJNrg8sachYe6KfyJJO80ptwSP4WLjXNScLxeVKkxbW7jmWxnktJkVwXMUhMV0iNKrWoPpwrvcUp/w==}
+  '@directus/storage-driver-local@13.0.0':
+    resolution: {integrity: sha512-JJ+mEnHSUMVjkPhOtqwqd/uMtZqF/5aXS14Ppi7OyHMDkHUQCkOtc39PEKjzn8ruQNvoxGE0iQwe6ZjquRuvXw==}
+
+  '@directus/storage-driver-s3@13.0.1':
+    resolution: {integrity: sha512-DCrFTSlEhIgqcD0aWEZVuQvXNqNArAryj0jBxPrsGQLl/MBvl6w0msY1Va5rin1cdjB04C+BroknwmNSAO/C4Q==}
+
+  '@directus/storage-driver-supabase@4.0.1':
+    resolution: {integrity: sha512-NoDrWZ8HRTMQHfM/494FY7LalRItxFNoehz++8JMr/wOPNjYC4wWzuhpWJ8l5RxSfNhJjfESVS5cgWrjz6QFUg==}
 
   '@directus/storage@12.0.4':
     resolution: {integrity: sha512-dfM1o0PKHIJV81vGRnvzLPl/YlAO+3vTcpY6eGXxYZ094Uiz52BzJCofmAf6LjWt7d8ydEVDxKG0trSaRFAkCw==}
 
-  '@directus/system-data@4.4.0':
-    resolution: {integrity: sha512-4uVp2J1eLokE7NQQwlY3ssEA2/wPZpF/LYeWQ8oaV7GM77dLOvRarRiIzXUjiHvLk8kfjfOkYDlfi+mGZaqxMA==}
+  '@directus/storage@13.0.0':
+    resolution: {integrity: sha512-0o2IMwbANUwZh2K8j9mO8scXOTl0YUc+71pWdkGmX38wLfGXjN96Kuc+KMaUfeTYoZYhwp4GaemBiK4UaCk/Iw==}
 
-  '@directus/themes@1.3.3':
-    resolution: {integrity: sha512-jw44ND/qyq5j9bGrC7/FXRpDw7yCq4p9FSRQyRDpJPe75XP+tmdQRCu2hJ5CvNJxjGUENxoawPuP/itfCl44kQ==}
+  '@directus/system-data@4.5.1':
+    resolution: {integrity: sha512-oSfqU0slAE9+NGEocgqbYiHe5GiZr5MFCmY0Blz6XaxA/PiRz+Lzw6wPxMEAL6/Q//Qdpwp8CT1Xbpu8Ho0QCg==}
+
+  '@directus/themes@2.0.1':
+    resolution: {integrity: sha512-dyKzANLzIdubLiiIumbiMsnVR6gyl1dWrhN18WKWQd5iowgfnlqYnrWMh8NOcFEDEDEVuirXqTP+8BGS2mvndw==}
     peerDependencies:
       '@unhead/vue': 1.11.20
       pinia: 2.3.1
       vue: 3.5.24
 
-  '@directus/types@15.0.3':
-    resolution: {integrity: sha512-0M27sbfEjzX5hh1Y8U5c4jU5FtirQsTfYTZvm2DL0XQ9cxklk0JQGrydmIoSaNjXh5VXOnZXkC/jn7RljQm3rA==}
+  '@directus/types@16.0.0':
+    resolution: {integrity: sha512-qWI/ZgbzpHt1exQw3LpV+eFpYCmAflLRf9yW0CRnQZ03fFFypEp14Ja5ZD3tcvpXeOuXqejGyxTI5OkM1aBnAw==}
     peerDependencies:
       deep-diff: 1.0.2
       express: 4.21.2
@@ -757,25 +770,22 @@ packages:
       ws:
         optional: true
 
-  '@directus/update-check@13.0.5':
-    resolution: {integrity: sha512-K1VooUaXB7wmIR/DMsG51Cv7tcAY9jS+4AlzYuVmHFr9CaGLUSqrb1k9PN4F8leyjcmEqWHwdJW5r9Qkvs16gA==}
+  '@directus/update-check@14.0.0':
+    resolution: {integrity: sha512-wKnInGBMXPy5I6h35HvS14YWazgHWQvIhdJf72uMK2YXUQoBH603MQmaK8+iENqJTPRFHnBnI3c4/sLp3XvA0w==}
 
-  '@directus/utils@13.4.1':
-    resolution: {integrity: sha512-GMaWQjF5ss+96UgiuZv0hrr7ftqmLQDt9G/iddy6NxWX2ZKSSsyHi+9pkrFYJo4wpPHZZS5q0PPPzO9+/ufj1A==}
+  '@directus/utils@13.5.1':
+    resolution: {integrity: sha512-3OEWb+ByoY8mUWReLJXB2ILL4zYL9YBur9ef5s1dlgsNw77mW5MvJy73YfYxSgA1JENe/MI2wonlXeV29XUu5A==}
     peerDependencies:
       vue: 3.5.24
     peerDependenciesMeta:
       vue:
         optional: true
 
-  '@directus/validation@2.0.23':
-    resolution: {integrity: sha512-Axj1a4x+JWONSZNpzhCRYr4/qCZoBLo+ZxfuHigfx4TCqwlxTD7bTtezGqptzg42Ol7dKkW77j874UR9e/uDDw==}
+  '@directus/validation@3.0.1':
+    resolution: {integrity: sha512-b5UuODNFUVY/6u3rSJ/nd6oKXivwspoiP4Poix/2ZiLexyaHGXCfmig4J9N45ivaJ/oO9Nh4pQ4JMAnRcEI7cw==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -783,26 +793,11 @@ packages:
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
-
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
-
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.26.0':
-    resolution: {integrity: sha512-hj0sKNCQOOo2fgyII3clmJXP28VhgDfU5iy3GNHlWO76KG6N7x4D9ezH5lJtQTG+1J6MFDAJXC1qsI+W+LvZoA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -810,17 +805,11 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.26.0':
-    resolution: {integrity: sha512-DDnoJ5eoa13L8zPh87PUlRd/IyFaIKOlRbxiwcSbeumcJ7UZKdtuMCHa1Q27LWQggug6W4m28i4/O2qiQQ5NZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
@@ -828,16 +817,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.26.0':
-    resolution: {integrity: sha512-C0hkDsYNHZkBtPxxDx177JN90/1MiCpvBNjz1f5yWJo1+5+c5zr8apjastpEG+wtPjo9FFtGG7owSsAxyKiHxA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -846,16 +829,10 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.26.0':
-    resolution: {integrity: sha512-bKDkGXGZnj0T70cRpgmv549x38Vr2O3UWLbjT2qmIkdIWcmlg8yebcFWoT9Dku7b5OV3UqPEuNKRzlNhjwUJ9A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.28.0':
@@ -864,17 +841,11 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.26.0':
-    resolution: {integrity: sha512-6Z3naJgOuAIB0RLlJkYc81An3rTlQ/IeRdrU3dOea8h/PvZSgitZV+thNuIccw0MuK1GmIAnAmd5TrMZad8FTQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
+    cpu: [x64]
+    os: [android]
 
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
@@ -882,16 +853,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.26.0':
-    resolution: {integrity: sha512-OPnYj0zpYW0tHusMefyaMvNYQX5pNQuSsHFTHUBNp3vVXupwqpxofcjVsUx11CQhGVkGeXjC3WLjh91hgBG2xw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -900,17 +865,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.26.0':
-    resolution: {integrity: sha512-jix2fa6GQeZhO1sCKNaNMjfj5hbOvoL2F5t+w6gEPxALumkpOV/wq7oUBMHBn2hY2dOm+mEV/K+xfZy3mrsxNQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
+    cpu: [x64]
+    os: [darwin]
 
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
@@ -918,16 +877,10 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.26.0':
-    resolution: {integrity: sha512-tccJaH5xHJD/239LjbVvJwf6T4kSzbk6wPFerF0uwWlkw/u7HL+wnAzAH5GB2irGhYemDgiNTp8wJzhAHQ64oA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -936,17 +889,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.26.0':
-    resolution: {integrity: sha512-IMJYN7FSkLttYyTbsbme0Ra14cBO5z47kpamo16IwggzzATFY2lcZAwkbcNkWiAduKrTgFJP7fW5cBI7FzcuNQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
+    cpu: [x64]
+    os: [freebsd]
 
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
@@ -954,16 +901,10 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.26.0':
-    resolution: {integrity: sha512-JY8NyU31SyRmRpuc5W8PQarAx4TvuYbyxbPIpHAZdr/0g4iBr8KwQBS4kiiamGl2f42BBecHusYCsyxi7Kn8UQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -972,16 +913,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.26.0':
-    resolution: {integrity: sha512-XITaGqGVLgk8WOHw8We9Z1L0lbLFip8LyQzKYFKO4zFo1PFaaSKsbNjvkb7O8kEXytmSGRkYpE8LLVpPJpsSlw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.28.0':
@@ -990,16 +925,10 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.26.0':
-    resolution: {integrity: sha512-MkggfbDIczStUJwq9wU7gQ7kO33d8j9lWuOCDifN9t47+PeI+9m2QVh51EI/zZQ1spZtFMC1nzBJ+qNGCjJnsg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
+    cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -1008,16 +937,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.26.0':
-    resolution: {integrity: sha512-fUYup12HZWAeccNLhQ5HwNBPr4zXCPgUWzEq2Rfw7UwqwfQrFZ0SR/JljaURR8xIh9t+o1lNUFTECUTmaP7yKA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.28.0':
@@ -1026,16 +949,10 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.26.0':
-    resolution: {integrity: sha512-MzRKhM0Ip+//VYwC8tialCiwUQ4G65WfALtJEFyU0GKJzfTYoPBw5XNWf0SLbCUYQbxTKamlVwPmcw4DgZzFxg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
+    cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -1044,16 +961,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.26.0':
-    resolution: {integrity: sha512-QhCc32CwI1I4Jrg1enCv292sm3YJprW8WHHlyxJhae/dVs+KRWkbvz2Nynl5HmZDW/m9ZxrXayHzjzVNvQMGQA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.28.0':
@@ -1062,16 +973,10 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.26.0':
-    resolution: {integrity: sha512-1D6vi6lfI18aNT1aTf2HV+RIlm6fxtlAp8eOJ4mmnbYmZ4boz8zYDar86sIYNh0wmiLJEbW/EocaKAX6Yso2fw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
+    cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
@@ -1080,16 +985,10 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.26.0':
-    resolution: {integrity: sha512-rnDcepj7LjrKFvZkx+WrBv6wECeYACcFjdNPvVPojCPJD8nHpb3pv3AuR9CXgdnjH1O23btICj0rsp0L9wAnHA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.0':
@@ -1098,17 +997,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.26.0':
-    resolution: {integrity: sha512-FSWmgGp0mDNjEXXFcsf12BmVrb+sZBBBlyh3LwB/B9ac3Kkc8x5D2WimYW9N7SUkolui8JzVnVlWh7ZmjCpnxw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
+    cpu: [x64]
+    os: [linux]
 
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
@@ -1116,16 +1009,10 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.26.0':
-    resolution: {integrity: sha512-0QfciUDFryD39QoSPUDshj4uNEjQhp73+3pbSAaxjV2qGOEDsM67P7KbJq7LzHoVl46oqhIhJ1S+skKGR7lMXA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.0':
@@ -1134,17 +1021,11 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.26.0':
-    resolution: {integrity: sha512-vmAK+nHhIZWImwJ3RNw9hX3fU4UGN/OqbSE0imqljNbUQC3GvVJ1jpwYoTfD6mmXmQaxdJY6Hn4jQbLGJKg5Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
+    cpu: [x64]
+    os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
@@ -1152,16 +1033,10 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.26.0':
-    resolution: {integrity: sha512-GPXF7RMkJ7o9bTyUsnyNtrFMqgM3X+uM/LWw4CeHIjqc32fm0Ir6jKDnWHpj8xHFstgWDUYseSABK9KCkHGnpg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -1170,17 +1045,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.26.0':
-    resolution: {integrity: sha512-nUHZ5jEYqbBthbiBksbmHTlbb5eElyVfs/s1iHQ8rLBq1eWsd5maOnDpCocw1OM8kFK747d1Xms8dXJHtduxSw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
+    cpu: [x64]
+    os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
@@ -1188,17 +1057,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.26.0':
-    resolution: {integrity: sha512-TMg3KCTCYYaVO+R6P5mSORhcNDDlemUVnUbb8QkboUtOhb5JWKAzd5uMIMECJQOxHZ/R+N8HHtDF5ylzLfMiLw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
@@ -1206,17 +1069,11 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.26.0':
-    resolution: {integrity: sha512-apqYgoAUd6ZCb9Phcs8zN32q6l0ZQzQBdVXOofa6WvHDlSOhwCWgSfVQabGViThS40Y1NA4SCvQickgZMFZRlA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
@@ -1224,16 +1081,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.26.0':
-    resolution: {integrity: sha512-FGJAcImbJNZzLWu7U6WB0iKHl4RuY4TsXEwxJPl9UZLS47agIZuILZEX3Pagfw7I4J3ddflomt9f0apfaJSbaw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
+    cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
@@ -1242,20 +1093,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.26.0':
-    resolution: {integrity: sha512-WAckBKaVnmFqbEhbymrPK7M086DQMpL1XoRbpmN0iW8k5JSXjDRQBhcZNa0VweItknLq9eAeCL34jK7/CDcw7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.0':
     resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2123,9 +1974,6 @@ packages:
     resolution: {integrity: sha512-3rzy1bJAZ4s7zV9TKT60x119RwJDCDqEtCwK/Zc2qlm7wGhiIUxLLYUhE/mN91yB0u1kxm5sh4NjU12sPqQTpg==}
     engines: {node: '>=6.9.0'}
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
-
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -2404,14 +2252,14 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2427,14 +2275,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2450,14 +2298,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2473,14 +2321,14 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2496,14 +2344,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2521,15 +2369,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2548,15 +2396,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2567,13 +2415,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2581,15 +2422,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
+    cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -2608,15 +2456,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2635,15 +2483,15 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2655,14 +2503,14 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2677,13 +2525,13 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
@@ -2698,14 +2546,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2732,14 +2580,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2753,11 +2601,11 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.45':
     resolution: {integrity: sha512-Le9ulGCrD8ggInzWw/k2J8QcbPz7eGIOWqfJ2L+1R0Opm7n6J37s2hiDWlh6LJN0Lk9L5sUzMvRHKW7UxBZsQA==}
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
-
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -4545,8 +4393,8 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
-  directus@11.17.4:
-    resolution: {integrity: sha512-QfDAzXbgm2pabcaF7jn6GX6OvZBHzw1P1GBfY7D52MT7nFUxtAYZoer/g60U+7xLc8uMEMcbckfrSTZiTgcPqg==}
+  directus@12.1.1:
+    resolution: {integrity: sha512-FMtVEGNMIgvr5VjE4kqG+I1bi2XZHk6PmSUfn10uTRkiaiWDC8WwCEjXxsCr9Q2VvdjiyvvDXozskpE1JPs/Bg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4673,18 +4521,13 @@ packages:
   es-toolkit@1.47.0:
     resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.26.0:
-    resolution: {integrity: sha512-3Hq7jri+tRrVWha+ZeIVhl4qJRha/XjRNSopvTsOaCvfPHrflTYTcUFcEjMKdxofsXXsdc4zjg5NOTnL4Gl57Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5365,6 +5208,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -5713,8 +5560,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  liquidjs@10.25.7:
-    resolution: {integrity: sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==}
+  liquidjs@10.26.0:
+    resolution: {integrity: sha512-Ub9FFNOLB9tdH/gB2MKkeU7x9NifoVidxAam6YWU7LUcy7Glumi6q5C3tDpWOEpeNaT8Cdwdb1axEdlvLSoyaQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -6126,8 +5973,8 @@ packages:
   nodemailer-mailgun-transport@2.1.5:
     resolution: {integrity: sha512-hF7POkaxFgMvYEd5aHLaQJI2511ld+aQlQi7JH6bGjhjlZ33cIbTB9PimlIrLu5XC3z76Kde6e65OIwL9lOdTA==}
 
-  nodemailer@8.0.5:
-    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
   nopt@5.0.0:
@@ -6948,13 +6795,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7007,8 +6854,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  samlify@2.12.0:
-    resolution: {integrity: sha512-ewGsHyY4kInDH0BfprlAZ1rHpH1jBmbqYiXDbuI3t1Y8h71gqEt4Z7jdCFyPHFR8jItJkbdckTijUZGg14CDlg==}
+  samlify@2.13.1:
+    resolution: {integrity: sha512-vdYr/zohDGBbfWNU4miEzc1jmWOtkLySPViapC6nfGkv9KxzLq4UlGkKyryzwLw4jVlZk88Rw93HaCRVpe+t+g==}
 
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
@@ -7488,8 +7335,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.20.6:
-    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -7555,8 +7402,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unhead@1.11.20:
@@ -7631,13 +7478,13 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -7938,6 +7785,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@4.1.1:
+    resolution: {integrity: sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA==}
+
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
@@ -8003,10 +7853,10 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.12.0)':
+  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.13.1)':
     dependencies:
       node-xmllint: 1.0.0
-      samlify: 2.12.0
+      samlify: 2.13.1
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -8040,7 +7890,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.922.0
+      '@aws-sdk/types': 3.973.11
       '@aws-sdk/util-locate-window': 3.965.6
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8048,7 +7898,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.922.0
+      '@aws-sdk/types': 3.973.11
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -8940,41 +8790,42 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@directus/ai@1.3.1': {}
+  '@directus/ai@1.3.2': {}
 
-  '@directus/api@35.2.0(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)':
+  '@directus/api@37.0.1(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.58(zod@4.1.12)
       '@ai-sdk/devtools': 0.0.15
       '@ai-sdk/google': 3.0.43(zod@4.1.12)
       '@ai-sdk/openai': 3.0.41(zod@4.1.12)
       '@ai-sdk/openai-compatible': 2.0.35(zod@4.1.12)
-      '@authenio/samlify-node-xmllint': 2.0.0(samlify@2.12.0)
+      '@authenio/samlify-node-xmllint': 2.0.0(samlify@2.13.1)
       '@aws-sdk/client-sesv2': 3.928.0
       '@braintrust/otel': 0.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))
-      '@directus/ai': 1.3.1
-      '@directus/app': 15.10.0
-      '@directus/constants': 14.3.0
-      '@directus/env': 5.8.0(vue@3.5.24(typescript@5.9.3))
-      '@directus/errors': 2.3.1
-      '@directus/extensions': 3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/extensions-registry': 3.0.26(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/extensions-sdk': 17.1.4(@types/node@22.19.20)(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)
-      '@directus/format-title': 12.1.2
-      '@directus/memory': 3.1.8(vue@3.5.24(typescript@5.9.3))
-      '@directus/pressure': 3.0.22(vue@3.5.24(typescript@5.9.3))
-      '@directus/schema': 13.0.8(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
-      '@directus/specs': 13.0.0
-      '@directus/storage': 12.0.4
-      '@directus/storage-driver-azure': 12.0.22(vue@3.5.24(typescript@5.9.3))
-      '@directus/storage-driver-cloudinary': 12.0.22(vue@3.5.24(typescript@5.9.3))
-      '@directus/storage-driver-gcs': 12.0.22(encoding@0.1.13)(vue@3.5.24(typescript@5.9.3))
-      '@directus/storage-driver-local': 12.0.4
-      '@directus/storage-driver-s3': 12.1.8(vue@3.5.24(typescript@5.9.3))
-      '@directus/storage-driver-supabase': 3.0.22(vue@3.5.24(typescript@5.9.3))
-      '@directus/system-data': 4.4.0
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
-      '@directus/validation': 2.0.23(vue@3.5.24(typescript@5.9.3))
+      '@directus/ai': 1.3.2
+      '@directus/app': 16.2.1
+      '@directus/constants': 14.4.0
+      '@directus/env': 6.1.0(vue@3.5.24(typescript@5.9.3))
+      '@directus/errors': 2.4.0
+      '@directus/extensions': 4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/extensions-registry': 4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/extensions-sdk': 18.0.1(@types/node@22.19.20)(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)
+      '@directus/format-title': 13.0.0
+      '@directus/license': 0.3.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
+      '@directus/memory': 4.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/pressure': 4.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/schema': 14.0.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
+      '@directus/specs': 15.0.0
+      '@directus/storage': 13.0.0
+      '@directus/storage-driver-azure': 13.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage-driver-cloudinary': 13.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage-driver-gcs': 13.0.1(encoding@0.1.13)(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage-driver-local': 13.0.0
+      '@directus/storage-driver-s3': 13.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage-driver-supabase': 4.0.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/system-data': 4.5.1
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/validation': 3.0.1(vue@3.5.24(typescript@5.9.3))
       '@godaddy/terminus': 4.12.1
       '@langfuse/otel': 4.0.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.1.12)
@@ -9004,7 +8855,7 @@ snapshots:
       cron: 4.3.4
       date-fns: 4.1.0
       deep-diff: 1.0.2
-      directus: 11.17.4(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
+      directus: 12.1.1(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
       dotenv: 17.2.3
       encodeurl: 2.0.0
       eventemitter2: 6.4.9
@@ -9031,7 +8882,7 @@ snapshots:
       keyv: 5.5.3
       knex: 3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
       ldapts: 8.1.3
-      liquidjs: 10.25.7
+      liquidjs: 10.26.0
       lodash-es: 4.18.1
       marked: 16.4.1
       micromustache: 8.0.3
@@ -9041,7 +8892,7 @@ snapshots:
       ms: 2.1.3
       nanoid: 5.1.6
       node-machine-id: 1.1.12
-      nodemailer: 8.0.5
+      nodemailer: 9.0.3
       object-hash: 3.0.0
       openapi3-ts: 4.5.0
       openid-client: 5.7.1
@@ -9061,7 +8912,7 @@ snapshots:
       rate-limiter-flexible: 7.2.0
       rolldown: 1.0.0-beta.31(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)
       rollup: 4.59.0
-      samlify: 2.12.0
+      samlify: 2.13.1
       sanitize-filename: 1.6.3
       sanitize-html: 2.17.0
       sharp: 0.34.5
@@ -9069,7 +8920,7 @@ snapshots:
       stream-json: 1.9.1
       tar: 7.5.8
       tsdown: 0.15.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(oxc-resolver@11.20.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))
-      tsx: 4.20.6
+      tsx: 4.22.4
       uuid: 11.1.1
       wellknown: 0.5.0
       ws: 8.21.0
@@ -9187,12 +9038,12 @@ snapshots:
       - whiskers
       - yaml
 
-  '@directus/app@15.10.0': {}
+  '@directus/app@16.2.1': {}
 
-  '@directus/composables@11.4.1(vue@3.5.24(typescript@5.9.3))':
+  '@directus/composables@11.5.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@vueuse/core': 14.0.0(vue@3.5.24(typescript@5.9.3))
       axios: 1.15.2
       lodash-es: 4.18.1
@@ -9201,12 +9052,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@directus/constants@14.3.0': {}
+  '@directus/constants@14.4.0': {}
 
-  '@directus/env@5.8.0(vue@3.5.24(typescript@5.9.3))':
+  '@directus/env@6.1.0(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       dotenv: 17.2.3
       lodash-es: 4.18.1
     transitivePeerDependencies:
@@ -9217,11 +9068,16 @@ snapshots:
       '@directus/storage': 12.0.4
       ms: 2.1.3
 
-  '@directus/extensions-registry@3.0.26(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
+  '@directus/errors@2.4.0':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/errors': 2.3.1
-      '@directus/extensions': 3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/storage': 13.0.0
+      ms: 2.1.3
+
+  '@directus/extensions-registry@4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
+    dependencies:
+      '@directus/constants': 14.4.0
+      '@directus/errors': 2.4.0
+      '@directus/extensions': 4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
       ky: 1.14.0
       zod: 4.1.12
     transitivePeerDependencies:
@@ -9245,33 +9101,33 @@ snapshots:
       - vue-router
       - ws
 
-  '@directus/extensions-sdk@17.1.4(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(ws@8.21.0)(yaml@2.9.0)':
+  '@directus/extensions-sdk@18.0.1(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(ws@8.21.0)(yaml@2.9.0)':
     dependencies:
-      '@directus/composables': 11.4.1(vue@3.5.24(typescript@5.9.3))
-      '@directus/constants': 14.3.0
-      '@directus/extensions': 3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/themes': 1.3.3(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))
-      '@directus/types': 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/composables': 11.5.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/extensions': 4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/themes': 2.0.1(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))
+      '@directus/types': 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@rollup/plugin-terser': 1.0.0(rollup@4.59.0)
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.1(vite@8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))
       chalk: 5.6.2
       commander: 14.0.2
-      esbuild: 0.26.0
+      esbuild: 0.28.1
       execa: 9.6.0
       fs-extra: 11.3.2
       inquirer: 12.11.0(@types/node@22.19.20)
       ora: 8.2.0
       rollup: 4.59.0
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.26.0)(rollup@4.59.0)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.59.0)
       rollup-plugin-styler: 2.0.0(rollup@4.59.0)(typescript@5.9.3)
       semver: 7.7.3
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.24(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -9308,33 +9164,33 @@ snapshots:
       - ws
       - yaml
 
-  '@directus/extensions-sdk@17.1.4(@types/node@22.19.20)(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)':
+  '@directus/extensions-sdk@18.0.1(@types/node@22.19.20)(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)':
     dependencies:
-      '@directus/composables': 11.4.1(vue@3.5.24(typescript@5.9.3))
-      '@directus/constants': 14.3.0
-      '@directus/extensions': 3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/themes': 1.3.3(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))
-      '@directus/types': 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/composables': 11.5.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/extensions': 4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/themes': 2.0.1(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))
+      '@directus/types': 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@rollup/plugin-terser': 1.0.0(rollup@4.59.0)
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.1(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))
       chalk: 5.6.2
       commander: 14.0.2
-      esbuild: 0.26.0
+      esbuild: 0.28.1
       execa: 9.6.0
       fs-extra: 11.3.2
       inquirer: 12.11.0(@types/node@22.19.20)
       ora: 8.2.0
       rollup: 4.59.0
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.26.0)(rollup@4.59.0)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.59.0)
       rollup-plugin-styler: 2.0.0(rollup@4.59.0)(typescript@5.9.3)
       semver: 7.7.3
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.24(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -9371,74 +9227,11 @@ snapshots:
       - ws
       - yaml
 
-  '@directus/extensions-sdk@17.1.4(@types/node@22.19.20)(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(jiti@2.7.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sass@1.100.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(terser@5.48.0)(tsx@4.20.6)(typescript@5.9.3)(ws@8.21.0)(yaml@2.9.0)':
+  '@directus/extensions@4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
     dependencies:
-      '@directus/composables': 11.4.1(vue@3.5.24(typescript@5.9.3))
-      '@directus/constants': 14.3.0
-      '@directus/extensions': 3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/themes': 1.3.3(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))
-      '@directus/types': 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
-      '@rollup/plugin-commonjs': 28.0.9(rollup@4.59.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.59.0)
-      '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.1(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))
-      chalk: 5.6.2
-      commander: 14.0.2
-      esbuild: 0.26.0
-      execa: 9.6.0
-      fs-extra: 11.3.2
-      inquirer: 12.11.0(@types/node@22.19.20)
-      ora: 8.2.0
-      rollup: 4.59.0
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.26.0)(rollup@4.59.0)
-      rollup-plugin-styler: 2.0.0(rollup@4.59.0)(typescript@5.9.3)
-      semver: 7.7.3
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.24(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@unhead/vue'
-      - '@vitejs/devtools'
-      - better-sqlite3
-      - debug
-      - deep-diff
-      - express
-      - graphql
-      - jiti
-      - knex
-      - less
-      - mysql
-      - mysql2
-      - nodemailer
-      - openapi3-ts
-      - pg
-      - pg-native
-      - pinia
-      - pino
-      - sass
-      - sass-embedded
-      - sharp
-      - sqlite3
-      - stylus
-      - sugarss
-      - supports-color
-      - tedious
-      - terser
-      - tsx
-      - typescript
-      - vue-router
-      - ws
-      - yaml
-
-  '@directus/extensions@3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
-    dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/types': 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/types': 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@types/express': 4.17.21
       fs-extra: 11.3.2
       lodash-es: 4.18.1
@@ -9464,11 +9257,11 @@ snapshots:
       - tedious
       - ws
 
-  '@directus/extensions@3.0.25(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
+  '@directus/extensions@4.0.1(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/types': 15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/types': 16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@types/express': 4.17.21
       fs-extra: 11.3.2
       lodash-es: 4.18.1
@@ -9495,12 +9288,30 @@ snapshots:
       - tedious
       - ws
 
-  '@directus/format-title@12.1.2': {}
+  '@directus/format-title@13.0.0': {}
 
-  '@directus/memory@3.1.8(vue@3.5.24(typescript@5.9.3))':
+  '@directus/license@0.3.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))':
     dependencies:
       '@directus/errors': 2.3.1
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/sdk': 21.3.0
+      jose: 6.2.3
+      knex: 3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
+      lodash-es: 4.18.1
+      zod: 4.1.1
+    transitivePeerDependencies:
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@directus/memory@4.0.1(vue@3.5.24(typescript@5.9.3))':
+    dependencies:
+      '@directus/errors': 2.4.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@sesamecare-oss/redlock': 1.4.0(ioredis@5.8.2)
       ioredis: 5.8.2
       lru-cache: 11.2.2
@@ -9509,13 +9320,13 @@ snapshots:
       - supports-color
       - vue
 
-  '@directus/pressure@3.0.22(vue@3.5.24(typescript@5.9.3))':
+  '@directus/pressure@4.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
     transitivePeerDependencies:
       - vue
 
-  '@directus/schema@13.0.8(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))':
+  '@directus/schema@14.0.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))':
     dependencies:
       knex: 3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
     transitivePeerDependencies:
@@ -9528,49 +9339,51 @@ snapshots:
       - supports-color
       - tedious
 
-  '@directus/specs@13.0.0':
+  '@directus/sdk@21.3.0': {}
+
+  '@directus/specs@15.0.0':
     dependencies:
       openapi3-ts: 4.5.0
 
-  '@directus/storage-driver-azure@12.0.22(vue@3.5.24(typescript@5.9.3))':
+  '@directus/storage-driver-azure@13.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@azure/storage-blob': 12.29.1
-      '@directus/storage': 12.0.4
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage': 13.0.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - vue
 
-  '@directus/storage-driver-cloudinary@12.0.22(vue@3.5.24(typescript@5.9.3))':
+  '@directus/storage-driver-cloudinary@13.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/storage': 12.0.4
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage': 13.0.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       p-queue: 8.1.0
-      undici: 7.24.5
+      undici: 7.28.0
     transitivePeerDependencies:
       - vue
 
-  '@directus/storage-driver-gcs@12.0.22(encoding@0.1.13)(vue@3.5.24(typescript@5.9.3))':
+  '@directus/storage-driver-gcs@13.0.1(encoding@0.1.13)(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/storage': 12.0.4
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/storage': 13.0.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@google-cloud/storage': 7.18.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
       - vue
 
-  '@directus/storage-driver-local@12.0.4':
+  '@directus/storage-driver-local@13.0.0':
     dependencies:
-      '@directus/storage': 12.0.4
+      '@directus/storage': 13.0.0
 
-  '@directus/storage-driver-s3@12.1.8(vue@3.5.24(typescript@5.9.3))':
+  '@directus/storage-driver-s3@13.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@aws-sdk/client-s3': 3.928.0
       '@aws-sdk/lib-storage': 3.928.0(@aws-sdk/client-s3@3.928.0)
-      '@directus/storage': 12.0.4
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/storage': 13.0.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@shopify/semaphore': 3.1.0
       '@smithy/node-http-handler': 4.4.5
       '@tus/utils': 0.6.0
@@ -9579,24 +9392,26 @@ snapshots:
       - aws-crt
       - vue
 
-  '@directus/storage-driver-supabase@3.0.22(vue@3.5.24(typescript@5.9.3))':
+  '@directus/storage-driver-supabase@4.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/storage': 12.0.4
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/constants': 14.4.0
+      '@directus/storage': 13.0.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@supabase/storage-js': 2.81.0
       tus-js-client: 4.3.1
-      undici: 7.24.5
+      undici: 7.28.0
     transitivePeerDependencies:
       - vue
 
   '@directus/storage@12.0.4': {}
 
-  '@directus/system-data@4.4.0': {}
+  '@directus/storage@13.0.0': {}
 
-  '@directus/themes@1.3.3(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))':
+  '@directus/system-data@4.5.1': {}
+
+  '@directus/themes@2.0.1(@unhead/vue@1.11.20(vue@3.5.24(typescript@5.9.3)))(pinia@2.3.1(typescript@5.9.3)(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       '@unhead/vue': 1.11.20(vue@3.5.24(typescript@5.9.3))
       decamelize: 6.0.1
       flat: 6.0.1
@@ -9605,11 +9420,11 @@ snapshots:
       vue: 3.5.24(typescript@5.9.3)
       zod: 4.1.12
 
-  '@directus/types@15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
+  '@directus/types@16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2)))(mysql2@3.15.3)(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
     dependencies:
-      '@directus/ai': 1.3.1
-      '@directus/constants': 14.3.0
-      '@directus/schema': 13.0.8(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
+      '@directus/ai': 1.3.2
+      '@directus/constants': 14.4.0
+      '@directus/schema': 14.0.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
       '@types/archiver': 7.0.0
       '@types/express': 4.17.21
       '@types/geojson': 7946.0.16
@@ -9621,7 +9436,7 @@ snapshots:
       express: 4.21.2
       graphql: 16.12.0
       knex: 3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
-      nodemailer: 8.0.5
+      nodemailer: 9.0.3
       openapi3-ts: 4.5.0
       pino: 9.7.0
       sharp: 0.34.5
@@ -9637,11 +9452,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@directus/types@15.0.3(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@8.0.5)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
+  '@directus/types@16.0.0(better-sqlite3@12.10.0)(deep-diff@1.0.2)(express@4.21.2)(graphql@16.12.0)(knex@3.1.0(better-sqlite3@12.10.0)(pg@8.16.3))(nodemailer@9.0.3)(openapi3-ts@4.5.0)(pg@8.16.3)(pino@9.7.0)(sharp@0.34.5)(vue-router@4.6.4(vue@3.5.24(typescript@5.9.3)))(vue@3.5.24(typescript@5.9.3))(ws@8.21.0)':
     dependencies:
-      '@directus/ai': 1.3.1
-      '@directus/constants': 14.3.0
-      '@directus/schema': 13.0.8(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
+      '@directus/ai': 1.3.2
+      '@directus/constants': 14.4.0
+      '@directus/schema': 14.0.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
       '@types/archiver': 7.0.0
       '@types/express': 4.17.21
       '@types/geojson': 7946.0.16
@@ -9653,7 +9468,7 @@ snapshots:
       express: 4.21.2
       graphql: 16.12.0
       knex: 3.1.0(better-sqlite3@12.10.0)(mysql2@3.15.3)(pg@8.16.3)(sqlite3@5.1.7)(tedious@18.6.1(@azure/core-client@1.10.2))
-      nodemailer: 8.0.5
+      nodemailer: 9.0.3
       openapi3-ts: 4.5.0
       pino: 9.7.0
       sharp: 0.34.5
@@ -9670,7 +9485,7 @@ snapshots:
       - supports-color
       - tedious
 
-  '@directus/update-check@13.0.5':
+  '@directus/update-check@14.0.0':
     dependencies:
       axios: 1.15.2
       axios-cache-interceptor: 1.11.1(axios@1.15.2)
@@ -9681,12 +9496,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@directus/utils@13.4.1(vue@3.5.24(typescript@5.9.3))':
+  '@directus/utils@13.5.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/constants': 14.3.0
-      '@directus/system-data': 4.4.0
+      '@directus/constants': 14.4.0
+      '@directus/system-data': 4.5.1
       date-fns: 4.1.0
       fs-extra: 11.3.2
+      ipaddr.js: 2.4.0
       joi: 18.0.1
       js-yaml: 4.1.1
       lodash-es: 4.18.1
@@ -9695,21 +9511,15 @@ snapshots:
     optionalDependencies:
       vue: 3.5.24(typescript@5.9.3)
 
-  '@directus/validation@2.0.23(vue@3.5.24(typescript@5.9.3))':
+  '@directus/validation@3.0.1(vue@3.5.24(typescript@5.9.3))':
     dependencies:
-      '@directus/errors': 2.3.1
-      '@directus/utils': 13.4.1(vue@3.5.24(typescript@5.9.3))
+      '@directus/errors': 2.4.0
+      '@directus/utils': 13.5.1(vue@3.5.24(typescript@5.9.3))
       joi: 18.0.1
     transitivePeerDependencies:
       - vue
 
   '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
@@ -9725,11 +9535,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -9737,238 +9542,160 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/aix-ppc64@0.26.0':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.26.0':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm@0.26.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.26.0':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.26.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.26.0':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.26.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.26.0':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm64@0.26.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.26.0':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ia32@0.26.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.26.0':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.26.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.26.0':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.26.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.26.0':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.26.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.26.0':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.26.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.26.0':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.26.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.26.0':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.26.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.26.0':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.26.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.26.0':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
@@ -10390,7 +10117,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
-      cors: 2.8.5
+      cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
@@ -10476,13 +10203,6 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.11.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -10695,8 +10415,6 @@ snapshots:
     optional: true
 
   '@oxc-project/runtime@0.80.0': {}
-
-  '@oxc-project/types@0.124.0': {}
 
   '@oxc-project/types@0.127.0': {}
 
@@ -10924,10 +10642,10 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
@@ -10936,10 +10654,10 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.31':
@@ -10948,10 +10666,10 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.31':
@@ -10960,10 +10678,10 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.31':
@@ -10972,10 +10690,10 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
@@ -10984,10 +10702,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
@@ -10996,25 +10714,25 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.31':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
@@ -11023,10 +10741,10 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
@@ -11035,19 +10753,19 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.31(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)':
@@ -11066,14 +10784,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -11086,10 +10804,10 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
@@ -11104,10 +10822,10 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.45':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.29': {}
@@ -11116,9 +10834,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.45': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
-
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.59.0)':
     optionalDependencies:
@@ -11786,16 +11504,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-vue@6.0.1(vite@8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
-      vue: 3.5.24(typescript@5.9.3)
-
-  '@vitejs/plugin-vue@6.0.1(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))(vue@3.5.24(typescript@5.9.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.24(typescript@5.9.3)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
@@ -11810,7 +11522,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -11821,13 +11533,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -12845,10 +12557,10 @@ snapshots:
 
   diff@8.0.4: {}
 
-  directus@11.17.4(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0):
+  directus@12.1.1(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
-      '@directus/api': 35.2.0(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
-      '@directus/update-check': 13.0.5
+      '@directus/api': 37.0.1(@azure/core-client@1.10.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.0)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.202.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.1))(@types/node@22.19.20)(better-sqlite3@12.10.0)(braintrust@3.17.0(@aws-sdk/credential-provider-web-identity@3.972.49)(zod@4.1.12))(encoding@0.1.13)(jiti@2.7.0)(lodash@4.18.1)(oxc-resolver@11.20.0)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))(yaml@2.9.0)
+      '@directus/update-check': 14.0.0
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@azure/core-client'
@@ -13062,64 +12774,6 @@ snapshots:
 
   es-toolkit@1.47.0: {}
 
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.26.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.26.0
-      '@esbuild/android-arm': 0.26.0
-      '@esbuild/android-arm64': 0.26.0
-      '@esbuild/android-x64': 0.26.0
-      '@esbuild/darwin-arm64': 0.26.0
-      '@esbuild/darwin-x64': 0.26.0
-      '@esbuild/freebsd-arm64': 0.26.0
-      '@esbuild/freebsd-x64': 0.26.0
-      '@esbuild/linux-arm': 0.26.0
-      '@esbuild/linux-arm64': 0.26.0
-      '@esbuild/linux-ia32': 0.26.0
-      '@esbuild/linux-loong64': 0.26.0
-      '@esbuild/linux-mips64el': 0.26.0
-      '@esbuild/linux-ppc64': 0.26.0
-      '@esbuild/linux-riscv64': 0.26.0
-      '@esbuild/linux-s390x': 0.26.0
-      '@esbuild/linux-x64': 0.26.0
-      '@esbuild/netbsd-arm64': 0.26.0
-      '@esbuild/netbsd-x64': 0.26.0
-      '@esbuild/openbsd-arm64': 0.26.0
-      '@esbuild/openbsd-x64': 0.26.0
-      '@esbuild/openharmony-arm64': 0.26.0
-      '@esbuild/sunos-x64': 0.26.0
-      '@esbuild/win32-arm64': 0.26.0
-      '@esbuild/win32-ia32': 0.26.0
-      '@esbuild/win32-x64': 0.26.0
-
   esbuild@0.28.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.0
@@ -13148,6 +12802,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -13924,6 +13607,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.4.0: {}
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -14238,7 +13923,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  liquidjs@10.25.7:
+  liquidjs@10.26.0:
     dependencies:
       commander: 10.0.1
 
@@ -14678,7 +14363,7 @@ snapshots:
       - whiskers
     optional: true
 
-  nodemailer@8.0.5: {}
+  nodemailer@9.0.3: {}
 
   nopt@5.0.0:
     dependencies:
@@ -15691,27 +15376,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.15:
-    dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
-
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -15733,11 +15397,32 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.26.0)(rollup@4.59.0):
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.59.0):
     dependencies:
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      esbuild: 0.26.0
+      esbuild: 0.28.1
       get-tsconfig: 4.14.0
       rollup: 4.59.0
       unplugin-utils: 0.2.5
@@ -15828,7 +15513,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  samlify@2.12.0:
+  samlify@2.13.1:
     dependencies:
       '@authenio/xml-encryption': 2.0.2
       '@xmldom/xmldom': 0.8.13
@@ -16442,10 +16127,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.20.6:
+  tsx@4.22.4:
     dependencies:
-      esbuild: 0.25.12
-      get-tsconfig: 4.14.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -16528,7 +16212,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.5: {}
+  undici@7.28.0: {}
 
   unhead@1.11.20:
     dependencies:
@@ -16597,44 +16281,27 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.8(@types/node@22.19.20)(esbuild@0.26.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0):
+  vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.0-rc.15
+      rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.20
-      esbuild: 0.26.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.100.0
       terser: 5.48.0
-      tsx: 4.20.6
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.19.20
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      sass: 1.100.0
-      terser: 5.48.0
-      tsx: 4.20.6
-      yaml: 2.9.0
-
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -16651,7 +16318,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -16840,6 +16507,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.1.12):
     dependencies:
       zod: 4.1.12
+
+  zod@4.1.1: {}
 
   zod@4.1.12: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,3 +52,25 @@ overrides:
   # baseline so the AxiosInstance shape is identical, while keeping our CVE
   # coverage. Re-verify against the latest Directus SDK whenever bumping.
   axios: 1.15.2
+
+minimumReleaseAgeExclude:
+  - '@directus/api@37.0.1'
+  - '@directus/app@16.2.1'
+  - '@directus/composables@11.5.1'
+  - '@directus/env@6.1.0'
+  - '@directus/extensions-registry@4.0.1'
+  - '@directus/extensions-sdk@18.0.1'
+  - '@directus/extensions@4.0.1'
+  - '@directus/memory@4.0.1'
+  - '@directus/pressure@4.0.1'
+  - '@directus/specs@15.0.0'
+  - '@directus/storage-driver-azure@13.0.1'
+  - '@directus/storage-driver-cloudinary@13.0.1'
+  - '@directus/storage-driver-gcs@13.0.1'
+  - '@directus/storage-driver-s3@13.0.1'
+  - '@directus/storage-driver-supabase@4.0.1'
+  - '@directus/system-data@4.5.1'
+  - '@directus/themes@2.0.1'
+  - '@directus/utils@13.5.1'
+  - '@directus/validation@3.0.1'
+  - directus@12.1.1


### PR DESCRIPTION
## What & why

Adds **Directus 12** support alongside 11 and fixes the v12-specific admin UI regressions. Both extensions already declared `host: ^11.0.0 || ^12.0.0`, but the build toolchain and styling were still tuned for the v11 line.

## Changes

### Toolchain
- `@directus/extensions-sdk` `^17.1.4` → **`^18.0.1`** and `@directus/types` `^15.0.0` → **`^16.0.0`** across `module`, `sync-hook`, and `common` (kept in lockstep with the host major).
- Local dev `directus` `^11.17.4` → **`^12.1.1`** (root devDependency).
- `pnpm-workspace.yaml` / `pnpm-lock.yaml` updated accordingly.

### v12 admin UI fixes
Directus 12 rewrote `header-bar` and forwards `private-view`'s `#headline` slot **inline** into the title flex row (it was a separate line above the title in v11), and now vertically centres `#actions`. That produced two visible regressions on every module page:
- The "Localazy" breadcrumb abutted the page title (`LocalazyProject setup`).
- Header action buttons (`Save changes`) were pushed ~10px below centre by a stale `margin-top`.

Fix: a shared **`styles/mixins/private-view.scss`** mixin (`@include private-view-header`) added to each page's **scoped** style, so it only targets our own slot content and never core Directus screens. Applied to all 8 pages; removed the now-stale `.panel-button` top margins.

- **Activity page**: restored the panel's top padding so the "Last 100 sync sessions" note no longer hugs the header (its first child, unlike other pages', has no top margin of its own).

### Docs
- README compatibility tables + prerequisites now read **"Directus 11 or 12"** (`^11.0.0 || ^12.0.0`); fixed leftover `extensions/*` → `packages/*` monorepo paths in both READMEs, `constants.ts` (`BUNDLE_README_URL`), and `About.vue`.
- `CLAUDE.md` records the v12 target, the toolchain-lockstep rule, the migrate-on-boot note, and the `#headline` slot gotcha.

## Verification (against Directus 12.1.1)
- ✅ `typecheck`, production `build` (SDK 18 CLI), and full `test` suite (module 241 / common 251 / sync-hook) pass; lint + prettier clean.
- ✅ All 8 admin pages render with **no console errors**; breadcrumb spacing + button alignment confirmed.
- ✅ Server-side sync-hook works (Automation page detects "Bundle version: 2.0.0" via its `/localazy-automation/status` endpoint).
- ✅ **Import & Export exercised end-to-end** against the live Localazy API — export ("already up to date") and import ("nothing to import — export first", the expected domain outcome; fetch itself succeeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
